### PR TITLE
fix: メニュー詳細保存後に一覧の重量（g）を同期する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 - **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。
 
+### Fixed
+
+- **メニュー一覧**: 詳細で保存した 1 食あたりの重量（g）が、一覧右端の表示にすぐ反映されるよう修正（[#78](https://github.com/kzkski/ketolog/issues/78)）。
+
 ## [1.15.1] - 2026-04-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。
 
+## [1.15.2] - 2026-04-12
+
 ### Fixed
 
 - **メニュー一覧**: 詳細で保存した 1 食あたりの重量（g）が、一覧右端の表示にすぐ反映されるよう修正（[#78](https://github.com/kzkski/ketolog/issues/78)）。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.15.1",
+  "version": "1.15.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -2612,7 +2612,7 @@ export default function TodayClient({
             if (group.groupName === null) {
               return group.items.map((item) => (
                 <MenuItemRow
-                  key={item.id}
+                  key={`${item.id}-${item.default_grams}`}
                   item={item}
                   entry={cart.get(item.id)}
                   onAdd={(g) => addItem(item, g)}
@@ -2651,7 +2651,7 @@ export default function TodayClient({
                 </button>
                 {!isCollapsed && group.items.map((item) => (
                   <MenuItemRow
-                    key={item.id}
+                    key={`${item.id}-${item.default_grams}`}
                     item={item}
                     entry={cart.get(item.id)}
                     onAdd={(g) => addItem(item, g)}


### PR DESCRIPTION
## 概要
メニュー詳細で `default_grams` を保存したあと、一覧右端の g 表示が古いままになる不具合を修正します。

## 変更内容
- `MenuItemRow` の `key` を `${item.id}-${item.default_grams}` にし、保存で重量が変わったときに行をリマウントして `localGrams` の初期状態を親と一致させる。
- `useEffect` 内の `setLocalGrams` は `react-hooks/set-state-in-effect` に抵触するため採用していません。

## チェック
- `npm run lint` / `npm run build` 通過

closes #78

Made with [Cursor](https://cursor.com)