### PR TITLE
fix: ログイン／新規登録のロゴが表示されない問題を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.28.1] - 2026-04-12
+
+### Fixed
+
+- **ログイン・新規登録**: 画面上部のアイコンが表示されない場合がある問題を修正した。ロゴは `next/image` の最適化を経由せず `public` の PNG をそのまま参照し、認証用 `proxy` をミドルウェア化した際も `/icons/`・PWA 用 `sw.js`・`manifest.webmanifest` が未ログインで `/login` に飛ばされないようにした（[#134](https://github.com/kzkski/ketolog/issues/134)）。
+
 ## [Unreleased]
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.28.0",
+  "version": "1.28.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -62,6 +62,7 @@ export default function LoginPage() {
             height={72}
             className="h-[72px] w-[72px] rounded-full object-cover mb-4"
             priority
+            unoptimized
           />
           <h1 className="text-2xl font-bold text-white mb-2 text-center">Ketolog</h1>
         </div>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -61,6 +61,7 @@ export default function SignupPage() {
             height={72}
             className="h-[72px] w-[72px] rounded-full object-cover mb-4"
             priority
+            unoptimized
           />
           <h1 className="text-2xl font-bold text-white mb-2 text-center">Ketolog</h1>
         </div>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -2,6 +2,16 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 export async function proxy(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+  // 未認証でも配信が必要な静的アセット（ミドルウェア化時に /login へ飛ばさない）
+  if (
+    pathname.startsWith("/icons/") ||
+    pathname === "/sw.js" ||
+    pathname === "/manifest.webmanifest"
+  ) {
+    return NextResponse.next();
+  }
+
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(
@@ -29,7 +39,6 @@ export async function proxy(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser();
 
-  const pathname = request.nextUrl.pathname;
   const isAuthRoute = pathname.startsWith("/login") || pathname.startsWith("/signup");
 
   if (!user && !isAuthRoute) {
@@ -59,5 +68,7 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!_next/static|_next/image|favicon.ico|auth/callback).*)"],
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|auth/callback|icons/|sw\\.js|manifest\\.webmanifest).*)",
+  ],
 };


### PR DESCRIPTION
## 概要

未ログイン時、`src/proxy.ts` が Next.js 16 のミドルウェアとして動いており、`/icons/icon-192.png` へのリクエストが `/login` へリダイレクトされ、ロゴが壊れて見えていました。

## 変更内容

- `proxy` の先頭で `/icons/`・`/sw.js`・`/manifest.webmanifest` をパススルー
- ミドルウェア `matcher` から上記パスを除外（不要な Supabase 呼び出しも避ける）
- ログイン／新規登録のロゴ `Image` に `unoptimized` を付与し、`/_next/image` ではなく静的 PNG を直接参照

## バージョン

- 1.28.1（パッチ）

closes #134

Made with [Cursor](https://cursor.com)