### PR TITLE
chore: Cursor 常時ルールと AGENTS の GitHub Flow 要約（closes #24, closes #25）

### DIFF
--- a/.cursor/rules/github-flow.mdc
+++ b/.cursor/rules/github-flow.mdc
@@ -1,0 +1,23 @@
+---
+description: GitHub Flow・CONTRIBUTING.md 準拠（常時適用）
+alwaysApply: true
+---
+
+# 開発フロー
+
+作業の**正**はリポジトリ直下の **CONTRIBUTING.md** である。実装・コミット・PR の前に不足がないか確認すること。
+
+## 必須
+
+- **`main` への直接コミット・プッシュは禁止**。変更は必ず作業ブランチで行い、Pull Request 経由でマージする。
+- **実装を始める前に** `main` を最新化し、`feat/`・`fix/`・`docs/` など **CONTRIBUTING.md** のブランチ命名規則に従ったブランチを切る。
+- Issue がある場合は PR 本文で **`closes #<番号>`** 等により紐づける。
+- マージ後はローカル・リモートの作業ブランチを削除する習慣とする（CONTRIBUTING の手順に従う）。
+
+## バージョン（`package.json`）
+
+- **`feat/`** の PR: マイナー版を上げる。**`fix/`** の PR: パッチ版を上げる。
+- **`docs/`** / **`chore/`** / **`refactor/`** のみの PR: バージョンを上げなくてよい。
+- バージョン更新は単独コミットとし、メッセージは `chore: バージョンを X.Y.Z に更新` とする。
+
+詳細・表・コミット規約はすべて **CONTRIBUTING.md** に書いてある。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,13 @@
 
 This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` before writing any code. Heed deprecation notices.
 <!-- END:nextjs-agent-rules -->
+
+## リポジトリ運用（GitHub Flow）
+
+開発の手順・ブランチ名・コミット規約・**`package.json` のバージョン更新タイミング**は、すべて **CONTRIBUTING.md** に従う。
+
+- `main` への直接コミットは禁止。作業ブランチで実装し、PR でマージする。
+- Issue がある場合は PR で `closes #<番号>` などと紐づける。
+- `feat/` の PR ではマイナー、`fix/` の PR ではパッチを上げる。`docs` / `chore` / `refactor` のみの変更では上げなくてよい（詳細は CONTRIBUTING.md）。
+
+Cursor では **`.cursor/rules/github-flow.mdc`** が常時適用され、上記と同じ方針が補強される。


### PR DESCRIPTION
## 概要

Issue #24・#25 に対応。CONTRIBUTING.md を正とした GitHub Flow を Cursor が毎回読むルールとして追加し、AGENTS.md に案Bどおり短い要約を載せた。

## 変更

- **`.cursor/rules/github-flow.mdc`**（`alwaysApply: true`）: `main` 禁止・作業ブランチ・PR・Issue 連携・`package.json` バージョン方針を列挙。詳細は CONTRIBUTING.md 参照。
- **`AGENTS.md`**: Next.js 注意ブロックは維持。リポジトリ運用の要約と CONTRIBUTING / `github-flow.mdc` への誘導を追加。

## バージョン

`chore/` のみのため `package.json` は変更なし（CONTRIBUTING の方針どおり）。

closes #24
closes #25

Made with [Cursor](https://cursor.com)