### PR TITLE
fix: /today Phase 1 — サーバー冗長排除と並列化 (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.29.1] - 2026-04-13
+
+### Fixed
+
+- **今日（/today）**: サーバー側の初回表示を速くするため、同一リクエスト内の `getUser` を `react` の `cache` で 1 回にまとめ、初回データ取得とスナップショット用レストラン取得を並列化し、`public/presets` の一覧読み込みをプロセス内キャッシュした（[#145](https://github.com/kzkski/ketolog/issues/145) Phase 1）。
+
 ## [1.29.0] - 2026-04-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.29.0",
+  "version": "1.29.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/actions.ts
+++ b/src/app/today/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createClient } from "@/lib/supabase/server";
+import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import { RESTAURANT_NAME_MAX_LENGTH } from "@/lib/restaurant-limits";
 import { SNAPSHOT_RESTAURANT_NAME } from "@/lib/snapshot-restaurant";
 import type {
@@ -69,8 +70,7 @@ export async function saveMealToLog(
   mealType: string,
   date: string
 ): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { error: "認証が必要です" };
 
   const { error } = await supabase.from("food_log").insert(
@@ -100,10 +100,7 @@ export type UserSettingsPatch = {
 };
 
 export async function updateUserSettings(data: UserSettingsPatch): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { error: "認証が必要です" };
 
   if (data.diet_phase === undefined && data.phase_profiles === undefined) {
@@ -138,8 +135,7 @@ export async function getFoodLogForDate(date: string): Promise<{
   consumed: TodayConsumed;
   error: string | null;
 }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { entries: [], consumed: { protein: 0, fat: 0, carbs: 0 }, error: "認証が必要です" };
 
   const { data, error } = await supabase
@@ -186,10 +182,7 @@ export async function getFoodLogForExport(): Promise<{
   entries: FoodLogExportEntry[];
   error: string | null;
 }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { entries: [], error: "認証が必要です" };
 
   const entries: FoodLogExportEntry[] = [];
@@ -234,8 +227,7 @@ export async function getFoodLogForExport(): Promise<{
 }
 
 export async function deleteFoodLogEntry(id: string): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { error: "認証が必要です" };
 
   const { error } = await supabase
@@ -253,8 +245,7 @@ export async function updateFoodLogEntry(
   newGrams: number,
   newMealType: string
 ): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { error: "認証が必要です" };
 
   const { data: entry, error: fetchError } = await supabase
@@ -363,8 +354,7 @@ export async function lookupSharedProductByBarcode(rawBarcode: string): Promise<
   const barcode = normalizeBarcode(rawBarcode);
   if (!barcode) return { status: "error", product: null, error: "バーコードが不正です" };
 
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { status: "error", product: null, error: "認証が必要です" };
 
   const { data: cached } = await supabase
@@ -405,8 +395,7 @@ export async function addSharedProductMenuItem(input: {
   defaultGrams: number;
   rank?: number;
 }): Promise<{ data: MenuItem | null; error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: null, error: "認証が必要です" };
 
   const barcode = normalizeBarcode(input.barcode);
@@ -471,10 +460,7 @@ export async function searchStandardFoods(input: {
   limit?: number;
   offset?: number;
 }): Promise<{ rows: StandardFoodSearchRow[]; error: string | null }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { rows: [], error: "認証が必要です" };
 
   const q = input.query
@@ -546,8 +532,7 @@ export async function updateMenuItem(
   id: string,
   data: MenuItemUpdate
 ): Promise<{ data: MenuItem | null; error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: null, error: "認証が必要です" };
 
   const { data: current, error: fetchErr } = await supabase
@@ -638,10 +623,7 @@ export async function fetchFavoriteGroupsPayload(): Promise<{
   data: FavoriteGroupPayload[];
   error: string | null;
 }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: [], error: "認証が必要です" };
   return fetchFavoriteGroupsPayloadInternal(supabase, user.id);
 }
@@ -723,10 +705,7 @@ async function ensureFavoriteEntryForMenuItem(
 export async function addMenuItemToFavorites(
   menuItemId: string
 ): Promise<{ data: FavoriteGroupPayload[] | null; error: string | null }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: null, error: "認証が必要です" };
 
   const { data: mi, error: miErr } = await supabase
@@ -764,10 +743,7 @@ export async function addMenuItemToFavorites(
 export async function removeMenuItemFromFavorites(
   menuItemId: string
 ): Promise<{ data: FavoriteGroupPayload[] | null; error: string | null }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: null, error: "認証が必要です" };
 
   const { error } = await supabase.from("favorite_entries").delete().eq("menu_item_id", menuItemId);
@@ -781,8 +757,7 @@ export async function addMenuItem(
   restaurantId: string,
   data: MenuItemUpdate
 ): Promise<{ data: MenuItem | null; error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: null, error: "認証が必要です" };
 
   const groupName = data.group_name?.trim() || null;
@@ -812,8 +787,7 @@ export async function addMenuItem(
 export async function deleteMenuItem(
   id: string
 ): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { error: "認証が必要です" };
 
   const { error } = await supabase
@@ -846,8 +820,7 @@ export async function addRestaurant(
   name: string,
   category: string
 ): Promise<{ data: Restaurant | null; error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: null, error: "認証が必要です" };
 
   const displayOrder = await nextRestaurantDisplayOrder(supabase, user.id);
@@ -874,8 +847,7 @@ export async function addRestaurant(
 export async function reorderRestaurants(
   orderedRestaurantIds: string[]
 ): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { error: "認証が必要です" };
   if (orderedRestaurantIds.length === 0) return { error: null };
 
@@ -923,10 +895,7 @@ export async function getOrCreateSnapshotRestaurant(): Promise<{
   data: Restaurant | null;
   error: string | null;
 }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: null, error: "認証が必要です" };
 
   const { data: existingRows, error: selectError } = await supabase
@@ -995,8 +964,7 @@ export async function getOrCreateSnapshotRestaurant(): Promise<{
 export async function deleteRestaurant(
   id: string
 ): Promise<{ error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { error: "認証が必要です" };
 
   const { data: target } = await supabase
@@ -1027,10 +995,7 @@ export async function updateRestaurantName(
   updatedFavoriteGroupId: string | null;
   error: string | null;
 }> {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) {
     return { data: null, updatedFavoriteGroupId: null, error: "認証が必要です" };
   }
@@ -1233,8 +1198,7 @@ export async function importRestaurantData(data: ImportData): Promise<{
   newMenuItems: MenuItem[];
   error: string | null;
 }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { added: 0, skipped: [], newRestaurants: [], newMenuItems: [], error: "認証が必要です" };
 
   const { data: existing } = await supabase
@@ -1320,8 +1284,7 @@ export async function importMenuItemsToRestaurant(
   restaurantId: string,
   items: ImportRestaurantItem[]
 ): Promise<{ newMenuItems: MenuItem[]; error: string | null }> {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { newMenuItems: [], error: "認証が必要です" };
 
   const groupOrderMap = new Map<string, number>();

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -1,60 +1,45 @@
-import { createClient } from "@/lib/supabase/server";
+import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import { getMealTypeForTimeZone } from "@/lib/meal-timezone";
 import { redirect } from "next/navigation";
 import TodayClient from "./TodayClient";
 import { getOrCreateSnapshotRestaurant, fetchFavoriteGroupsPayload } from "./actions";
 import type { FoodLogEntry, MenuItem, Restaurant, UserSettings, TodayConsumed } from "@/types/database";
 import { normalizeUserSettings } from "@/lib/diet-phase";
-import fs from "fs";
-import path from "path";
+import { loadPresets } from "@/lib/presets-server";
 
-export type PresetMeta = { name: string; file: string; itemCount: number };
-
-function loadPresets(): PresetMeta[] {
-  const dir = path.join(process.cwd(), "public", "presets");
-  return fs
-    .readdirSync(dir)
-    .filter((f) => f.endsWith(".json"))
-    .map((file) => {
-      const json = JSON.parse(fs.readFileSync(path.join(dir, file), "utf-8"));
-      return { name: json.name as string, file, itemCount: (json.menuItems as unknown[]).length };
-    })
-    .sort((a, b) => a.file.localeCompare(b.file));
-}
+export type { PresetMeta } from "@/lib/presets-server";
 
 export default async function TodayPage() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) redirect("/login");
 
   const today = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
 
-  const [settingsRes, restaurantsRes, menuItemsRes, foodLogRes, favoritePayload] = await Promise.all([
-    supabase.from("user_settings").select("*").eq("user_id", user.id).maybeSingle(),
-    supabase.from("restaurants").select("*").eq("user_id", user.id),
-    supabase
-      .from("menu_items")
-      .select("*")
-      .eq("user_id", user.id)
-      .order("rank")
-      .order("order_count", { ascending: false }),
-    supabase
-      .from("food_log")
-      .select("*")
-      .eq("user_id", user.id)
-      .eq("date", today)
-      .order("created_at", { ascending: true }),
-    fetchFavoriteGroupsPayload(),
-  ]);
+  const [settingsRes, restaurantsRes, menuItemsRes, foodLogRes, favoritePayload, snapshotRestaurant] =
+    await Promise.all([
+      supabase.from("user_settings").select("*").eq("user_id", user.id).maybeSingle(),
+      supabase.from("restaurants").select("*").eq("user_id", user.id),
+      supabase
+        .from("menu_items")
+        .select("*")
+        .eq("user_id", user.id)
+        .order("rank")
+        .order("order_count", { ascending: false }),
+      supabase
+        .from("food_log")
+        .select("*")
+        .eq("user_id", user.id)
+        .eq("date", today)
+        .order("created_at", { ascending: true }),
+      fetchFavoriteGroupsPayload(),
+      getOrCreateSnapshotRestaurant(),
+    ]);
 
   const settings: UserSettings = settingsRes.data
     ? normalizeUserSettings(settingsRes.data)
     : normalizeUserSettings(null);
 
   const rawRestaurants: Restaurant[] = restaurantsRes.data ?? [];
-  const snapshotRestaurant = await getOrCreateSnapshotRestaurant();
   const rawWithSnapshot =
     snapshotRestaurant.data &&
     !rawRestaurants.some((r) => r.id === snapshotRestaurant.data!.id)

--- a/src/lib/presets-server.ts
+++ b/src/lib/presets-server.ts
@@ -1,0 +1,23 @@
+import fs from "fs";
+import path from "path";
+
+export type PresetMeta = { name: string; file: string; itemCount: number };
+
+let presetsCache: PresetMeta[] | null = null;
+
+/** `public/presets` の一覧。プロセス内で 1 回だけ読み込む。 */
+export function loadPresets(): PresetMeta[] {
+  if (presetsCache) return presetsCache;
+
+  const dir = path.join(process.cwd(), "public", "presets");
+  presetsCache = fs
+    .readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .map((file) => {
+      const json = JSON.parse(fs.readFileSync(path.join(dir, file), "utf-8"));
+      return { name: json.name as string, file, itemCount: (json.menuItems as unknown[]).length };
+    })
+    .sort((a, b) => a.file.localeCompare(b.file));
+
+  return presetsCache;
+}

--- a/src/lib/supabase/request-auth.ts
+++ b/src/lib/supabase/request-auth.ts
@@ -1,0 +1,14 @@
+import { cache } from "react";
+import { createClient } from "./server";
+
+/**
+ * 同一リクエスト内の RSC / Server Actions で `getUser()` と Supabase クライアントを重複取得しない。
+ * @see https://react.dev/reference/react/cache
+ */
+export const getSupabaseAuthForRequest = cache(async () => {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  return { supabase, user };
+});


### PR DESCRIPTION
## 概要
イシュー #145 の **Phase 1**（サーバー側の冗長排除と並列化）を実装する。

## 変更内容
- `react` の `cache` で `getSupabaseAuthForRequest` を提供し、同一リクエスト内の `getUser` / `createClient` を 1 回に集約（`/today` の page・`fetchFavoriteGroupsPayload`・`getOrCreateSnapshotRestaurant` の重複解消、および `today/actions.ts` の各 Server Action で同様に再利用）
- `getOrCreateSnapshotRestaurant` を `Promise.all` に含め、初回の DB 取得を並列化
- `loadPresets` を `src/lib/presets-server.ts` に切り出し、プロセス内モジュールキャッシュ

## バージョン
- `1.29.1`（patch）

## 関連
- Ref #145（Phase 1 のみ。Phase 2〜4 は別 PR で対応）

Phase 2 以降はイシュー記載のブランチ順（`fix/today-cls-loading` 等）で進めてください。