### PR TITLE
fix: iOSのバーコード読み取りでカメラプレビューが黒画面になる不具合

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@
 
 ## [Unreleased]
 
+## [1.7.1] - 2026-04-10
+
+### Fixed
+
+- iPhone の Safari / Chrome でバーコード読み取りのカメラプレビューが真っ暗になる不具合を修正した。`getUserMedia` と `BarcodeDetector` の可否を分離し、後者が無い環境では ZXing でビデオフレームからデコードするようにした。
+
+## [1.7.0] - 2026-04-10
+
 ### Added
 
 - Open Food Facts 連携の Phase1 として、バーコード検索で市販品を取得し、共有キャッシュ（`shared_products`）経由でメニューへ追加できるようにした。

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,20 @@
 {
   "name": "ketolog",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@supabase/ssr": "^0.10.0",
         "@supabase/supabase-js": "^2.102.1",
+        "@zxing/browser": "^0.1.5",
+        "@zxing/library": "^0.21.3",
         "next": "16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -2398,6 +2400,40 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@zxing/browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@zxing/browser/-/browser-0.1.5.tgz",
+      "integrity": "sha512-4Lmrn/il4+UNb87Gk8h1iWnhj39TASEHpd91CwwSJtY5u+wa0iH9qS0wNLAWbNVYXR66WmT5uiMhZ7oVTrKfxw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "@zxing/text-encoding": "^0.9.0"
+      },
+      "peerDependencies": {
+        "@zxing/library": "^0.21.0"
+      }
+    },
+    "node_modules/@zxing/library": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/@zxing/library/-/library-0.21.3.tgz",
+      "integrity": "sha512-hZHqFe2JyH/ZxviJZosZjV+2s6EDSY0O24R+FQmlWZBZXP9IqMo7S3nb3+2LBWxodJQkSurdQGnqE7KXqrYgow==",
+      "license": "MIT",
+      "dependencies": {
+        "ts-custom-error": "^3.2.1"
+      },
+      "engines": {
+        "node": ">= 10.4.0"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "~0.9.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -6439,6 +6475,15 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tsconfig-paths": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@supabase/ssr": "^0.10.0",
     "@supabase/supabase-js": "^2.102.1",
+    "@zxing/browser": "^0.1.5",
+    "@zxing/library": "^0.21.3",
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -38,6 +38,8 @@ import {
   type ImportRestaurantItem,
 } from "./actions";
 import type { SharedProduct } from "@/types/database";
+import { BrowserMultiFormatReader } from "@zxing/browser";
+import { BarcodeFormat, DecodeHintType } from "@zxing/library";
 
 // ─── 型 ────────────────────────────────────────────────────────────────────────
 
@@ -185,8 +187,8 @@ function MenuItemDrawer({
   const videoRef = useRef<HTMLVideoElement>(null);
   const cameraSupported =
     typeof window !== "undefined" &&
-    "BarcodeDetector" in window &&
-    Boolean(navigator.mediaDevices?.getUserMedia);
+    Boolean(navigator.mediaDevices?.getUserMedia) &&
+    (typeof window.isSecureContext === "undefined" || window.isSecureContext);
 
   const displayP = mode === "per100g" ? protein : toServing(protein, grams);
   const displayF = mode === "per100g" ? fat     : toServing(fat,     grams);
@@ -243,39 +245,122 @@ function MenuItemDrawer({
 
   useEffect(() => {
     if (isEdit || !cameraOn || !cameraSupported) return;
-    let stop = false;
+    let stopped = false;
     let stream: MediaStream | null = null;
-    const w = window as Window & { BarcodeDetector?: new () => { detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue?: string }>> } };
+    let stopZxing: (() => void) | null = null;
+
+    const w = window as Window & {
+      BarcodeDetector?: new () => { detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue?: string }>> };
+    };
+
     void (async () => {
       try {
-        stream = await navigator.mediaDevices.getUserMedia({
-          video: { facingMode: { ideal: "environment" } },
-          audio: false,
-        });
-        if (!videoRef.current) return;
-        videoRef.current.srcObject = stream;
-        await videoRef.current.play();
-        if (!w.BarcodeDetector) return;
-        const detector = new w.BarcodeDetector();
-        while (!stop) {
-          if (!videoRef.current) break;
-          const detected = await detector.detect(videoRef.current);
-          const value = detected[0]?.rawValue?.trim();
-          if (value) {
-            setCameraOn(false);
-            void handleLookupBarcode(value);
-            break;
-          }
-          await new Promise((r) => setTimeout(r, 350));
+        try {
+          stream = await navigator.mediaDevices.getUserMedia({
+            video: { facingMode: { ideal: "environment" } },
+            audio: false,
+          });
+        } catch {
+          stream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
         }
       } catch {
-        setScanError("カメラを起動できませんでした。権限設定を確認してください。");
-        setCameraOn(false);
+        if (!stopped) {
+          setScanError("カメラを起動できませんでした。権限設定を確認してください。");
+          setCameraOn(false);
+        }
+        return;
+      }
+
+      if (stopped) {
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+
+      const video = videoRef.current;
+      if (!video) {
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+
+      video.srcObject = stream;
+      video.muted = true;
+      video.playsInline = true;
+      video.setAttribute("playsinline", "true");
+      video.setAttribute("webkit-playsinline", "true");
+
+      try {
+        await video.play();
+      } catch {
+        if (!stopped) {
+          setScanError("映像の再生を開始できませんでした。");
+          setCameraOn(false);
+        }
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+
+      if (stopped) {
+        stream.getTracks().forEach((t) => t.stop());
+        return;
+      }
+
+      if (typeof w.BarcodeDetector !== "undefined") {
+        try {
+          const detector = new w.BarcodeDetector();
+          while (!stopped) {
+            if (!videoRef.current) break;
+            try {
+              const detected = await detector.detect(videoRef.current);
+              const value = detected[0]?.rawValue?.trim();
+              if (value) {
+                setCameraOn(false);
+                void handleLookupBarcode(value);
+                break;
+              }
+            } catch {
+              // フレームごとの検出失敗は無視して続行
+            }
+            await new Promise((r) => setTimeout(r, 350));
+          }
+        } catch {
+          if (!stopped) {
+            setScanError("バーコードの自動読み取りを開始できませんでした。");
+            setCameraOn(false);
+          }
+        }
+      } else {
+        try {
+          const hints = new Map<DecodeHintType, BarcodeFormat[]>();
+          hints.set(DecodeHintType.POSSIBLE_FORMATS, [
+            BarcodeFormat.EAN_13,
+            BarcodeFormat.EAN_8,
+            BarcodeFormat.UPC_A,
+            BarcodeFormat.UPC_E,
+          ]);
+          const reader = new BrowserMultiFormatReader(hints);
+          const controls = reader.scan(video, (result, _err, ctrls) => {
+            if (stopped || !result) return;
+            const text = result.getText().trim();
+            if (text) {
+              ctrls.stop();
+              setCameraOn(false);
+              void handleLookupBarcode(text);
+            }
+          });
+          stopZxing = () => controls.stop();
+        } catch {
+          if (!stopped) {
+            setScanError("バーコードの自動読み取りを開始できませんでした。");
+            setCameraOn(false);
+          }
+        }
       }
     })();
 
     return () => {
-      stop = true;
+      stopped = true;
+      stopZxing?.();
+      stopZxing = null;
       if (stream) stream.getTracks().forEach((t) => t.stop());
     };
   }, [isEdit, cameraOn, cameraSupported, handleLookupBarcode]);
@@ -355,6 +440,12 @@ function MenuItemDrawer({
               <button
                 type="button"
                 onClick={() => {
+                  if (!cameraOn && !cameraSupported) {
+                    setScanError(
+                      "この環境ではカメラを利用できません。HTTPS で開いているか、ブラウザのカメラ権限を確認してください。"
+                    );
+                    return;
+                  }
                   setScanError(null);
                   setCameraResult(null);
                   setServingHint(null);
@@ -370,6 +461,7 @@ function MenuItemDrawer({
                   ref={videoRef}
                   muted
                   playsInline
+                  autoPlay
                   className="w-full rounded-lg border border-gray-700 bg-black aspect-video object-cover"
                 />
               )}


### PR DESCRIPTION
## Summary
- `cameraSupported` から `BarcodeDetector` 依存を外し、`getUserMedia` が使える環境では必ずストリームを `video` に接続してプレビューを表示する
- `BarcodeDetector` が無い環境（iOS Safari / Chrome 等）では `@zxing/browser` でビデオフレームから EAN/UPC を連続デコードする
- 背面カメラ指定に失敗した場合は汎用 `video: true` にフォールバックし、`video` に `autoPlay` / `playsInline` / `webkit-playsinline` を明示

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

closes #47

Made with [Cursor](https://cursor.com)