### PR TITLE
docs: CONTRIBUTING の Changelog CI 記述を実態に合わせる (#126)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,4 +128,8 @@ chore: バージョンを X.Y.Z に更新
 - **`feat/` / `fix/` の PR で `package.json` のバージョンを上げる場合**（`chore: バージョンを X.Y.Z に更新` を含める場合）、**その PR がリリースするユーザー向け変更を `## [Unreleased]` から `## [X.Y.Z] - YYYY-MM-DD` に移す**。`[Unreleased]` には未リリースの予定分だけを残す（リリース済みの箇条書きを置いたままにしない）。
 - `chore/` のみの変更は必須ではない（必要に応じて更新は可）
 - `ROADMAP.md` は背景・計画・補足を扱い、リリース要点は `CHANGELOG.md` を正とする
-- CI で上記必須条件をチェックする（差分に `CHANGELOG.md` が無い対象PRは失敗）
+- **CI で自動検証しているのは次のとおり**（`.github/workflows/pr-guardrails.yml` の `require-changelog`）:
+  - `feat/`・`fix/`・`refactor/`・`docs/` の PR について、ベースブランチとの差分に **`CHANGELOG.md` が含まれること**（含まれないと CI が失敗する）
+- **次の項目は現状 CI では検証していない**。PR テンプレのチェックとレビューで確認する:
+  - `## [Unreleased]` から版付き見出し（`## [X.Y.Z] - YYYY-MM-DD`）への移し替え（リリース済みの箇条書きが Unreleased に残っていないこと）
+  - `package.json` の `version` と CHANGELOG の版付き見出しの対応


### PR DESCRIPTION
## 内容

[CONTRIBUTING.md](CONTRIBUTING.md) の「Changelog 運用」で、CI が検証する内容と検証していない内容を分けて記載した。実装は [.github/workflows/pr-guardrails.yml](.github/workflows/pr-guardrails.yml) の `require-changelog` に合わせている。

## Issue

- refs #126（本 PR でドキュメント面の合意事項を反映。CI 拡張（B）は別 PR でフォローアップ）

Made with [Cursor](https://cursor.com)