### PR TITLE
fix: JSONエクスポート・テンプレートの _schema に group フィールドを追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -395,6 +395,7 @@ const EXPORT_SCHEMA = {
     "menuItems[].default_grams": "number (必須, 1以上) — 1回分のデフォルト重量 (g)",
     "menuItems[].rank": "1〜4の整数 (必須) — 1=◎最優先 / 2=○通常 / 3=△控えめ / 4=✕避ける",
     "menuItems[].notes": "string or null — メモ（任意）",
+    "menuItems[].group": "string or null — グループ名（任意。同じ値のアイテムがまとめて表示されます）",
   },
 } as const;
 
@@ -476,6 +477,7 @@ function downloadTemplate() {
         default_grams: 100,
         rank: 2,
         notes: null,
+        group: null,
       },
     ],
   };


### PR DESCRIPTION
## Summary

- `EXPORT_SCHEMA._schema` に `menuItems[].group` のフィールド説明を追加
- `downloadTemplate()` のサンプルアイテムに `group: null` を追加

## Test plan

- [ ] メニュー管理画面で「JSONでエクスポート」を押し、出力JSONの `_schema` に `menuItems[].group` の説明が含まれていることを確認
- [ ] インポートモーダルで「テンプレートをダウンロード」を押し、サンプルアイテムに `"group": null` が含まれていることを確認
- [ ] 既存のインポート・エクスポート動作に影響がないことを確認

closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)