### PR TITLE
fix: /today Phase 2 — CLS と loading スケルトン (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.29.2] - 2026-04-13
+
+### Fixed
+
+- **今日（/today）**: デスクトップでカートを `useEffect` + `requestAnimationFrame` のあとから開いていたためレイアウトがずれていたのを、`useLayoutEffect` で初回ペイント前に開くように変えた（[#145](https://github.com/kzkski/ketolog/issues/145) Phase 2）。
+- **今日（/today）**: サーバーでデータ取得中は `loading.tsx` のスケルトンを表示するようにした（[#145](https://github.com/kzkski/ketolog/issues/145) Phase 2）。
+
 ## [1.29.1] - 2026-04-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.29.1",
+  "version": "1.29.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Image from "next/image";
-import { useState, useMemo, useRef, useId, useEffect, useCallback } from "react";
+import { useState, useMemo, useRef, useId, useEffect, useLayoutEffect, useCallback } from "react";
 import {
   DndContext,
   PointerSensor,
@@ -2573,12 +2573,13 @@ export default function TodayClient({
   const [mealType, setMealType]     = useState<MealType>(initialMealType);
   const [saving, setSaving]         = useState(false);
   const [cartExpanded, setCartExpanded] = useState(false);
-  useEffect(() => {
-    const id = requestAnimationFrame(() => {
-      const wide = window.matchMedia("(min-width: 640px)").matches;
-      if (wide) setCartExpanded(true);
-    });
-    return () => cancelAnimationFrame(id);
+  // sm 未満は折りたたみのまま。デスクトップは初回ペイント前に開く（useEffect+rAF だと描画後に伸びて CLS になる）
+  useLayoutEffect(() => {
+    if (window.matchMedia("(min-width: 640px)").matches) {
+      // 初回ペイント前にデスクトップ既定（開いたカート）を適用して CLS を防ぐ。モバイルは SSR も折りたたみのまま。
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- 上記の同期レイアウト用途のみ
+      setCartExpanded(true);
+    }
   }, []);
   const [itemDrawer, setItemDrawer] = useState<ItemDrawerState | null>(null);
   const [compositionTargetRestaurantId, setCompositionTargetRestaurantId] =

--- a/src/app/today/loading.tsx
+++ b/src/app/today/loading.tsx
@@ -1,0 +1,43 @@
+export default function TodayLoading() {
+  return (
+    <div className="flex min-h-dvh h-dvh w-full flex-col bg-gray-950">
+      <header className="flex shrink-0 items-center gap-3 border-b border-gray-800 px-3 py-2 sm:px-4">
+        <div className="h-9 w-9 shrink-0 rounded-lg bg-gray-800 animate-pulse" aria-hidden />
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="h-4 w-3/5 max-w-[200px] rounded bg-gray-800 animate-pulse" aria-hidden />
+          <div className="h-3 w-2/5 max-w-[140px] rounded bg-gray-800/80 animate-pulse" aria-hidden />
+        </div>
+        <div className="h-8 w-20 shrink-0 rounded-md bg-gray-800 animate-pulse" aria-hidden />
+      </header>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex shrink-0 gap-1 overflow-x-auto border-b border-gray-800 px-2 py-2 sm:px-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div
+              key={i}
+              className="h-9 w-20 shrink-0 rounded-lg bg-gray-800 animate-pulse"
+              aria-hidden
+            />
+          ))}
+        </div>
+
+        <div className="min-h-0 flex-1 space-y-3 overflow-hidden p-3 sm:p-4">
+          <div className="h-5 w-40 rounded bg-gray-800 animate-pulse" aria-hidden />
+          <div className="space-y-2">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div
+                key={i}
+                className="h-14 w-full rounded-lg bg-gray-800/90 animate-pulse"
+                aria-hidden
+              />
+            ))}
+          </div>
+        </div>
+
+        <div className="shrink-0 border-t border-gray-800 px-3 py-3 sm:px-4">
+          <div className="h-12 w-full rounded-lg bg-gray-800 animate-pulse" aria-hidden />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
[#145](https://github.com/kzkski/ketolog/issues/145) **Phase 2**（CLS 修正 + `loading.tsx`）。

## 変更内容
- **カート**: `useEffect` + `requestAnimationFrame` でデスクトップ幅のあとから開くのをやめ、`useLayoutEffect` で**初回ペイント前**に `(min-width: 640px)` のときだけ開く。モバイルは SSR／初回とも折りたたみのまま（`useState(true)` だけだとモバイルでオーバーレイが先に出るため採用していない）
- **`src/app/today/loading.tsx`**: サーバーデータ取得中のスケルトン（`bg-gray-950` ベースでページに近い骨組み）

## バージョン
- `1.29.2`（patch）

## 関連
- Ref #145（Phase 2 のみ。Phase 3・4 は別 PR）

Made with [Cursor](https://cursor.com)