### PR TITLE
fix: shared_products の RLS と upsert エラー検知

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-04-10
+
+### Fixed
+
+- `shared_products` に RLS がありポリシーが無いとキャッシュ行が作れず、`menu_items.shared_barcode` の外部キーで保存に失敗する問題に対し、認証ユーザー向けの SELECT / INSERT / UPDATE ポリシーをマイグレーションで追加した。
+- OFF 取得後の `shared_products` upsert が失敗しても成功扱いにならないよう、エラーを返すようにした。
+
 ## [1.7.1] - 2026-04-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/actions.ts
+++ b/src/app/today/actions.ts
@@ -226,8 +226,8 @@ async function fetchOffProduct(barcode: string): Promise<SharedProduct | null> {
 async function upsertSharedProduct(
   supabase: Awaited<ReturnType<typeof createClient>>,
   product: SharedProduct
-): Promise<void> {
-  await supabase.from("shared_products").upsert(
+): Promise<{ error: string | null }> {
+  const { error } = await supabase.from("shared_products").upsert(
     {
       barcode: product.barcode,
       product_name: product.product_name,
@@ -243,6 +243,7 @@ async function upsertSharedProduct(
     },
     { onConflict: "barcode" }
   );
+  return { error: error?.message ?? null };
 }
 
 export async function lookupSharedProductByBarcode(rawBarcode: string): Promise<BarcodeLookupResult> {
@@ -264,7 +265,9 @@ export async function lookupSharedProductByBarcode(rawBarcode: string): Promise<
     if (stale) {
       void (async () => {
         const refreshed = await fetchOffProduct(barcode);
-        if (refreshed) await upsertSharedProduct(supabase, refreshed);
+        if (refreshed) {
+          await upsertSharedProduct(supabase, refreshed);
+        }
       })();
     }
     return { status: "ok", product: cached as SharedProduct, error: null };
@@ -273,7 +276,10 @@ export async function lookupSharedProductByBarcode(rawBarcode: string): Promise<
   try {
     const fetched = await fetchOffProduct(barcode);
     if (!fetched) return { status: "not_found", product: null, error: null };
-    await upsertSharedProduct(supabase, fetched);
+    const { error: upsertError } = await upsertSharedProduct(supabase, fetched);
+    if (upsertError) {
+      return { status: "error", product: null, error: upsertError };
+    }
     return { status: "ok", product: fetched, error: null };
   } catch {
     return { status: "error", product: null, error: "OFFからの取得に失敗しました" };

--- a/supabase/migrations/20260410230000_shared_products_rls.sql
+++ b/supabase/migrations/20260410230000_shared_products_rls.sql
@@ -1,0 +1,27 @@
+-- shared_products は OFF 由来の共有キャッシュ。認証ユーザーが読み取り・upsert できるようにする。
+-- RLS 有効かつポリシー無しだと、JWT 経由の操作はすべて拒否され行が増えず menu_items の FK が失敗する。
+
+ALTER TABLE public.shared_products ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "shared_products_select_authenticated" ON public.shared_products;
+DROP POLICY IF EXISTS "shared_products_insert_authenticated" ON public.shared_products;
+DROP POLICY IF EXISTS "shared_products_update_authenticated" ON public.shared_products;
+
+CREATE POLICY "shared_products_select_authenticated"
+  ON public.shared_products
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+CREATE POLICY "shared_products_insert_authenticated"
+  ON public.shared_products
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (true);
+
+CREATE POLICY "shared_products_update_authenticated"
+  ON public.shared_products
+  FOR UPDATE
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- `shared_products` で RLS 有効かつポリシー無しのとき、認証 JWT では upsert がすべて拒否され行が増えず `menu_items_shared_barcode_fkey` で失敗する問題を修正
- マイグレーションで `authenticated` 向け SELECT / INSERT / UPDATE を追加
- `upsertSharedProduct` の `error` を検査し、失敗時は `lookupSharedProductByBarcode` がエラーを返すように変更

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

closes #49

Made with [Cursor](https://cursor.com)