### PR TITLE
fix(ui): モバイル今日ページの上部クロームを縮小

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
 
 - **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。
 
+## [1.16.1] - 2026-04-12
+
+### Changed
+
+- **今日ページ（モバイル）**: タイトルバー・日付ナビ・PFC・食事タブ・お気に入り／店タブの縦余白とフォントを抑え、一覧の見える範囲を広げた。過去日は「今日に戻る」を日付と同じ行に並べて高さを削減（[#83](https://github.com/kzkski/ketolog/issues/83)）。
+
 ## [1.16.0] - 2026-04-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -380,13 +380,13 @@ function PFCBar({ label, current, target, color }: {
   const pct = Math.min((current / target) * 100, 100);
   const over = current > target;
   return (
-    <div className="flex items-center gap-2 sm:gap-2">
-      <span className="text-sm sm:text-xs text-gray-400 w-5 sm:w-4 shrink-0">{label}</span>
-      <div className="flex-1 h-2.5 sm:h-2 bg-gray-800 rounded-full overflow-hidden">
+    <div className="flex items-center gap-1.5 sm:gap-2">
+      <span className="text-xs text-gray-400 w-4 shrink-0">{label}</span>
+      <div className="flex-1 h-2 sm:h-2 bg-gray-800 rounded-full overflow-hidden">
         <div className={`h-full rounded-full transition-all duration-300 ${over ? "bg-red-500" : color}`}
           style={{ width: `${pct}%` }} />
       </div>
-      <span className={`text-sm sm:text-xs tabular-nums w-[5.25rem] sm:w-[4.5rem] text-right ${over ? "text-red-400" : "text-gray-300"}`}>
+      <span className={`text-xs tabular-nums w-[4.75rem] sm:w-[4.5rem] text-right ${over ? "text-red-400" : "text-gray-300"}`}>
         {fmt(current)} / {target}g
       </span>
     </div>
@@ -1937,7 +1937,7 @@ function SortableRestaurantTab({
     <div
       ref={setNodeRef}
       style={style}
-      className={`flex shrink-0 items-stretch border-b-2 min-h-12 sm:min-h-0 ${
+      className={`flex shrink-0 items-stretch border-b-2 min-h-10 sm:min-h-0 ${
         selected ? "border-emerald-500" : "border-transparent"
       }`}
     >
@@ -1954,7 +1954,7 @@ function SortableRestaurantTab({
       <button
         type="button"
         onClick={onSelect}
-        className={`pl-1 pr-3 sm:pl-0.5 sm:pr-2.5 py-3.5 sm:py-2.5 text-base sm:text-sm font-medium whitespace-nowrap text-left transition-colors touch-manipulation min-w-0 max-w-[12rem] sm:max-w-none truncate ${
+        className={`pl-1 pr-3 sm:pl-0.5 sm:pr-2.5 py-2 sm:py-2.5 text-sm font-medium whitespace-nowrap text-left transition-colors touch-manipulation min-w-0 max-w-[12rem] sm:max-w-none truncate ${
           selected ? "text-white" : "text-gray-500 hover:text-gray-300"
         }`}
       >
@@ -2514,8 +2514,8 @@ export default function TodayClient({
   return (
     <>
       {/* ヘッダー */}
-      <header className="flex-none flex items-center gap-2 px-4 py-3.5 sm:py-3 border-b border-gray-800 pt-[max(0.75rem,env(safe-area-inset-top))]">
-        <h1 className="text-lg sm:text-base font-bold text-white shrink-0">
+      <header className="flex-none flex items-center gap-2 px-4 py-2 sm:py-3 border-b border-gray-800 pt-[max(0.5rem,env(safe-area-inset-top))]">
+        <h1 className="text-base font-bold text-white shrink-0">
           Ketolog
           {changelogUrl ? (
             <a
@@ -2523,18 +2523,18 @@ export default function TodayClient({
               target="_blank"
               rel="noopener noreferrer"
               aria-label="変更履歴（Changelog）を開く"
-              className="text-sm sm:text-xs font-normal text-gray-500 ml-1.5 hover:text-gray-300 hover:underline underline-offset-2"
+              className="text-xs font-normal text-gray-500 ml-1.5 hover:text-gray-300 hover:underline underline-offset-2"
             >
               v{process.env.NEXT_PUBLIC_APP_VERSION}
             </a>
           ) : (
-            <span className="text-sm sm:text-xs font-normal text-gray-500 ml-1.5">v{process.env.NEXT_PUBLIC_APP_VERSION}</span>
+            <span className="text-xs font-normal text-gray-500 ml-1.5">v{process.env.NEXT_PUBLIC_APP_VERSION}</span>
           )}
         </h1>
         <div className="flex-1 min-w-0 flex justify-center items-center px-1">
           {headerHint ? (
             <p
-              className="text-center text-xs sm:text-[11px] text-gray-400 leading-snug truncate max-w-full"
+              className="text-center text-[11px] text-gray-400 leading-snug truncate max-w-full"
               title={headerHint}
             >
               {headerHint}
@@ -2543,40 +2543,40 @@ export default function TodayClient({
         </div>
         <button onClick={() => setShowSettings(true)}
           type="button"
-          className="shrink-0 text-gray-400 hover:text-white transition-colors text-xl sm:text-lg leading-none min-h-11 min-w-11 sm:min-h-0 sm:min-w-0 flex items-center justify-center rounded-lg sm:rounded-none active:bg-gray-800/60 sm:active:bg-transparent">
+          className="shrink-0 text-gray-400 hover:text-white transition-colors text-lg sm:text-lg leading-none min-h-10 min-w-10 sm:min-h-0 sm:min-w-0 flex items-center justify-center rounded-lg sm:rounded-none active:bg-gray-800/60 sm:active:bg-transparent">
           ⚙
         </button>
       </header>
 
       <div className="flex-1 flex flex-col min-h-0">
         {/* 日付ナビゲーション */}
-        <div className="flex-none flex items-center justify-between px-4 py-2.5 sm:py-2 border-b border-gray-800 bg-gray-900 gap-2">
+        <div className="flex-none flex items-center justify-between px-3 sm:px-4 py-1.5 sm:py-2 border-b border-gray-800 bg-gray-900 gap-1 sm:gap-2">
           <button type="button" onClick={() => navigateDate(-1)} disabled={loadingDate}
-            className="min-h-11 min-w-11 sm:min-h-8 sm:min-w-8 flex items-center justify-center text-gray-400 hover:text-white disabled:opacity-30 transition-colors text-xl sm:text-lg rounded-lg sm:rounded-none active:bg-gray-800/50 shrink-0">
+            className="min-h-10 min-w-10 sm:min-h-8 sm:min-w-8 flex items-center justify-center text-gray-400 hover:text-white disabled:opacity-30 transition-colors text-lg sm:text-lg rounded-lg sm:rounded-none active:bg-gray-800/50 shrink-0">
             ‹
           </button>
-          <div className="flex flex-col items-center gap-1 min-w-0 flex-1">
-            <span className="text-base sm:text-sm font-medium text-white text-center">
+          <div className="flex flex-row sm:flex-col flex-wrap items-center justify-center gap-x-2 gap-y-0 sm:gap-1 min-w-0 flex-1 px-0.5">
+            <span className="text-sm font-medium text-white text-center">
               {loadingDate ? "読込中..." : formatNavDate(selectedDate, today)}
             </span>
             {selectedDate !== today && !loadingDate && (
               <button
                 type="button"
                 onClick={() => void goToToday()}
-                className="text-xs sm:text-[11px] text-emerald-400 hover:text-emerald-300 underline-offset-2 hover:underline py-0.5"
+                className="text-[11px] text-emerald-400 hover:text-emerald-300 underline-offset-2 hover:underline shrink-0 py-0.5"
               >
                 今日に戻る
               </button>
             )}
           </div>
           <button type="button" onClick={() => navigateDate(1)} disabled={selectedDate >= today || loadingDate}
-            className="min-h-11 min-w-11 sm:min-h-8 sm:min-w-8 flex items-center justify-center text-gray-400 hover:text-white disabled:opacity-30 transition-colors text-xl sm:text-lg rounded-lg sm:rounded-none active:bg-gray-800/50 shrink-0">
+            className="min-h-10 min-w-10 sm:min-h-8 sm:min-w-8 flex items-center justify-center text-gray-400 hover:text-white disabled:opacity-30 transition-colors text-lg sm:text-lg rounded-lg sm:rounded-none active:bg-gray-800/50 shrink-0">
             ›
           </button>
         </div>
 
         {/* PFCバー */}
-        <div className="flex-none px-4 py-3.5 sm:py-3 bg-gray-900 border-b border-gray-800 space-y-2 sm:space-y-1.5">
+        <div className="flex-none px-4 py-2.5 sm:py-3 bg-gray-900 border-b border-gray-800 space-y-1.5 sm:space-y-1.5">
           <PFCBar label="P" current={totalPFC.p} target={currentSettings.protein_target_g} color={MACRO_BAR_BG.p} />
           <PFCBar label="F" current={totalPFC.f} target={currentSettings.fat_target_g}     color={MACRO_BAR_BG.f} />
           <PFCBar label="C" current={totalPFC.c} target={currentSettings.carbs_target_g}   color={MACRO_BAR_BG.c} />
@@ -2589,7 +2589,7 @@ export default function TodayClient({
               type="button"
               aria-expanded={showLogEntries}
               onClick={() => setShowLogEntries((v) => !v)}
-              className="w-full flex items-center justify-end gap-2 px-4 py-3 sm:py-2 text-sm sm:text-xs text-gray-400 hover:text-white transition-colors min-h-11 sm:min-h-0"
+              className="w-full flex items-center justify-end gap-2 px-4 py-2 sm:py-2 text-xs text-gray-400 hover:text-white transition-colors min-h-10 sm:min-h-0"
             >
               <span className="font-medium text-gray-300 text-right">
                 この日の記録（{logEntries.length}件）
@@ -2633,7 +2633,7 @@ export default function TodayClient({
                   key={type}
                   type="button"
                   onClick={() => setMealType(type)}
-                  className={`flex-1 min-w-0 min-h-12 sm:min-h-0 py-3.5 sm:py-2.5 text-sm sm:text-xs font-medium border-b-2 transition-colors text-center touch-manipulation ${
+                  className={`flex-1 min-w-0 min-h-10 sm:min-h-0 py-2 sm:py-2.5 text-xs font-medium border-b-2 transition-colors text-center touch-manipulation ${
                     active
                       ? `${a.row} ${a.label}`
                       : "border-transparent text-gray-500 hover:text-gray-300"
@@ -2671,7 +2671,7 @@ export default function TodayClient({
               setSelectedRestaurantId(FAVORITES_TAB_ID);
               setConfirmDeleteRestaurant(false);
             }}
-            className={`px-4 py-3.5 sm:py-2.5 text-base sm:text-sm font-medium whitespace-nowrap shrink-0 border-b-2 transition-colors min-h-12 sm:min-h-0 touch-manipulation ${
+            className={`px-3 sm:px-4 py-2 sm:py-2.5 text-sm font-medium whitespace-nowrap shrink-0 border-b-2 transition-colors min-h-10 sm:min-h-0 touch-manipulation ${
               selectedRestaurantIdResolved === FAVORITES_TAB_ID
                 ? "border-amber-500 text-amber-100"
                 : "border-transparent text-gray-500 hover:text-gray-300"
@@ -2698,7 +2698,7 @@ export default function TodayClient({
               setConfirmDeleteRestaurant(false);
               setSelectedRestaurantId(MEXT_COMPOSITION_TAB_ID);
             }}
-            className={`px-3 py-3.5 sm:py-2.5 text-sm sm:text-sm font-medium whitespace-nowrap shrink-0 border-b-2 transition-colors min-h-12 sm:min-h-0 touch-manipulation max-w-[9.5rem] sm:max-w-none ${
+            className={`px-2.5 sm:px-3 py-2 sm:py-2.5 text-xs sm:text-sm font-medium whitespace-nowrap shrink-0 border-b-2 transition-colors min-h-10 sm:min-h-0 touch-manipulation max-w-[9.5rem] sm:max-w-none ${
               selectedRestaurantIdResolved === MEXT_COMPOSITION_TAB_ID
                 ? "border-sky-500 text-sky-100"
                 : "border-transparent text-gray-500 hover:text-gray-300"


### PR DESCRIPTION
## 概要

iPhone など狭いビューポートで「今日」画面上部の固定領域が縦に積み上がり一覧が窮屈になる問題を緩和する。

## 変更内容

- ヘッダー・日付ナビ・PFC ブロック・「この日の記録」トグル・食事タブ・お気に入り／店タブで、`sm` 未満の padding / min-height / フォントを一段コンパクト化（`sm:` 以上は従来に近い値を維持）。
- 過去日表示時は「今日に戻る」を日付ラベルと**同一行**（`flex-row`）にし、`sm` 以上では従来どおり縦並び。
- PFC バー: 行間・バー高・数値列幅をモバイル向けに調整。

## Issue

closes #83

Made with [Cursor](https://cursor.com)