### PR TITLE
docs: ローカルでのモバイル幅確認手順を README に追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 npm run dev
 ```
 
+### モバイル表示の手元確認
+
+ローカルでブラウザから確認する際、開発者ツールのレスポンシブ／デバイスモードで **viewport の幅を変えれば**、スマートフォン相当のレイアウトや主要な挙動を **最低限** 確認できます。実機や Playwright などの E2E での回帰テストは、必要になったタイミングで別途検討してください。
+
 ## Open Food Facts API
 
 バーコードから商品情報を取り込む機能は [Open Food Facts](https://world.openfoodfacts.org)（OFF）の API を利用する。利用前に次を確認すること。


### PR DESCRIPTION
## 概要

Issue #59 の調査のうち、ローカルでのモバイル相当の確認手順を README に追記する。

## 変更内容

- 「ローカル開発」に「モバイル表示の手元確認」を追加。開発者ツールで viewport 幅を変えれば最低限のレイアウト・挙動確認ができる旨、および実機・Playwright 等の E2E は別途検討と記載。

## Issue #59 の扱い

E2E 基盤（認証バイパス・テスト用 Supabase・Playwright 最小構成など）は現時点では着手しない。当面のモバイルまわりの確認は上記の手順で足りる、という結論を文書化する。

Playwright・認証・テスト DB まわりが必要になったタイミングで、新規 Issue に切り出す。

closes #59

Made with [Cursor](https://cursor.com)