### PR TITLE
feat: OFF連携 Phase1のバーコード読み取り基盤を実装

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- Open Food Facts 連携の Phase1 として、バーコード検索で市販品を取得し、共有キャッシュ（`shared_products`）経由でメニューへ追加できるようにした。
+- 設定画面とバーコード追加UIに、Open Food Facts のデータソース表記を追加した。
+
+### Changed
+
+- JSON エクスポート/インポートが `shared_barcode` を扱えるようになり、市販品参照データを保持できるようにした（既存フォーマットとの互換を維持）。
+
 ## [1.6.0] - 2026-04-10
 
 ### Added

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,8 +57,10 @@
 - レストランの追加／削除
 - 栄養素入力の切替（100gあたり ↔ 1回分あたり）
 
-### 2-2 後日
-- バーコードスキャン（Open Food Facts API）
+### 2-2 進行中（Phase1実装）
+- バーコード検索（Open Food Facts API）で市販品を取得
+- `shared_products` キャッシュ基盤と `menu_items.shared_barcode` 参照を導入
+- スキャン結果をメニュー追加に接続（Not Found時は手入力へフォールバック）
 
 ### 2-3 後日
 - 食材名検索（文部科学省食品成分表）

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { useState, useMemo, useRef, useId } from "react";
-import { useRouter } from "next/navigation";
+import { useState, useMemo, useRef, useId, useEffect, useCallback } from "react";
 import {
   DndContext,
   PointerSensor,
@@ -34,10 +33,11 @@ import {
   deleteFoodLogEntry,
   updateFoodLogEntry,
   updateUserSettings,
+  lookupSharedProductByBarcode,
   type MenuItemUpdate,
-  type ImportData,
   type ImportRestaurantItem,
 } from "./actions";
+import type { SharedProduct } from "@/types/database";
 
 // ─── 型 ────────────────────────────────────────────────────────────────────────
 
@@ -175,6 +175,18 @@ function MenuItemDrawer({
   const [deleting, setDeleting] = useState(false);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [error, setError]     = useState<string | null>(null);
+  const [sharedBarcode, setSharedBarcode] = useState(existing?.shared_barcode ?? null);
+  const [scanError, setScanError] = useState<string | null>(null);
+  const [scanLoading, setScanLoading] = useState(false);
+  const [cameraOn, setCameraOn] = useState(false);
+  const [cameraResult, setCameraResult] = useState<SharedProduct | null>(null);
+  const [lastLookup, setLastLookup] = useState<{ barcode: string; at: number } | null>(null);
+  const [servingHint, setServingHint] = useState<string | null>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const cameraSupported =
+    typeof window !== "undefined" &&
+    "BarcodeDetector" in window &&
+    Boolean(navigator.mediaDevices?.getUserMedia);
 
   const displayP = mode === "per100g" ? protein : toServing(protein, grams);
   const displayF = mode === "per100g" ? fat     : toServing(fat,     grams);
@@ -193,6 +205,81 @@ function MenuItemDrawer({
     if (field === "c") { setCarbs(stored);   setRawC(null); }
   }
 
+  const handleLookupBarcode = useCallback(async (rawBarcode: string) => {
+    const normalized = rawBarcode.replace(/[^\d]/g, "");
+    if (!normalized) {
+      setScanError("バーコードを読み取れませんでした。もう一度お試しください。");
+      return;
+    }
+    if (lastLookup?.barcode === normalized && Date.now() - lastLookup.at < 3000) return;
+
+    setScanLoading(true);
+    setScanError(null);
+    setLastLookup({ barcode: normalized, at: Date.now() });
+    const res = await lookupSharedProductByBarcode(normalized);
+    setScanLoading(false);
+    if (res.status === "error" || !res.product) {
+      setScanError(res.error ?? "OFFで商品が見つかりませんでした");
+      return;
+    }
+    setCameraResult(res.product);
+    setSharedBarcode(res.product.barcode);
+    setName(res.product.product_name);
+    setProtein(res.product.protein_per_100g?.toString() ?? "");
+    setFat(res.product.fat_per_100g?.toString() ?? "");
+    setCarbs(res.product.carbs_per_100g?.toString() ?? "");
+    if (res.product.serving_size_grams && res.product.serving_size_grams > 0) {
+      setGrams(res.product.serving_size_grams.toString());
+      setServingHint(`OFFの serving_size (${res.product.serving_size}) を1回量に仮入力しました。ラベルで必ず確認してください。`);
+    } else if (res.product.serving_size) {
+      setServingHint(`OFFの serving_size (${res.product.serving_size}) を取得しました。1回量(g)を手動で確認してください。`);
+    } else {
+      setServingHint(null);
+    }
+    if (!notes.trim()) {
+      setNotes(res.product.brand ? `OFF: ${res.product.brand}` : "OFF連携");
+    }
+  }, [lastLookup, notes]);
+
+  useEffect(() => {
+    if (isEdit || !cameraOn || !cameraSupported) return;
+    let stop = false;
+    let stream: MediaStream | null = null;
+    const w = window as Window & { BarcodeDetector?: new () => { detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue?: string }>> } };
+    void (async () => {
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: { ideal: "environment" } },
+          audio: false,
+        });
+        if (!videoRef.current) return;
+        videoRef.current.srcObject = stream;
+        await videoRef.current.play();
+        if (!w.BarcodeDetector) return;
+        const detector = new w.BarcodeDetector();
+        while (!stop) {
+          if (!videoRef.current) break;
+          const detected = await detector.detect(videoRef.current);
+          const value = detected[0]?.rawValue?.trim();
+          if (value) {
+            setCameraOn(false);
+            void handleLookupBarcode(value);
+            break;
+          }
+          await new Promise((r) => setTimeout(r, 350));
+        }
+      } catch {
+        setScanError("カメラを起動できませんでした。権限設定を確認してください。");
+        setCameraOn(false);
+      }
+    })();
+
+    return () => {
+      stop = true;
+      if (stream) stream.getTracks().forEach((t) => t.stop());
+    };
+  }, [isEdit, cameraOn, cameraSupported, handleLookupBarcode]);
+
   async function handleSave() {
     if (!name.trim()) { setError("名前を入力してください"); return; }
     setSaving(true); setError(null);
@@ -201,6 +288,7 @@ function MenuItemDrawer({
       protein_per_100g: protein === "" ? null : parseFloat(protein),
       fat_per_100g:     fat     === "" ? null : parseFloat(fat),
       carbs_per_100g:   carbs   === "" ? null : parseFloat(carbs),
+      shared_barcode: sharedBarcode,
       default_grams: parseFloat(grams) || 100,
       rank,
       notes: notes.trim() || null,
@@ -261,6 +349,43 @@ function MenuItemDrawer({
               autoFocus={!isEdit}
               className="w-full px-3 py-2.5 sm:py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-base sm:text-sm focus:outline-none focus:border-emerald-500" />
           </div>
+
+          {!isEdit && (
+            <div className="space-y-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setScanError(null);
+                  setCameraResult(null);
+                  setServingHint(null);
+                  setCameraOn((v) => !v);
+                }}
+                className="w-full py-2.5 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm rounded-lg transition-colors inline-flex items-center justify-center gap-2"
+              >
+                <span aria-hidden="true">{cameraOn ? "■" : "|||:"}</span>
+                <span>{cameraOn ? "読み取りを停止" : "バーコード読み取り"}</span>
+              </button>
+              {cameraOn && (
+                <video
+                  ref={videoRef}
+                  muted
+                  playsInline
+                  className="w-full rounded-lg border border-gray-700 bg-black aspect-video object-cover"
+                />
+              )}
+              {scanLoading && <p className="text-xs text-emerald-300">読み取り結果を検索中...</p>}
+              {cameraResult && (
+                <p className="text-xs text-emerald-300">
+                  読み取り完了: {cameraResult.product_name}（{cameraResult.barcode}）
+                </p>
+              )}
+              {scanError && <p className="text-xs text-amber-300">{scanError}</p>}
+              {servingHint && <p className="text-xs text-amber-300">{servingHint}</p>}
+              <p className="text-[11px] text-gray-500">
+                Data source: Open Food Facts (ODbL)
+              </p>
+            </div>
+          )}
 
           <div>
             <label className="block text-xs text-gray-400 mb-1">1回の量（g）</label>
@@ -447,6 +572,7 @@ const EXPORT_SCHEMA = {
     "menuItems[].protein_per_100g": "number or null — 100gあたりタンパク質 (g)",
     "menuItems[].fat_per_100g": "number or null — 100gあたり脂質 (g)",
     "menuItems[].carbs_per_100g": "number or null — 100gあたり糖質 (g)",
+    "menuItems[].shared_barcode": "string or null — 市販品参照バーコード（OFF連携時）",
     "menuItems[].default_grams": "number (必須, 1以上) — 1回分のデフォルト重量 (g)",
     "menuItems[].rank": "1〜4の整数 (必須) — 1=◎最優先 / 2=○通常 / 3=△控えめ / 4=✕避ける",
     "menuItems[].notes": "string or null — メモ（任意）",
@@ -467,6 +593,7 @@ function downloadRestaurantJson(restaurant: Restaurant, menuItems: MenuItem[]) {
         protein_per_100g: m.protein_per_100g,
         fat_per_100g: m.fat_per_100g,
         carbs_per_100g: m.carbs_per_100g,
+        shared_barcode: m.shared_barcode ?? null,
         default_grams: m.default_grams,
         rank: m.rank,
         notes: m.notes,
@@ -500,6 +627,9 @@ function parseSingleRestaurantJson(text: string): SingleRestaurantJson | { error
     }
     const invalidItems = (raw.menuItems as ImportRestaurantItem[])
       .map((item, i) => {
+        if (item.shared_barcode !== undefined && item.shared_barcode !== null && typeof item.shared_barcode !== "string") {
+          return `${i + 1}番目「${item.name}」の shared_barcode が不正です（文字列またはnull）`;
+        }
         if (item.rank < 1 || item.rank > 4 || !Number.isInteger(item.rank)) {
           return `${i + 1}番目「${item.name}」の rank が不正です（1〜4の整数を指定してください）`;
         }
@@ -529,6 +659,7 @@ function downloadTemplate() {
         protein_per_100g: null,
         fat_per_100g: null,
         carbs_per_100g: null,
+        shared_barcode: null,
         default_grams: 100,
         rank: 2,
         notes: null,
@@ -1123,6 +1254,21 @@ function SettingsDrawer({
             </button>
           </div>
 
+          <div>
+            <h3 className="text-sm font-medium text-white mb-1">データソース</h3>
+            <p className="text-xs text-gray-400">
+              市販品データは Open Food Facts を利用しています（ODbL）。
+              <a
+                href="https://world.openfoodfacts.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-1 text-emerald-400 hover:text-emerald-300 underline underline-offset-2"
+              >
+                Open Food Facts
+              </a>
+            </p>
+          </div>
+
           {/* ログアウト */}
           <div className="pt-2 border-t border-gray-800">
             <button onClick={handleLogout}
@@ -1150,6 +1296,7 @@ function downloadAllRestaurants(restaurants: Restaurant[], menuItems: MenuItem[]
           protein_per_100g: m.protein_per_100g,
           fat_per_100g: m.fat_per_100g,
           carbs_per_100g: m.carbs_per_100g,
+          shared_barcode: m.shared_barcode ?? null,
           default_grams: m.default_grams,
           rank: m.rank,
           notes: m.notes,
@@ -1178,6 +1325,7 @@ function SortableRestaurantTab({
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id: restaurant.id,
   });
+
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
@@ -1196,6 +1344,7 @@ function SortableRestaurantTab({
         type="button"
         className="pl-2 pr-1 sm:pl-1.5 sm:pr-0.5 flex items-center text-gray-500 hover:text-gray-300 cursor-grab active:cursor-grabbing touch-manipulation"
         aria-label={`${restaurant.name}の表示順を変更`}
+        suppressHydrationWarning
         {...attributes}
         {...listeners}
       >
@@ -1235,7 +1384,6 @@ export default function TodayClient({
   initialLogEntries,
   presets,
 }: Props) {
-  const router = useRouter();
   const [currentSettings, setCurrentSettings] = useState<UserSettings>(settings);
   const [showSettings, setShowSettings]       = useState(false);
   const [restaurants, setRestaurants] = useState<Restaurant[]>(initialRestaurants);

--- a/src/app/today/actions.ts
+++ b/src/app/today/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
-import type { FoodLogEntry, MenuItem, Restaurant, TodayConsumed } from "@/types/database";
+import type { FoodLogEntry, MenuItem, Restaurant, TodayConsumed, SharedProduct } from "@/types/database";
 
 export type SaveItem = {
   menuItemId: string;
@@ -12,6 +12,34 @@ export type SaveItem = {
   carbsG: number;
   restaurantId: string;
 };
+
+const OFF_API_BASE = process.env.OFF_API_BASE ?? "https://world.openfoodfacts.org";
+const OFF_DEFAULT_CONTACT = "info@civictech.tv";
+const OFF_USER_AGENT =
+  process.env.OFF_USER_AGENT ??
+  `Ketolog/${process.env.NEXT_PUBLIC_APP_VERSION ?? "dev"} (${OFF_DEFAULT_CONTACT})`;
+const SHARED_PRODUCT_TTL_MS = 1000 * 60 * 60 * 24 * 180; // 180日
+
+function normalizeBarcode(raw: string): string {
+  return raw.replace(/[^\d]/g, "").trim();
+}
+
+function parseOffNumber(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return null;
+}
+
+function parseServingSizeGrams(servingSize: string | undefined): number | null {
+  if (!servingSize) return null;
+  const m = servingSize.match(/(\d+(?:\.\d+)?)\s*g/i);
+  if (!m) return null;
+  const grams = Number(m[1]);
+  return Number.isFinite(grams) && grams > 0 ? grams : null;
+}
 
 export async function saveMealToLog(
   items: SaveItem[],
@@ -146,6 +174,163 @@ export async function updateFoodLogEntry(
   return { error: null };
 }
 
+// ─── 共有商品（Open Food Facts）──────────────────────────────────────────────
+
+export type BarcodeLookupResult = {
+  status: "ok" | "not_found" | "error";
+  product: SharedProduct | null;
+  error: string | null;
+};
+
+async function fetchOffProduct(barcode: string): Promise<SharedProduct | null> {
+  const url = `${OFF_API_BASE}/api/v2/product/${barcode}.json?fields=code,product_name,brands,nutriments`;
+  const res = await fetch(url, {
+    method: "GET",
+    headers: { "User-Agent": OFF_USER_AGENT },
+    cache: "no-store",
+  });
+  if (!res.ok) return null;
+  const json = (await res.json()) as {
+    status?: number;
+    product?: {
+      product_name?: string;
+      brands?: string;
+      serving_size?: string;
+      nutriments?: Record<string, unknown>;
+    };
+  };
+  if (json.status !== 1 || !json.product) return null;
+
+  const name = json.product.product_name?.trim();
+  if (!name) return null;
+  const nutriments = json.product.nutriments ?? {};
+  const protein = parseOffNumber(nutriments.proteins_100g);
+  const fat = parseOffNumber(nutriments.fat_100g);
+  const carbs = parseOffNumber(
+    nutriments.carbohydrates_100g ?? nutriments.carbohydrates
+  );
+
+  return {
+    barcode,
+    product_name: name,
+    brand: json.product.brands?.trim() || null,
+    protein_per_100g: protein,
+    fat_per_100g: fat,
+    carbs_per_100g: carbs,
+    serving_size: json.product.serving_size?.trim() || null,
+    serving_size_grams: parseServingSizeGrams(json.product.serving_size),
+    last_checked_at: new Date().toISOString(),
+  };
+}
+
+async function upsertSharedProduct(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  product: SharedProduct
+): Promise<void> {
+  await supabase.from("shared_products").upsert(
+    {
+      barcode: product.barcode,
+      product_name: product.product_name,
+      brand: product.brand,
+      protein_per_100g: product.protein_per_100g,
+      fat_per_100g: product.fat_per_100g,
+      carbs_per_100g: product.carbs_per_100g,
+      serving_size: product.serving_size,
+      serving_size_grams: product.serving_size_grams,
+      last_checked_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      raw_json: product,
+    },
+    { onConflict: "barcode" }
+  );
+}
+
+export async function lookupSharedProductByBarcode(rawBarcode: string): Promise<BarcodeLookupResult> {
+  const barcode = normalizeBarcode(rawBarcode);
+  if (!barcode) return { status: "error", product: null, error: "バーコードが不正です" };
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { status: "error", product: null, error: "認証が必要です" };
+
+  const { data: cached } = await supabase
+    .from("shared_products")
+    .select("barcode, product_name, brand, protein_per_100g, fat_per_100g, carbs_per_100g, serving_size, serving_size_grams, last_checked_at")
+    .eq("barcode", barcode)
+    .maybeSingle();
+
+  if (cached) {
+    const stale = Date.now() - new Date(cached.last_checked_at).getTime() > SHARED_PRODUCT_TTL_MS;
+    if (stale) {
+      void (async () => {
+        const refreshed = await fetchOffProduct(barcode);
+        if (refreshed) await upsertSharedProduct(supabase, refreshed);
+      })();
+    }
+    return { status: "ok", product: cached as SharedProduct, error: null };
+  }
+
+  try {
+    const fetched = await fetchOffProduct(barcode);
+    if (!fetched) return { status: "not_found", product: null, error: null };
+    await upsertSharedProduct(supabase, fetched);
+    return { status: "ok", product: fetched, error: null };
+  } catch {
+    return { status: "error", product: null, error: "OFFからの取得に失敗しました" };
+  }
+}
+
+export async function addSharedProductMenuItem(input: {
+  restaurantId: string;
+  barcode: string;
+  defaultGrams: number;
+  rank?: number;
+}): Promise<{ data: MenuItem | null; error: string | null }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { data: null, error: "認証が必要です" };
+
+  const barcode = normalizeBarcode(input.barcode);
+  if (!barcode) return { data: null, error: "バーコードが不正です" };
+
+  const existing = await supabase
+    .from("menu_items")
+    .select("*")
+    .eq("user_id", user.id)
+    .eq("restaurant_id", input.restaurantId)
+    .eq("shared_barcode", barcode)
+    .limit(1)
+    .maybeSingle();
+  if (existing.data) return { data: existing.data as MenuItem, error: null };
+
+  const lookup = await lookupSharedProductByBarcode(barcode);
+  if (lookup.status !== "ok" || !lookup.product) {
+    return { data: null, error: lookup.error ?? "商品情報の取得に失敗しました" };
+  }
+
+  const insert = await supabase
+    .from("menu_items")
+    .insert({
+      user_id: user.id,
+      restaurant_id: input.restaurantId,
+      name: lookup.product.product_name,
+      protein_per_100g: lookup.product.protein_per_100g,
+      fat_per_100g: lookup.product.fat_per_100g,
+      carbs_per_100g: lookup.product.carbs_per_100g,
+      default_grams: input.defaultGrams > 0 ? input.defaultGrams : 100,
+      rank: input.rank ?? 2,
+      notes: lookup.product.brand ? `OFF: ${lookup.product.brand}` : "OFF連携",
+      group_name: null,
+      group_order: 0,
+      shared_barcode: barcode,
+    })
+    .select()
+    .single();
+
+  if (insert.error) return { data: null, error: insert.error.message };
+  return { data: insert.data as MenuItem, error: null };
+}
+
 // ─── メニューアイテム ──────────────────────────────────────────────────────────
 
 export type MenuItemUpdate = {
@@ -153,6 +338,7 @@ export type MenuItemUpdate = {
   protein_per_100g: number | null;
   fat_per_100g: number | null;
   carbs_per_100g: number | null;
+  shared_barcode?: string | null;
   default_grams: number;
   rank: number;
   notes: string | null;
@@ -408,6 +594,7 @@ export type ImportRestaurantItem = {
   protein_per_100g: number | null;
   fat_per_100g: number | null;
   carbs_per_100g: number | null;
+  shared_barcode?: string | null;
   default_grams: number;
   rank: number;
   notes: string | null;
@@ -472,10 +659,17 @@ export async function importRestaurantData(data: ImportData): Promise<{
       const groupOrderMap = new Map<string, number>();
       const { data: items } = await supabase
         .from("menu_items")
-        .insert(r.menuItems.map(({ group, ...item }) => {
+        .insert(r.menuItems.map(({ group, shared_barcode, ...item }) => {
           const g = group ?? null;
           if (g !== null && !groupOrderMap.has(g)) groupOrderMap.set(g, groupOrderMap.size);
-          return { user_id: user.id, restaurant_id: newR.id, ...item, group_name: g, group_order: g !== null ? (groupOrderMap.get(g) ?? 0) : 0 };
+          return {
+            user_id: user.id,
+            restaurant_id: newR.id,
+            ...item,
+            shared_barcode: shared_barcode ?? null,
+            group_name: g,
+            group_order: g !== null ? (groupOrderMap.get(g) ?? 0) : 0,
+          };
         }))
         .select();
       if (items) newMenuItems.push(...(items as MenuItem[]));
@@ -496,10 +690,17 @@ export async function importMenuItemsToRestaurant(
   const groupOrderMap = new Map<string, number>();
   const { data, error } = await supabase
     .from("menu_items")
-    .insert(items.map(({ group, ...item }) => {
+    .insert(items.map(({ group, shared_barcode, ...item }) => {
       const g = group ?? null;
       if (g !== null && !groupOrderMap.has(g)) groupOrderMap.set(g, groupOrderMap.size);
-      return { user_id: user.id, restaurant_id: restaurantId, ...item, group_name: g, group_order: g !== null ? (groupOrderMap.get(g) ?? 0) : 0 };
+      return {
+        user_id: user.id,
+        restaurant_id: restaurantId,
+        ...item,
+        shared_barcode: shared_barcode ?? null,
+        group_name: g,
+        group_order: g !== null ? (groupOrderMap.get(g) ?? 0) : 0,
+      };
     }))
     .select();
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -26,6 +26,19 @@ export type MenuItem = {
   notes: string | null;
   group_name: string | null;
   group_order: number;
+  shared_barcode?: string | null;
+};
+
+export type SharedProduct = {
+  barcode: string;
+  product_name: string;
+  brand: string | null;
+  protein_per_100g: number | null;
+  fat_per_100g: number | null;
+  carbs_per_100g: number | null;
+  serving_size: string | null;
+  serving_size_grams: number | null;
+  last_checked_at: string;
 };
 
 export type TodayConsumed = {

--- a/supabase/migrations/20260410210000_issue2_phase1_shared_products.sql
+++ b/supabase/migrations/20260410210000_issue2_phase1_shared_products.sql
@@ -1,0 +1,46 @@
+CREATE TABLE IF NOT EXISTS public.shared_products (
+  barcode text PRIMARY KEY,
+  product_name text NOT NULL,
+  brand text,
+  protein_per_100g numeric,
+  fat_per_100g numeric,
+  carbs_per_100g numeric,
+  serving_size text,
+  serving_size_grams numeric,
+  source text NOT NULL DEFAULT 'open_food_facts',
+  raw_json jsonb,
+  last_checked_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.shared_products
+  ADD COLUMN IF NOT EXISTS serving_size text;
+
+ALTER TABLE public.shared_products
+  ADD COLUMN IF NOT EXISTS serving_size_grams numeric;
+
+ALTER TABLE public.menu_items
+  ADD COLUMN IF NOT EXISTS shared_barcode text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'menu_items_shared_barcode_fkey'
+  ) THEN
+    ALTER TABLE public.menu_items
+      ADD CONSTRAINT menu_items_shared_barcode_fkey
+      FOREIGN KEY (shared_barcode)
+      REFERENCES public.shared_products(barcode)
+      ON DELETE SET NULL;
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS idx_menu_items_shared_barcode
+  ON public.menu_items (shared_barcode);
+
+CREATE INDEX IF NOT EXISTS idx_shared_products_last_checked_at
+  ON public.shared_products (last_checked_at);


### PR DESCRIPTION
## Summary
- Issue #2 の Phase1として、`shared_products` テーブルと `menu_items.shared_barcode` を導入し、OFFデータのキャッシュ基盤を追加
- メニュー追加ドロワー内にバーコード読み取り導線を追加し、読み取り結果から商品名・100gあたりPFC・1回量候補を転記可能に改善
- JSON import/export を `shared_barcode` 対応し、設定画面/読み取りUIにOFFクレジット表示を追加、あわせてバージョンを 1.7.0 に更新

## Test plan
- [x] `npm run lint`
- [x] バーコード読み取りでメニュー追加フォームに値が転記されることを確認
- [x] 追加したメニューが保存できることを確認

closes #2

Made with [Cursor](https://cursor.com)