### PR TITLE
feat: PWA（manifest・メタ・Service Worker）を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@
 
 ## [Unreleased]
 
+## [1.18.0] - 2026-04-12
+
+### Added
+
+- **PWA**: Web App Manifest（ホーム画面追加・スタンドアロン表示）、テーマ色・iOS 向けメタ、本番のみ有効な Service Worker（`/_next/static/` と `/icons/` の GET のみキャッシュ。HTML・API はキャッシュしない）。
+
 ## [1.17.1] - 2026-04-12
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ npm run dev
 
 ローカルでブラウザから確認する際、開発者ツールのレスポンシブ／デバイスモードで **viewport の幅を変えれば**、スマートフォン相当のレイアウトや主要な挙動を **最低限** 確認できます。実機や Playwright などの E2E での回帰テストは、必要になったタイミングで別途検討してください。
 
+### PWA（ホーム画面に追加）
+
+本番（HTTPS）では Web App Manifest と Service Worker が有効です。**iPhone（Safari）**: 共有 → **ホーム画面に追加**。**Android（Chrome）**: メニューから **アプリをインストール** または **ホーム画面に追加**（表示は端末・バージョンにより異なります）。ローカル `npm run dev` では Service Worker は登録しません（ホットリロードとの兼ね合い）。
+
 ## Open Food Facts API
 
 バーコードから商品情報を取り込む機能は [Open Food Facts](https://world.openfoodfacts.org)（OFF）の API を利用する。利用前に次を確認すること。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.17.1",
+  "version": "1.18.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/icons/README.md
+++ b/public/icons/README.md
@@ -8,4 +8,4 @@
 | `icon-192.png` | 192×192 |
 | `icon-header.png` | 160×160（512 から縮小。今日ページヘッダー用。表示は約 40–44px で 2–3x DPR 向け） |
 
-Web App Manifest からは `/icons/icon-512.png` と `/icons/icon-192.png` を参照する想定です（[#88](https://github.com/kzkski/ketolog/issues/88)）。
+Web App Manifest（`src/app/manifest.ts`）から `/icons/icon-512.png` と `/icons/icon-192.png` を参照しています（[#88](https://github.com/kzkski/ketolog/issues/88)）。

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,49 @@
+/* Ketolog PWA — caches only hashed static chunks and local icons. No HTML / API caching. */
+const CACHE_NAME = "ketolog-static-v1";
+const CACHED_PREFIXES = ["/_next/static/", "/icons/"];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(
+          keys
+            .filter(
+              (key) =>
+                key.startsWith("ketolog-static-") && key !== CACHE_NAME,
+            )
+            .map((key) => caches.delete(key)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+  if (req.method !== "GET") return;
+
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return;
+
+  const path = url.pathname;
+  const cacheable = CACHED_PREFIXES.some((p) => path.startsWith(p));
+  if (!cacheable) return;
+
+  event.respondWith(
+    caches.open(CACHE_NAME).then((cache) =>
+      cache.match(req).then((cached) => {
+        if (cached) return cached;
+        return fetch(req).then((res) => {
+          if (res.ok) cache.put(req, res.clone());
+          return res;
+        });
+      }),
+    ),
+  );
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { Geist } from "next/font/google";
+import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 import "./globals.css";
 
 const geist = Geist({
@@ -7,15 +8,31 @@ const geist = Geist({
   subsets: ["latin"],
 });
 
+const themeColor = "#0f1e3d";
+
 export const metadata: Metadata = {
   title: "Ketolog",
   description: "ケトジェニック食事管理アプリ",
+  applicationName: "Ketolog",
+  appleWebApp: {
+    capable: true,
+    title: "Ketolog",
+    statusBarStyle: "black-translucent",
+  },
+  icons: {
+    icon: [
+      { url: "/icons/icon-192.png", sizes: "192x192", type: "image/png" },
+      { url: "/icons/icon-512.png", sizes: "512x512", type: "image/png" },
+    ],
+    apple: "/icons/icon-192.png",
+  },
 };
 
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   viewportFit: "cover",
+  themeColor,
 };
 
 export default function RootLayout({
@@ -26,6 +43,7 @@ export default function RootLayout({
   return (
     <html lang="ja" className={`${geist.variable} h-full antialiased`}>
       <body className="min-h-full flex flex-col bg-gray-950 text-white touch-manipulation">
+        <ServiceWorkerRegister />
         {children}
       </body>
     </html>

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,0 +1,37 @@
+import type { MetadataRoute } from "next";
+
+const THEME = "#0f1e3d";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Ketolog",
+    short_name: "Ketolog",
+    description: "ケトジェニック食事管理アプリ",
+    lang: "ja",
+    start_url: "/",
+    display: "standalone",
+    orientation: "portrait",
+    background_color: THEME,
+    theme_color: THEME,
+    icons: [
+      {
+        src: "/icons/icon-192.png",
+        sizes: "192x192",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/icons/icon-512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "any",
+      },
+      {
+        src: "/icons/icon-512.png",
+        sizes: "512x512",
+        type: "image/png",
+        purpose: "maskable",
+      },
+    ],
+  };
+}

--- a/src/components/ServiceWorkerRegister.tsx
+++ b/src/components/ServiceWorkerRegister.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Registers the app shell service worker in production only.
+ * Failures are ignored so the site keeps working without SW.
+ */
+export function ServiceWorkerRegister() {
+  useEffect(() => {
+    if (process.env.NODE_ENV !== "production") return;
+    if (!("serviceWorker" in navigator)) return;
+    navigator.serviceWorker.register("/sw.js").catch(() => {});
+  }, []);
+
+  return null;
+}


### PR DESCRIPTION
## 概要

Issue #88 のスコープに沿って PWA を実装しました。

## 変更内容

- Web App Manifest（`src/app/manifest.ts`）
- ルート `metadata`（`appleWebApp`・`icons` 等）と `viewport.themeColor`
- 本番のみ `/sw.js` 登録。/`_next/static/` と `/icons/` の GET のみキャッシュ（HTML・API は対象外）
- `CHANGELOG.md`・`README.md`（ホーム画面追加の手引き）

## バージョン

マイナー: **1.18.0**（単独コミット）

closes #88

Made with [Cursor](https://cursor.com)