### PR TITLE
feat: お気に入りを favorite_groups / favorite_entries に移行 (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@
 
 ### Added
 
-- **お気に入り**: メニュー行の星でトグル。先頭の「お気に入り」タブに店別で集約表示し、そこからカート・記録できる（[#6](https://github.com/kzkski/ketolog/issues/6)）。
-- **DB**: `menu_items.is_favorite`（マイグレーション `20260411120000_menu_items_is_favorite.sql`）。
+- **お気に入り**: メニュー行の星でトグル。先頭の「お気に入り」タブからカート・記録できる（[#6](https://github.com/kzkski/ketolog/issues/6)）。
+- **お気に入り（DB 再設計）**: `favorite_groups` / `favorite_entries` で `menu_items` を参照。お気に入りタブは **グループ単位**（初期は店名）で表示し、各行に **店名・店内グループ** 由来を表示（[#66](https://github.com/kzkski/ketolog/issues/66)）。マイグレーション `20260412120000_favorite_groups_entries.sql`（既存 `is_favorite` を移行のうえ列廃止）。
 
 ### Fixed
 
@@ -23,7 +23,8 @@
 
 - **自炊・プリセット**: 「マイフード」の特別扱い（タブ先頭固定・削除・並べ替え不可）を廃止。同梱プリセットを `homemade-keto.json`（店名 **汎用食材**）に統一し、他店と同様に並べ替え・削除できる。新規シードも `display_order` に従う（[#6](https://github.com/kzkski/ketolog/issues/6)）。
 - **`homemade-keto.json`**: Issue #6 コメント添付の JSON をそのまま反映（55 品・`_schema` 付きエクスポート形式）。
-- **JSON エクスポート/インポート**: メニューに任意の `is_favorite`（boolean）を含められるようにした。
+- **JSON エクスポート**: 単店・全店エクスポートから `is_favorite` を削除（お気に入りは DB の `favorite_entries` で管理）。
+- **JSON インポート**: メニューに `is_favorite: true` があれば、取り込み後に `favorite_entries` へ反映（店名グループへ配置）。
 - **今日ページ（スマホ）**: カートは折りたたみ時は細いバーのみとし、展開時はボトムシートのオーバーレイに表示してメニュー一覧の縦スペースを確保した（[#60](https://github.com/kzkski/ketolog/issues/60)）。
 - **メニュー追加ドロワー**: 見出しを「{店名}へメニューを追加」形式に集約し、登録先の説明ブロックをなくした。バーコード映像は最大高さ付きでスクロール内に表示。新規追加時の登録系3ボタンはスマホで2列＋短いラベルとし、固定フッターではなくフォーム末尾までスクロールして操作する。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.10.0",
+  "version": "1.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -17,7 +17,14 @@ import {
   useSortable,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import type { FoodLogEntry, MenuItem, Restaurant, UserSettings, TodayConsumed } from "@/types/database";
+import type {
+  FoodLogEntry,
+  MenuItem,
+  Restaurant,
+  UserSettings,
+  TodayConsumed,
+  FavoriteGroupPayload,
+} from "@/types/database";
 import type { MealType } from "@/lib/meal-timezone";
 import { isSnapshotRestaurant } from "@/lib/snapshot-restaurant";
 import { createClient } from "@/lib/supabase/client";
@@ -26,7 +33,8 @@ import {
   updateMenuItem,
   addMenuItem,
   deleteMenuItem,
-  setMenuItemFavorite,
+  addMenuItemToFavorites,
+  removeMenuItemFromFavorites,
   addRestaurant,
   deleteRestaurant,
   reorderRestaurants,
@@ -1058,7 +1066,6 @@ const EXPORT_SCHEMA = {
     "menuItems[].rank": "1〜4の整数 (必須) — 1=◎最優先 / 2=○通常 / 3=△控えめ / 4=✕避ける",
     "menuItems[].notes": "string or null — メモ（任意）",
     "menuItems[].group": "string or null — グループ名（任意。同じ値のアイテムがまとめて表示されます）",
-    "menuItems[].is_favorite": "boolean（任意）— true のときお気に入りとして扱う",
   },
 } as const;
 
@@ -1080,7 +1087,6 @@ function downloadRestaurantJson(restaurant: Restaurant, menuItems: MenuItem[]) {
         rank: m.rank,
         notes: m.notes,
         group: m.group_name,
-        is_favorite: m.is_favorite === true,
       })),
   };
   const date = new Date().toISOString().split("T")[0];
@@ -1147,7 +1153,6 @@ function downloadTemplate() {
         rank: 2,
         notes: null,
         group: null,
-        is_favorite: false,
       },
     ],
   };
@@ -1447,11 +1452,13 @@ const RANK_ICON: Record<number, { icon: string; className: string }> = {
   4: { icon: "✕", className: "text-red-400" },
 };
 
-function MenuItemRow({ item, entry, onAdd, onRemove, onChangeGrams, onEdit, onToggleFavorite }: {
+function MenuItemRow({ item, entry, onAdd, onRemove, onChangeGrams, onEdit, onToggleFavorite, isFavorited, originCaption }: {
   item: MenuItem; entry: CartEntry | undefined;
   onAdd: (grams: number) => void; onRemove: () => void;
   onChangeGrams: (g: number) => void; onEdit: () => void;
   onToggleFavorite: () => void | Promise<void>;
+  isFavorited: boolean;
+  originCaption?: string | null;
 }) {
   const [editingGrams, setEditingGrams] = useState(false);
   const [gramsInput, setGramsInput] = useState("");
@@ -1462,7 +1469,6 @@ function MenuItemRow({ item, entry, onAdd, onRemove, onChangeGrams, onEdit, onTo
   const serving = pfc(item, displayGrams);
   const count = entry?.count ?? 0;
   const rank = RANK_ICON[item.rank] ?? RANK_ICON[2];
-  const isFavorite = item.is_favorite === true;
 
   function startGramsEdit() {
     setGramsInput(displayGrams.toString());
@@ -1486,25 +1492,36 @@ function MenuItemRow({ item, entry, onAdd, onRemove, onChangeGrams, onEdit, onTo
     <div className="flex items-center gap-2.5 sm:gap-2 px-4 py-3 sm:py-2.5 border-b border-gray-800/60">
       <button
         type="button"
-        aria-label={isFavorite ? "お気に入りを解除" : "お気に入りに追加"}
+        aria-label={isFavorited ? "お気に入りを解除" : "お気に入りに追加"}
         onClick={(e) => {
           e.stopPropagation();
           void onToggleFavorite();
         }}
         className={`shrink-0 w-10 h-11 sm:w-8 sm:h-8 flex items-center justify-center text-lg sm:text-base leading-none rounded-lg sm:rounded-md active:bg-gray-800/70 touch-manipulation ${
-          isFavorite ? "text-amber-400" : "text-gray-600 hover:text-gray-400"
+          isFavorited ? "text-amber-400" : "text-gray-600 hover:text-gray-400"
         }`}
       >
-        {isFavorite ? "★" : "☆"}
+        {isFavorited ? "★" : "☆"}
       </button>
       <span className={`text-sm sm:text-xs shrink-0 w-5 sm:w-4 flex justify-center ${rank.className}`}>{rank.icon}</span>
       <button type="button" className="flex-1 min-w-0 text-left py-0.5 -my-0.5" onClick={onEdit}>
         <p className="text-base sm:text-sm text-white truncate">{item.name}</p>
-        <p className="text-sm sm:text-xs text-gray-500 mt-0.5">
-          {item.protein_per_100g !== null
-            ? `P${fmt(serving.p)} F${fmt(serving.f)} C${fmt(serving.c)}`
-            : "PFC未設定 — タップして編集"}
-        </p>
+        {originCaption ? (
+          <>
+            <p className="text-sm sm:text-xs text-gray-400 mt-0.5 truncate">{originCaption}</p>
+            <p className="text-sm sm:text-xs text-gray-500 mt-0.5">
+              {item.protein_per_100g !== null
+                ? `P${fmt(serving.p)} F${fmt(serving.f)} C${fmt(serving.c)}`
+                : "PFC未設定 — タップして編集"}
+            </p>
+          </>
+        ) : (
+          <p className="text-sm sm:text-xs text-gray-500 mt-0.5">
+            {item.protein_per_100g !== null
+              ? `P${fmt(serving.p)} F${fmt(serving.f)} C${fmt(serving.c)}`
+              : "PFC未設定 — タップして編集"}
+          </p>
+        )}
       </button>
 
       <div className="shrink-0">
@@ -1800,7 +1817,6 @@ function downloadAllRestaurants(restaurants: Restaurant[], menuItems: MenuItem[]
           rank: m.rank,
           notes: m.notes,
           group: m.group_name,
-          is_favorite: m.is_favorite === true,
         })),
     })),
   };
@@ -1868,6 +1884,7 @@ function SortableRestaurantTab({
 interface Props {
   restaurants: Restaurant[];
   menuItems: MenuItem[];
+  initialFavoriteGroups: FavoriteGroupPayload[];
   settings: UserSettings;
   todayConsumed: TodayConsumed;
   today: string;
@@ -1880,6 +1897,7 @@ interface Props {
 export default function TodayClient({
   restaurants: initialRestaurants,
   menuItems: initialMenuItems,
+  initialFavoriteGroups,
   settings,
   todayConsumed,
   today,
@@ -1892,6 +1910,7 @@ export default function TodayClient({
   const [showSettings, setShowSettings]       = useState(false);
   const [restaurants, setRestaurants] = useState<Restaurant[]>(initialRestaurants);
   const [menuItems, setMenuItems]     = useState<MenuItem[]>(initialMenuItems);
+  const [favoriteGroups, setFavoriteGroups] = useState<FavoriteGroupPayload[]>(initialFavoriteGroups);
   const [selectedRestaurantId, setSelectedRestaurantId] = useState(() =>
     firstTabRestaurantId(initialRestaurants)
   );
@@ -1969,6 +1988,20 @@ export default function TodayClient({
     () => tabRestaurants.map((r) => r.id),
     [tabRestaurants]
   );
+
+  const restaurantNameById = useMemo(() => {
+    const m = new Map<string, string>();
+    for (const r of restaurants) m.set(r.id, r.name);
+    return m;
+  }, [restaurants]);
+
+  const favoriteMenuItemIds = useMemo(() => {
+    const s = new Set<string>();
+    for (const g of favoriteGroups) {
+      for (const e of g.entries) s.add(e.menu_item_id);
+    }
+    return s;
+  }, [favoriteGroups]);
   const restaurantSensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
     useSensor(TouchSensor, { activationConstraint: { delay: 220, tolerance: 6 } })
@@ -1998,18 +2031,21 @@ export default function TodayClient({
   }
 
   async function handleToggleFavorite(item: MenuItem) {
-    const next = !item.is_favorite;
-    setMenuItems((prev) =>
-      prev.map((m) => (m.id === item.id ? { ...m, is_favorite: next } : m))
-    );
-    const result = await setMenuItemFavorite(item.id, next);
-    if (result.error) {
-      alert(result.error);
-      setMenuItems((prev) =>
-        prev.map((m) => (m.id === item.id ? { ...m, is_favorite: item.is_favorite } : m))
-      );
-    } else if (result.data) {
-      setMenuItems((prev) => prev.map((m) => (m.id === item.id ? result.data! : m)));
+    const was = favoriteMenuItemIds.has(item.id);
+    if (was) {
+      const result = await removeMenuItemFromFavorites(item.id);
+      if (result.error) {
+        alert(result.error);
+        return;
+      }
+      if (result.data) setFavoriteGroups(result.data);
+    } else {
+      const result = await addMenuItemToFavorites(item.id);
+      if (result.error) {
+        alert(result.error);
+        return;
+      }
+      if (result.data) setFavoriteGroups(result.data);
     }
   }
 
@@ -2047,41 +2083,36 @@ export default function TodayClient({
     groupName: string | null;
     groupOrder: number;
     items: MenuItem[];
+    /** お気に入りタブ用: 行ごとの由来（店名・店内グループ） */
+    originByItemId?: Record<string, string>;
   };
-
-  const restaurantOrderIndex = useMemo(() => {
-    const m = new Map<string, number>();
-    tabRestaurants.forEach((r, i) => m.set(r.id, i));
-    return m;
-  }, [tabRestaurants]);
 
   const menuGroups = useMemo((): MenuGroup[] => {
     if (selectedRestaurantIdResolved === FAVORITES_TAB_ID) {
-      const items = menuItems.filter((m) => m.is_favorite === true);
-      const byRest = new Map<string, MenuItem[]>();
-      for (const item of items) {
-        const list = byRest.get(item.restaurant_id) ?? [];
-        list.push(item);
-        byRest.set(item.restaurant_id, list);
-      }
-      const restIds = [...byRest.keys()].sort(
-        (a, b) =>
-          (restaurantOrderIndex.get(a) ?? 999) - (restaurantOrderIndex.get(b) ?? 999)
-      );
-      return restIds.map((rid) => {
-        const rest = tabRestaurants.find((r) => r.id === rid);
-        const label = rest?.name ?? "お店";
-        const groupItems = [...(byRest.get(rid) ?? [])].sort((a, b) => {
-          if (a.rank !== b.rank) return a.rank - b.rank;
-          return a.name.localeCompare(b.name, "ja");
+      return favoriteGroups
+        .filter((g) => g.entries.length > 0)
+        .slice()
+        .sort((a, b) => a.display_order - b.display_order)
+        .map((g) => {
+          const originByItemId: Record<string, string> = {};
+          const items: MenuItem[] = g.entries
+            .slice()
+            .sort((x, y) => x.display_order - y.display_order)
+            .map((e) => {
+              const live = menuItems.find((m) => m.id === e.menu_item_id) ?? e.menu_item;
+              const rname = restaurantNameById.get(live.restaurant_id) ?? "お店";
+              const gn = live.group_name?.trim();
+              originByItemId[live.id] = gn ? `${rname} · ${gn}` : rname;
+              return live;
+            });
+          return {
+            sectionKey: `favg:${g.id}`,
+            groupName: g.name,
+            groupOrder: g.display_order,
+            items,
+            originByItemId,
+          };
         });
-        return {
-          sectionKey: `fav:${rid}`,
-          groupName: label,
-          groupOrder: restaurantOrderIndex.get(rid) ?? 0,
-          items: groupItems,
-        };
-      });
     }
 
     const items = menuItems.filter(
@@ -2108,7 +2139,7 @@ export default function TodayClient({
         if (b.groupName === null) return 1;
         return a.groupOrder - b.groupOrder;
       });
-  }, [menuItems, selectedRestaurantIdResolved, restaurantOrderIndex, tabRestaurants]);
+  }, [menuItems, selectedRestaurantIdResolved, favoriteGroups, restaurantNameById]);
 
   // ── カート操作 ──────────────────────────────────────────────────────────────
   function addItem(item: MenuItem, grams: number) {
@@ -2160,6 +2191,14 @@ export default function TodayClient({
       if (idx >= 0) return prev.map((m) => m.id === saved.id ? saved : m);
       return [...prev, saved]; // 追加の場合
     });
+    setFavoriteGroups((prev) =>
+      prev.map((g) => ({
+        ...g,
+        entries: g.entries.map((e) =>
+          e.menu_item_id === saved.id ? { ...e, menu_item: saved } : e
+        ),
+      }))
+    );
     // カートにあれば item を更新（gramsPerServing はユーザーの手動編集値を保持）
     setCart((prev) => {
       const entry = prev.get(saved.id);
@@ -2172,6 +2211,14 @@ export default function TodayClient({
 
   function handleItemDeleted(id: string) {
     setMenuItems((prev) => prev.filter((m) => m.id !== id));
+    setFavoriteGroups((prev) =>
+      prev
+        .map((g) => ({
+          ...g,
+          entries: g.entries.filter((e) => e.menu_item_id !== id),
+        }))
+        .filter((g) => g.entries.length > 0)
+    );
     setCart((prev) => { const next = new Map(prev); next.delete(id); return next; });
   }
 
@@ -2181,9 +2228,21 @@ export default function TodayClient({
     setDeletingRestaurant(true);
     const result = await deleteRestaurant(selectedRestaurant.id);
     if (result.error) { alert(result.error); setDeletingRestaurant(false); return; }
-    const next = restaurants.filter((r) => r.id !== selectedRestaurant.id);
+    const rid = selectedRestaurant.id;
+    const next = restaurants.filter((r) => r.id !== rid);
     setRestaurants(next);
-    setMenuItems((prev) => prev.filter((m) => m.restaurant_id !== selectedRestaurant.id));
+    setMenuItems((prev) => prev.filter((m) => m.restaurant_id !== rid));
+    setFavoriteGroups((prev) =>
+      prev
+        .map((g) => ({
+          ...g,
+          entries: g.entries.filter((e) => {
+            const it = menuItems.find((m) => m.id === e.menu_item_id) ?? e.menu_item;
+            return it.restaurant_id !== rid;
+          }),
+        }))
+        .filter((g) => g.entries.length > 0)
+    );
     setSelectedRestaurantId(next[0]?.id ?? "");
     setConfirmDeleteRestaurant(false);
     setDeletingRestaurant(false);
@@ -2475,6 +2534,7 @@ export default function TodayClient({
                   onChangeGrams={(g) => updateGrams(item.id, g)}
                   onEdit={() => setItemDrawer({ kind: "edit", item })}
                   onToggleFavorite={() => void handleToggleFavorite(item)}
+                  isFavorited={favoriteMenuItemIds.has(item.id)}
                 />
               ));
             }
@@ -2509,6 +2569,8 @@ export default function TodayClient({
                     onChangeGrams={(g) => updateGrams(item.id, g)}
                     onEdit={() => setItemDrawer({ kind: "edit", item })}
                     onToggleFavorite={() => void handleToggleFavorite(item)}
+                    isFavorited={favoriteMenuItemIds.has(item.id)}
+                    originCaption={group.originByItemId?.[item.id] ?? null}
                   />
                 ))}
               </div>

--- a/src/app/today/actions.ts
+++ b/src/app/today/actions.ts
@@ -2,7 +2,15 @@
 
 import { createClient } from "@/lib/supabase/server";
 import { SNAPSHOT_RESTAURANT_NAME } from "@/lib/snapshot-restaurant";
-import type { FoodLogEntry, MenuItem, Restaurant, TodayConsumed, SharedProduct } from "@/types/database";
+import type {
+  FoodLogEntry,
+  MenuItem,
+  Restaurant,
+  TodayConsumed,
+  SharedProduct,
+  FavoriteGroupPayload,
+  FavoriteEntryPayload,
+} from "@/types/database";
 
 export type SaveItem = {
   menuItemId: string | null;
@@ -430,26 +438,195 @@ export async function updateMenuItem(
   return { data: row as MenuItem, error: null };
 }
 
-export async function setMenuItemFavorite(
-  id: string,
-  isFavorite: boolean
-): Promise<{ data: MenuItem | null; error: string | null }> {
+async function fetchFavoriteGroupsPayloadInternal(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string
+): Promise<{ data: FavoriteGroupPayload[]; error: string | null }> {
+  const { data: rows, error } = await supabase
+    .from("favorite_groups")
+    .select(
+      `
+      id,
+      name,
+      display_order,
+      favorite_entries (
+        id,
+        favorite_group_id,
+        menu_item_id,
+        display_order,
+        menu_items (*)
+      )
+    `
+    )
+    .eq("user_id", userId)
+    .order("display_order", { ascending: true });
+
+  if (error) return { data: [], error: error.message };
+
+  const groups: FavoriteGroupPayload[] = (rows ?? []).map((g: Record<string, unknown>) => {
+    const rawEntries =
+      (g.favorite_entries as Array<Record<string, unknown>> | null) ?? [];
+    const entries: FavoriteEntryPayload[] = rawEntries
+      .map((e) => ({
+        id: e.id as string,
+        favorite_group_id: e.favorite_group_id as string,
+        menu_item_id: e.menu_item_id as string,
+        display_order: e.display_order as number,
+        menu_item: e.menu_items as MenuItem,
+      }))
+      .sort((a, b) => a.display_order - b.display_order);
+    return {
+      id: g.id as string,
+      name: g.name as string,
+      display_order: g.display_order as number,
+      entries,
+    };
+  });
+
+  return { data: groups, error: null };
+}
+
+export async function fetchFavoriteGroupsPayload(): Promise<{
+  data: FavoriteGroupPayload[];
+  error: string | null;
+}> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { data: [], error: "認証が必要です" };
+  return fetchFavoriteGroupsPayloadInternal(supabase, user.id);
+}
+
+async function getOrCreateFavoriteGroupByName(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+  groupName: string
+): Promise<{ id: string | null; error: string | null }> {
+  const trimmed = groupName.trim();
+  if (!trimmed) return { id: null, error: "グループ名が空です" };
+
+  const { data: existing } = await supabase
+    .from("favorite_groups")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("name", trimmed)
+    .maybeSingle();
+  if (existing?.id) return { id: existing.id, error: null };
+
+  const { data: maxRow } = await supabase
+    .from("favorite_groups")
+    .select("display_order")
+    .eq("user_id", userId)
+    .order("display_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const displayOrder = (maxRow?.display_order ?? -1) + 1;
+
+  const { data: inserted, error } = await supabase
+    .from("favorite_groups")
+    .insert({ user_id: userId, name: trimmed, display_order: displayOrder })
+    .select("id")
+    .single();
+
+  if (error) return { id: null, error: error.message };
+  return { id: inserted.id as string, error: null };
+}
+
+/** お気に入りエントリを1件追加（既にあれば何もしない）。インポートからも利用。 */
+async function ensureFavoriteEntryForMenuItem(
+  supabase: Awaited<ReturnType<typeof createClient>>,
+  userId: string,
+  menuItemId: string,
+  restaurantDisplayName: string
+): Promise<{ error: string | null }> {
+  const { data: dup } = await supabase
+    .from("favorite_entries")
+    .select("id")
+    .eq("menu_item_id", menuItemId)
+    .maybeSingle();
+  if (dup) return { error: null };
+
+  const { id: groupId, error: gErr } = await getOrCreateFavoriteGroupByName(
+    supabase,
+    userId,
+    restaurantDisplayName
+  );
+  if (gErr || !groupId) return { error: gErr ?? "お気に入りグループの作成に失敗しました" };
+
+  const { data: maxE } = await supabase
+    .from("favorite_entries")
+    .select("display_order")
+    .eq("favorite_group_id", groupId)
+    .order("display_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const entryOrder = (maxE?.display_order ?? -1) + 1;
+
+  const { error: insErr } = await supabase.from("favorite_entries").insert({
+    favorite_group_id: groupId,
+    menu_item_id: menuItemId,
+    display_order: entryOrder,
+  });
+  if (insErr) return { error: insErr.message };
+  return { error: null };
+}
+
+export async function addMenuItemToFavorites(
+  menuItemId: string
+): Promise<{ data: FavoriteGroupPayload[] | null; error: string | null }> {
   const supabase = await createClient();
   const {
     data: { user },
   } = await supabase.auth.getUser();
   if (!user) return { data: null, error: "認証が必要です" };
 
-  const { data: row, error } = await supabase
+  const { data: mi, error: miErr } = await supabase
     .from("menu_items")
-    .update({ is_favorite: isFavorite })
-    .eq("id", id)
+    .select("restaurant_id")
+    .eq("id", menuItemId)
     .eq("user_id", user.id)
-    .select()
-    .single();
+    .maybeSingle();
+  if (miErr || !mi) {
+    return { data: null, error: miErr?.message ?? "メニューが見つかりません" };
+  }
 
+  const { data: rest, error: rErr } = await supabase
+    .from("restaurants")
+    .select("name")
+    .eq("id", mi.restaurant_id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (rErr || !rest) {
+    return { data: null, error: rErr?.message ?? "お店が見つかりません" };
+  }
+
+  const addErr = await ensureFavoriteEntryForMenuItem(
+    supabase,
+    user.id,
+    menuItemId,
+    rest.name
+  );
+  if (addErr.error) return { data: null, error: addErr.error };
+
+  const payload = await fetchFavoriteGroupsPayloadInternal(supabase, user.id);
+  return { data: payload.data, error: payload.error };
+}
+
+export async function removeMenuItemFromFavorites(
+  menuItemId: string
+): Promise<{ data: FavoriteGroupPayload[] | null; error: string | null }> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return { data: null, error: "認証が必要です" };
+
+  const { error } = await supabase.from("favorite_entries").delete().eq("menu_item_id", menuItemId);
   if (error) return { data: null, error: error.message };
-  return { data: row as MenuItem, error: null };
+
+  const payload = await fetchFavoriteGroupsPayloadInternal(supabase, user.id);
+  return { data: payload.data, error: payload.error };
 }
 
 export async function addMenuItem(
@@ -751,6 +928,7 @@ export async function importRestaurantData(data: ImportData): Promise<{
       const { data: items } = await supabase
         .from("menu_items")
         .insert(r.menuItems.map(({ group, shared_barcode, is_favorite, ...item }) => {
+          void is_favorite;
           const g = group ?? null;
           if (g !== null && !groupOrderMap.has(g)) groupOrderMap.set(g, groupOrderMap.size);
           return {
@@ -758,13 +936,34 @@ export async function importRestaurantData(data: ImportData): Promise<{
             restaurant_id: newR.id,
             ...item,
             shared_barcode: shared_barcode ?? null,
-            is_favorite: is_favorite === true,
             group_name: g,
             group_order: g !== null ? (groupOrderMap.get(g) ?? 0) : 0,
           };
         }))
         .select();
-      if (items) newMenuItems.push(...(items as MenuItem[]));
+      if (items) {
+        newMenuItems.push(...(items as MenuItem[]));
+        const rname = newR.name as string;
+        for (let i = 0; i < r.menuItems.length; i++) {
+          if (r.menuItems[i].is_favorite === true && items[i]) {
+            const fe = await ensureFavoriteEntryForMenuItem(
+              supabase,
+              user.id,
+              (items[i] as { id: string }).id,
+              rname
+            );
+            if (fe.error) {
+              return {
+                added: newRestaurants.length,
+                skipped,
+                newRestaurants,
+                newMenuItems,
+                error: fe.error,
+              };
+            }
+          }
+        }
+      }
     }
   }
 
@@ -783,6 +982,7 @@ export async function importMenuItemsToRestaurant(
   const { data, error } = await supabase
     .from("menu_items")
     .insert(items.map(({ group, shared_barcode, is_favorite, ...item }) => {
+      void is_favorite;
       const g = group ?? null;
       if (g !== null && !groupOrderMap.has(g)) groupOrderMap.set(g, groupOrderMap.size);
       return {
@@ -790,7 +990,6 @@ export async function importMenuItemsToRestaurant(
         restaurant_id: restaurantId,
         ...item,
         shared_barcode: shared_barcode ?? null,
-        is_favorite: is_favorite === true,
         group_name: g,
         group_order: g !== null ? (groupOrderMap.get(g) ?? 0) : 0,
       };
@@ -798,5 +997,22 @@ export async function importMenuItemsToRestaurant(
     .select();
 
   if (error) return { newMenuItems: [], error: error.message };
-  return { newMenuItems: (data ?? []) as MenuItem[], error: null };
+
+  const { data: restRow } = await supabase
+    .from("restaurants")
+    .select("name")
+    .eq("id", restaurantId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const rname = restRow?.name ?? "";
+
+  const inserted = (data ?? []) as MenuItem[];
+  for (let i = 0; i < items.length; i++) {
+    if (items[i].is_favorite === true && inserted[i] && rname) {
+      const fe = await ensureFavoriteEntryForMenuItem(supabase, user.id, inserted[i].id, rname);
+      if (fe.error) return { newMenuItems: inserted, error: fe.error };
+    }
+  }
+
+  return { newMenuItems: inserted, error: null };
 }

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -2,7 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getMealTypeForTimeZone } from "@/lib/meal-timezone";
 import { redirect } from "next/navigation";
 import TodayClient from "./TodayClient";
-import { getOrCreateSnapshotRestaurant } from "./actions";
+import { getOrCreateSnapshotRestaurant, fetchFavoriteGroupsPayload } from "./actions";
 import type { FoodLogEntry, MenuItem, Restaurant, UserSettings, TodayConsumed } from "@/types/database";
 import fs from "fs";
 import path from "path";
@@ -30,7 +30,7 @@ export default async function TodayPage() {
 
   const today = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
 
-  const [settingsRes, restaurantsRes, menuItemsRes, foodLogRes] = await Promise.all([
+  const [settingsRes, restaurantsRes, menuItemsRes, foodLogRes, favoritePayload] = await Promise.all([
     supabase.from("user_settings").select("*").eq("user_id", user.id).maybeSingle(),
     supabase.from("restaurants").select("*").eq("user_id", user.id),
     supabase
@@ -45,6 +45,7 @@ export default async function TodayPage() {
       .eq("user_id", user.id)
       .eq("date", today)
       .order("created_at", { ascending: true }),
+    fetchFavoriteGroupsPayload(),
   ]);
 
   const settings: UserSettings = settingsRes.data ?? {
@@ -86,12 +87,14 @@ export default async function TodayPage() {
   );
 
   const presets = loadPresets();
+  const initialFavoriteGroups = favoritePayload.error ? [] : favoritePayload.data;
 
   return (
     <div className="flex flex-col h-svh bg-gray-950 w-full">
       <TodayClient
         restaurants={restaurants}
         menuItems={menuItems}
+        initialFavoriteGroups={initialFavoriteGroups}
         settings={settings}
         todayConsumed={todayConsumed}
         today={today}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -27,7 +27,23 @@ export type MenuItem = {
   group_name: string | null;
   group_order: number;
   shared_barcode?: string | null;
-  is_favorite?: boolean;
+};
+
+/** お気に入りエントリ（menu_items 行への参照） */
+export type FavoriteEntryPayload = {
+  id: string;
+  favorite_group_id: string;
+  menu_item_id: string;
+  display_order: number;
+  menu_item: MenuItem;
+};
+
+/** ユーザー別お気に入りグループ（店名など任意のラベル） */
+export type FavoriteGroupPayload = {
+  id: string;
+  name: string;
+  display_order: number;
+  entries: FavoriteEntryPayload[];
 };
 
 export type SharedProduct = {

--- a/supabase/migrations/20260412120000_favorite_groups_entries.sql
+++ b/supabase/migrations/20260412120000_favorite_groups_entries.sql
@@ -1,0 +1,122 @@
+-- Issue #66: お気に入りを favorite_groups / favorite_entries に移行し menu_items.is_favorite を廃止
+
+CREATE TABLE public.favorite_groups (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  name text NOT NULL,
+  display_order integer NOT NULL DEFAULT 0,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT favorite_groups_user_name_unique UNIQUE (user_id, name)
+);
+
+CREATE TABLE public.favorite_entries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  favorite_group_id uuid NOT NULL REFERENCES public.favorite_groups (id) ON DELETE CASCADE,
+  menu_item_id uuid NOT NULL REFERENCES public.menu_items (id) ON DELETE CASCADE,
+  display_order integer NOT NULL DEFAULT 0,
+  CONSTRAINT favorite_entries_menu_item_unique UNIQUE (menu_item_id)
+);
+
+CREATE INDEX idx_favorite_groups_user_display
+  ON public.favorite_groups (user_id, display_order);
+
+CREATE INDEX idx_favorite_entries_group_display
+  ON public.favorite_entries (favorite_group_id, display_order);
+
+-- 既存 is_favorite を移行（店名と一致する favorite_groups を作成し、エントリを挿入）
+INSERT INTO public.favorite_groups (user_id, name, display_order)
+SELECT user_id, gname, dord
+FROM (
+  SELECT DISTINCT
+    m.user_id,
+    r.name AS gname,
+    (DENSE_RANK() OVER (PARTITION BY m.user_id ORDER BY r.name) - 1)::integer AS dord
+  FROM public.menu_items m
+  INNER JOIN public.restaurants r
+    ON r.id = m.restaurant_id AND r.user_id = m.user_id
+  WHERE COALESCE(m.is_favorite, false) = true
+) AS distinct_groups;
+
+INSERT INTO public.favorite_entries (favorite_group_id, menu_item_id, display_order)
+SELECT fg.id, m.id,
+  (ROW_NUMBER() OVER (PARTITION BY fg.id ORDER BY m.name) - 1)::integer
+FROM public.menu_items m
+INNER JOIN public.restaurants r
+  ON r.id = m.restaurant_id AND r.user_id = m.user_id
+INNER JOIN public.favorite_groups fg
+  ON fg.user_id = m.user_id AND fg.name = r.name
+WHERE COALESCE(m.is_favorite, false) = true;
+
+ALTER TABLE public.menu_items
+  DROP COLUMN IF EXISTS is_favorite;
+
+ALTER TABLE public.favorite_groups ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.favorite_entries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "favorite_groups_select_own"
+  ON public.favorite_groups FOR SELECT TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "favorite_groups_insert_own"
+  ON public.favorite_groups FOR INSERT TO authenticated
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "favorite_groups_update_own"
+  ON public.favorite_groups FOR UPDATE TO authenticated
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+CREATE POLICY "favorite_groups_delete_own"
+  ON public.favorite_groups FOR DELETE TO authenticated
+  USING (user_id = auth.uid());
+
+CREATE POLICY "favorite_entries_select_own"
+  ON public.favorite_entries FOR SELECT TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.favorite_groups fg
+      WHERE fg.id = favorite_group_id AND fg.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "favorite_entries_insert_own"
+  ON public.favorite_entries FOR INSERT TO authenticated
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.favorite_groups fg
+      WHERE fg.id = favorite_group_id AND fg.user_id = auth.uid()
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.menu_items mi
+      WHERE mi.id = menu_item_id AND mi.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "favorite_entries_update_own"
+  ON public.favorite_entries FOR UPDATE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.favorite_groups fg
+      WHERE fg.id = favorite_group_id AND fg.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.favorite_groups fg
+      WHERE fg.id = favorite_group_id AND fg.user_id = auth.uid()
+    )
+    AND EXISTS (
+      SELECT 1 FROM public.menu_items mi
+      WHERE mi.id = menu_item_id AND mi.user_id = auth.uid()
+    )
+  );
+
+CREATE POLICY "favorite_entries_delete_own"
+  ON public.favorite_entries FOR DELETE TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.favorite_groups fg
+      WHERE fg.id = favorite_group_id AND fg.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
## 概要

Issue #66 / 計画どおり、`menu_items.is_favorite` を廃止し **`favorite_groups` / `favorite_entries`** で `menu_item_id` 参照として管理します。

## 主な変更

- マイグレーション `20260412120000_favorite_groups_entries.sql`: テーブル作成・既存フラグ移行（店名グループ）・`is_favorite` DROP・RLS
- Server Actions: `addMenuItemToFavorites` / `removeMenuItemFromFavorites` / `fetchFavoriteGroupsPayload`
- Today: お気に入りタブは **グループ折りたたみ**、各行に **店名・店内グループ** の由来表示
- JSON エクスポートから `is_favorite` 削除。インポート時 `is_favorite: true` は `favorite_entries` へ反映

## デプロイ

Supabase にマイグレーション適用が必須です。

## バージョン

1.11.0（マイナー）

closes #66

Made with [Cursor](https://cursor.com)