### PR TITLE
feat: お気に入りがあるとき今日の初期タブをお気に入りにする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.29.0] - 2026-04-13
+
+### Added
+
+- **今日**: お気に入り（☆）が1件以上あるときは、開いたときのデフォルトタブを「お気に入り」にした（[#142](https://github.com/kzkski/ketolog/issues/142)）。
+
 ## [1.28.1] - 2026-04-12
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.28.2",
+  "version": "1.29.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -185,6 +185,25 @@ function firstTabRestaurantId(restaurants: Restaurant[]): string {
   return visible[0]?.id ?? "";
 }
 
+function hasFavoriteEntries(groups: FavoriteGroupPayload[]): boolean {
+  return groups.some((g) => g.entries.length > 0);
+}
+
+/** タブ並びの先頭から、お気に入りメニューが1件でもある店を探す */
+function firstRestaurantIdWithFavoriteMenu(
+  tabRestaurants: Restaurant[],
+  groups: FavoriteGroupPayload[]
+): string | undefined {
+  if (tabRestaurants.length === 0) return undefined;
+  const withFavorite = new Set<string>();
+  for (const g of groups) {
+    for (const e of g.entries) {
+      withFavorite.add(e.menu_item.restaurant_id);
+    }
+  }
+  return tabRestaurants.find((r) => withFavorite.has(r.id))?.id;
+}
+
 function pfcFromPer100(
   proteinPer100: number | null,
   fatPer100: number | null,
@@ -2546,7 +2565,9 @@ export default function TodayClient({
   const [menuItems, setMenuItems]     = useState<MenuItem[]>(initialMenuItems);
   const [favoriteGroups, setFavoriteGroups] = useState<FavoriteGroupPayload[]>(initialFavoriteGroups);
   const [selectedRestaurantId, setSelectedRestaurantId] = useState(() =>
-    firstTabRestaurantId(initialRestaurants)
+    hasFavoriteEntries(initialFavoriteGroups)
+      ? FAVORITES_TAB_ID
+      : firstTabRestaurantId(initialRestaurants)
   );
   const [cart, setCart]             = useState<Map<string, CartEntry>>(new Map());
   const [mealType, setMealType]     = useState<MealType>(initialMealType);
@@ -2673,10 +2694,19 @@ export default function TodayClient({
       return resolvedCompositionTargetId;
     }
     if (selectedRestaurantIdResolved === FAVORITES_TAB_ID) {
-      return tabRestaurants[0]?.id ?? "";
+      return (
+        firstRestaurantIdWithFavoriteMenu(tabRestaurants, favoriteGroups) ??
+        tabRestaurants[0]?.id ??
+        ""
+      );
     }
     return selectedRestaurantIdResolved;
-  }, [selectedRestaurantIdResolved, tabRestaurants, resolvedCompositionTargetId]);
+  }, [
+    selectedRestaurantIdResolved,
+    tabRestaurants,
+    resolvedCompositionTargetId,
+    favoriteGroups,
+  ]);
 
   const selectedRestaurant = restaurants.find(
     (r) => r.id === selectedRestaurantIdResolved


### PR DESCRIPTION
## 概要
お気に入り（☆）が1件以上あるユーザーでは、今日画面を開いたときのデフォルトタブを「お気に入り」にする。お気に入りが0件のときは従来どおり、並びの先頭レストランを選択する。

お気に入りタブ表示中にメニューを追加するときの紐づけ先は、☆付きメニューがある店をタブ並びで優先し、なければ先頭店とする。

## 変更ファイル
- `src/app/today/TodayClient.tsx`
- `CHANGELOG.md`（1.29.0）
- `package.json`（マイナー）

closes #142

Made with [Cursor](https://cursor.com)