### PR TITLE
docs: CHANGELOG に 1.3.0 を追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-10
+
+### Added
+- ヘッダーのバージョン表記をクリックすると変更履歴（Changelog）を開ける（環境変数 `NEXT_PUBLIC_CHANGELOG_URL` 設定時）。
+- ユーザー向けの変更履歴として `CHANGELOG.md` を整備。
+
+### Changed
+- 開発運用: `CONTRIBUTING.md`・PR テンプレート・GitHub Actions で Changelog 更新をガイド・チェックするようにした。
+
 ## [1.2.3] - 2026-04-10
 
 ### Changed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,14 @@
 
 ## 現行バージョン
 
-`package.json` の `version` は **1.2.3**（本リポジトリ上の値）。以下はリリース履歴のメモ。
+`package.json` の `version` は **1.3.0**（本リポジトリ上の値）。以下はリリース履歴のメモ。
+
+---
+
+## v1.3.0 リリース済み（2026-04-10）
+
+- ヘッダーのバージョンから変更履歴（`CHANGELOG.md`）への導線（環境変数 `NEXT_PUBLIC_CHANGELOG_URL`）
+- Changelog 運用（`CONTRIBUTING.md`・PR テンプレ・CI ガードレール）
 
 ---
 


### PR DESCRIPTION
## Summary
- `CHANGELOG.md` に **[1.3.0]** 節を追加（バージョンリンク・Changelog 整備・運用ガードの要点）
- `ROADMAP.md` の現行バージョンと v1.3.0 メモを `package.json` と整合

## Test plan
- [x] `CHANGELOG.md` に 1.3.0 が見える
- [x] `ROADMAP.md` の現行バージョンが 1.3.0


Made with [Cursor](https://cursor.com)