### PR TITLE
docs: PWA 対応のロードマップと public/icons 準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- **開発者向け**: PWA 化（manifest・アイコン・Service Worker）の方針を [ROADMAP.md](ROADMAP.md) と Issue に整理し、`public/icons/` へのロゴ配置を準備（[#88](https://github.com/kzkski/ketolog/issues/88)）。
 - **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。
 
 ## [1.16.7] - 2026-04-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 ### Changed
 
 - **開発者向け**: PWA 化（manifest・アイコン・Service Worker）の方針を [ROADMAP.md](ROADMAP.md) と Issue に整理し、`public/icons/` へのロゴ配置を準備（[#88](https://github.com/kzkski/ketolog/issues/88)）。
-- **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。
 
 ## [1.16.7] - 2026-04-12
 
@@ -75,6 +74,10 @@
 ### Added
 
 - **プリセット**: ケンタッキーフライドチキン（オリジナルチキン部位：キール・サイ・ドラム・ウイング・リブ）を `public/presets/kfc-original-chicken.json` として同梱（[#76](https://github.com/kzkski/ketolog/issues/76)）。
+
+### Changed
+
+- **開発者向け**: アプリ未使用の `body_composition` / `daily_log` / `daily_summary` をベースラインから削除（[#74](https://github.com/kzkski/ketolog/issues/74)）。ベースラインの内容を変更したため、ローカルでチェックサム不一致になる場合は `supabase db reset` するか、[migration repair](https://supabase.com/docs/reference/cli/supabase-migration-repair) を参照。
 
 ## [1.14.0] - 2026-04-11
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,6 +84,10 @@
   - PFC目標値（P/F/C）のカスタマイズ
   - 全データをJSONでエクスポート
 
+### 2-7 予定（PWA）
+- **プログレッシブ対応 PWA**: Web App Manifest、共有ロゴ由来の `public/icons/`、Service Worker の段階導入（認証・動的ページはキャッシュを慎重に扱う）
+- 追跡: [#88](https://github.com/kzkski/ketolog/issues/88)
+
 ---
 
 ## Phase 3 後日（優先度低）

--- a/public/icons/README.md
+++ b/public/icons/README.md
@@ -1,0 +1,10 @@
+# PWA 用アイコン
+
+[Issue #88](https://github.com/kzkski/ketolog/issues/88) で合意した **円形 KETOLOG ロゴ**の PNG を、次のファイル名でこのディレクトリに配置してください。
+
+| ファイル | 用途 |
+|----------|------|
+| `icon-512.png` | 512×512（マスターを正方形に整えたもの） |
+| `icon-192.png` | 192×192（同素材からリサイズ） |
+
+実装では Web App Manifest から `/icons/icon-512.png` および `/icons/icon-192.png` を参照する想定です。maskable 用に余白を増やした別画像が必要になった場合は、同 Issue で追記します。


### PR DESCRIPTION
refs #88

## 概要
PWA 対応の Issue 作成に合わせ、ロードマップ・ の配置手順・CHANGELOG を整えた。

## 変更内容
- **ROADMAP.md**: Phase 2-7（PWA）を追加し #88 へリンク
- **public/icons/README.md**: 共有ロゴ由来の `icon-512.png` / `icon-192.png` 配置の案内
- **CHANGELOG.md**: Unreleased に開発者向けの一行を追加（CI の changelog 必須に対応）

## 補足
manifest・Service Worker・`package.json` のマイナー更新は、`feat/pwa-progressive` などの後続 PR で #88 に向けて実装する。

Made with [Cursor](https://cursor.com)