### PR TITLE
preset: ケンタッキー（オリジナルチキン部位）新規追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 - **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。
 
+## [1.15.0] - 2026-04-12
+
+### Added
+
+- **プリセット**: ケンタッキーフライドチキン（オリジナルチキン部位：キール・サイ・ドラム・ウイング・リブ）を `public/presets/kfc-original-chicken.json` として同梱（[#76](https://github.com/kzkski/ketolog/issues/76)）。
+
 ## [1.14.0] - 2026-04-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/presets/kfc-original-chicken.json
+++ b/public/presets/kfc-original-chicken.json
@@ -1,0 +1,62 @@
+{
+  "version": 1,
+  "name": "ケンタッキーフライドチキン",
+  "category": "external",
+  "menuItems": [
+    {
+      "name": "キール（胸）",
+      "protein_per_100g": 29.3,
+      "fat_per_100g": 15.8,
+      "carbs_per_100g": 8.3,
+      "shared_barcode": null,
+      "default_grams": 133,
+      "rank": 2,
+      "notes": "可食部133g推計。P最大だがF密度は低め。P補填日向き。米国KFC公式ベース",
+      "group": "オリジナルチキン"
+    },
+    {
+      "name": "サイ（もも）",
+      "protein_per_100g": 24.1,
+      "fat_per_100g": 24.1,
+      "carbs_per_100g": 10.1,
+      "shared_barcode": null,
+      "default_grams": 79,
+      "rank": 1,
+      "notes": "可食部79g推計。可食部あたりF密度が全部位トップ（24.1g/100g）。ケト最強部位。米国KFC公式ベース",
+      "group": "オリジナルチキン"
+    },
+    {
+      "name": "ドラム（drumstick）",
+      "protein_per_100g": 21.8,
+      "fat_per_100g": 14.5,
+      "carbs_per_100g": 7.3,
+      "shared_barcode": null,
+      "default_grams": 55,
+      "rank": 3,
+      "notes": "可食部55g推計（USDA総重量75gから骨20g差引）。F密度が低くケトコスパは最も低い。米国KFC公式+USDA",
+      "group": "オリジナルチキン"
+    },
+    {
+      "name": "ウイング",
+      "protein_per_100g": 28.6,
+      "fat_per_100g": 22.9,
+      "carbs_per_100g": 8.6,
+      "shared_barcode": null,
+      "default_grams": 70,
+      "rank": 1,
+      "notes": "可食部70g推計。小ぶりだがF密度高くC最小。皮面積比が高い。米国KFC公式ベース",
+      "group": "オリジナルチキン"
+    },
+    {
+      "name": "リブ（あばら）",
+      "protein_per_100g": 34.3,
+      "fat_per_100g": 22.9,
+      "carbs_per_100g": 12.1,
+      "shared_barcode": null,
+      "default_grams": 70,
+      "rank": 1,
+      "notes": "可食部70g推計（骨多め）。P・Fともに高水準でバランス最良。英国KFC公式ベース（米国に部位なし）",
+      "group": "オリジナルチキン"
+    }
+  ]
+}


### PR DESCRIPTION
## 概要

`public/presets/kfc-original-chicken.json` を追加し、オリジナルチキンの代表的な5部位をプリセットとして同梱する。

## 関連

- Closes #76
- 親: #15

Made with [Cursor](https://cursor.com)