### PR TITLE
fix: ヘッダーヒントをPFCバーと同期（#79）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **今日ページヘッダー**: ヒントが PFC バー（確定摂取＋カート）と同期するよう改善。スロット内の `localStorage` 固定をやめ、文面は約 300ms デバウンスで更新（[#79](https://github.com/kzkski/ketolog/issues/79)）。
+
 ### Changed
 
 - **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- **今日ページヘッダー**: ヒントが PFC バー（確定摂取＋カート）と同期するよう改善。スロット内の `localStorage` 固定をやめ、文面は約 300ms デバウンスで更新（[#79](https://github.com/kzkski/ketolog/issues/79)）。
-
 ### Changed
 
 - **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。
+
+## [1.15.1] - 2026-04-12
+
+### Fixed
+
+- **今日ページヘッダー**: ヒントが PFC バー（確定摂取＋カート）と同期するよう改善。スロット内の `localStorage` 固定をやめ、文面は約 300ms デバウンスで更新（[#79](https://github.com/kzkski/ketolog/issues/79)）。
 
 ## [1.15.0] - 2026-04-12
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -58,13 +58,7 @@ import {
   menuRowMacroHighlights,
   type MacroHighlightTargets,
 } from "@/lib/macroHighlights";
-import {
-  computeHeaderHintText,
-  getActiveHintSlot,
-  getCachedHeaderHint,
-  setCachedHeaderHint,
-  targetsFingerprint,
-} from "@/lib/header-hint";
+import { computeHeaderHintText, getActiveHintSlot } from "@/lib/header-hint";
 
 // ─── 型 ────────────────────────────────────────────────────────────────────────
 
@@ -150,6 +144,8 @@ type NutrientMode = "per100g" | "perServing";
 type ItemDrawerState =
   | { kind: "edit"; item: MenuItem }
   | { kind: "add"; restaurantId: string; logMealType?: MealType };
+
+const HEADER_HINT_DEBOUNCE_MS = 300;
 
 // ─── ユーティリティ ────────────────────────────────────────────────────────────
 
@@ -2104,14 +2100,11 @@ export default function TodayClient({
     return () => clearInterval(id);
   }, []);
 
-  const headerHint = useMemo(() => {
+  const headerHintRaw = useMemo(() => {
     void headerHintTimeTick;
     if (selectedDate !== today) return null;
     const slot = getActiveHintSlot(new Date());
     if (!slot) return null;
-    const fp = targetsFingerprint(currentSettings);
-    const cached = getCachedHeaderHint(selectedDate, slot, fp);
-    if (cached !== null) return cached;
     return computeHeaderHintText({
       slot,
       consumed: { p: totalPFC.p, f: totalPFC.f, c: totalPFC.c },
@@ -2131,32 +2124,31 @@ export default function TodayClient({
     headerHintTimeTick,
   ]);
 
+  const [headerHint, setHeaderHint] = useState<string | null>(null);
+  const headerHintDisplayedRef = useRef<string | null>(null);
+
   useEffect(() => {
-    void headerHintTimeTick;
-    if (selectedDate !== today) return;
-    const slot = getActiveHintSlot(new Date());
-    if (!slot) return;
-    const fp = targetsFingerprint(currentSettings);
-    if (getCachedHeaderHint(selectedDate, slot, fp) !== null) return;
-    const text = computeHeaderHintText({
-      slot,
-      consumed: { p: totalPFC.p, f: totalPFC.f, c: totalPFC.c },
-      targets: {
-        p: currentSettings.protein_target_g,
-        f: currentSettings.fat_target_g,
-        c: currentSettings.carbs_target_g,
-      },
-    });
-    setCachedHeaderHint(selectedDate, slot, fp, text);
-  }, [
-    selectedDate,
-    today,
-    currentSettings,
-    totalPFC.p,
-    totalPFC.f,
-    totalPFC.c,
-    headerHintTimeTick,
-  ]);
+    if (headerHintRaw === null) {
+      headerHintDisplayedRef.current = null;
+      const clearId = window.setTimeout(() => {
+        setHeaderHint(null);
+      }, 0);
+      return () => clearTimeout(clearId);
+    }
+    if (headerHintDisplayedRef.current === null) {
+      const showId = window.setTimeout(() => {
+        headerHintDisplayedRef.current = headerHintRaw;
+        setHeaderHint(headerHintRaw);
+      }, 0);
+      return () => clearTimeout(showId);
+    }
+    if (headerHintDisplayedRef.current === headerHintRaw) return;
+    const id = window.setTimeout(() => {
+      headerHintDisplayedRef.current = headerHintRaw;
+      setHeaderHint(headerHintRaw);
+    }, HEADER_HINT_DEBOUNCE_MS);
+    return () => clearTimeout(id);
+  }, [headerHintRaw]);
 
   const cartEntries = useMemo(() => Array.from(cart.values()).filter((e) => e.count > 0), [cart]);
   const hasCart = cartEntries.length > 0;

--- a/src/lib/header-hint.ts
+++ b/src/lib/header-hint.ts
@@ -1,6 +1,7 @@
 /**
- * 今日ページヘッダー用の時間帯ベース日次ヒント（純粋ロジック + localStorage）。
+ * 今日ページヘッダー用の時間帯ベース日次ヒント（純粋ロジック）。
  * Issue #70: Asia/Tokyo・3スロット・糖質優先分岐・PFC不足割合による主マクロ。
+ * 表示文面は TodayClient 側で PFC バーと同じ摂取（確定＋カート）に追従させる（#79）。
  */
 
 export const TOKYO_TZ = "Asia/Tokyo";
@@ -22,17 +23,6 @@ const SLOT_BED_END = 24 * 60;
 export const NEAR_CARB_RATIO = 0.15;
 export const NEAR_CARB_ABS_G = 5;
 export const SHORTFALL_ATTENTION_RATIO = 0.3;
-
-export const HEADER_HINT_STORAGE_KEY = "ketolog.headerHint.v1";
-
-type StorageShape = {
-  v: 1;
-  entries: Record<string, { text: string; fp: string }>;
-};
-
-function fmtMacro(n: number): string {
-  return n < 10 ? n.toFixed(1) : String(Math.round(n));
-}
 
 export function getTokyoMinutesSinceMidnight(date: Date): number {
   const dtf = new Intl.DateTimeFormat("en-US", {
@@ -57,14 +47,6 @@ export function getActiveHintSlot(now: Date): HeaderHintSlot | null {
   if (t >= SLOT_DINNER_START && t < SLOT_DINNER_END) return "before_dinner";
   if (t >= SLOT_BED_START && t < SLOT_BED_END) return "before_bed";
   return null;
-}
-
-export function targetsFingerprint(targets: {
-  protein_target_g: number;
-  fat_target_g: number;
-  carbs_target_g: number;
-}): string {
-  return `${targets.protein_target_g},${targets.fat_target_g},${targets.carbs_target_g}`;
 }
 
 type CarbHeadline =
@@ -189,6 +171,10 @@ function copyCoaching(
   }
 }
 
+function fmtMacro(n: number): string {
+  return n < 10 ? n.toFixed(1) : String(Math.round(n));
+}
+
 export function computeHeaderHintText(input: {
   slot: HeaderHintSlot;
   consumed: { p: number; f: number; c: number };
@@ -213,66 +199,4 @@ export function computeHeaderHintText(input: {
   const primary = pickPrimaryMacro(rem, targets);
   if (primary === null) return copyAllMet(slot);
   return copyCoaching(slot, urgent, primary, rem);
-}
-
-function readStorage(): StorageShape {
-  if (typeof window === "undefined") return { v: 1, entries: {} };
-  try {
-    const raw = window.localStorage.getItem(HEADER_HINT_STORAGE_KEY);
-    if (!raw) return { v: 1, entries: {} };
-    const parsed = JSON.parse(raw) as StorageShape;
-    if (parsed?.v !== 1 || typeof parsed.entries !== "object" || !parsed.entries) {
-      return { v: 1, entries: {} };
-    }
-    return parsed;
-  } catch {
-    return { v: 1, entries: {} };
-  }
-}
-
-function writeStorage(data: StorageShape): void {
-  if (typeof window === "undefined") return;
-  try {
-    let { entries } = data;
-    const keys = Object.keys(entries);
-    if (keys.length > 40) {
-      const sorted = [...keys].sort();
-      const toRemove = sorted.slice(0, keys.length - 30);
-      const next = { ...entries };
-      for (const k of toRemove) delete next[k];
-      entries = next;
-    }
-    window.localStorage.setItem(
-      HEADER_HINT_STORAGE_KEY,
-      JSON.stringify({ v: 1, entries })
-    );
-  } catch {
-    /* ignore quota */
-  }
-}
-
-function cacheKey(date: string, slot: HeaderHintSlot): string {
-  return `${date}_${slot}`;
-}
-
-export function getCachedHeaderHint(
-  date: string,
-  slot: HeaderHintSlot,
-  fp: string
-): string | null {
-  const data = readStorage();
-  const row = data.entries[cacheKey(date, slot)];
-  if (!row || row.fp !== fp) return null;
-  return row.text;
-}
-
-export function setCachedHeaderHint(
-  date: string,
-  slot: HeaderHintSlot,
-  fp: string,
-  text: string
-): void {
-  const data = readStorage();
-  data.entries[cacheKey(date, slot)] = { text, fp };
-  writeStorage(data);
 }


### PR DESCRIPTION
## 概要

ヘッダーの時間帯ヒントが、`localStorage` のキャッシュ（日付・スロット・目標値のみ）によりスロット内で固定され、PFC バー（確定摂取＋カート）とずれる問題を修正しました。

## 変更内容

- `computeHeaderHintText` を `totalPFC` ベースで都度算出
- 表示文言は約 300ms デバウンス（連続操作時のちらつき抑制）。初回表示・クリアは `setTimeout(0)` で ESLint `set-state-in-effect` に適合
- `src/lib/header-hint.ts` から localStorage キャッシュ API を削除

## Issue

closes #79

関連: #70


Made with [Cursor](https://cursor.com)