### PR TITLE
fix: /today Phase 3 — ZXing dynamic import (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.29.3] - 2026-04-13
+
+### Fixed
+
+- **今日（/today）**: バーコード用の ZXing（`@zxing/browser` / `@zxing/library`）を静的 import せず、ネイティブ `BarcodeDetector` が使えない環境でカメラを起動したときだけ dynamic import するようにした。初回 JS の読み込み量を抑える（[#145](https://github.com/kzkski/ketolog/issues/145) Phase 3）。
+
 ## [1.29.2] - 2026-04-13
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.29.2",
+  "version": "1.29.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -60,8 +60,7 @@ import {
   type FoodLogExportEntry,
 } from "./actions";
 import type { SharedProduct } from "@/types/database";
-import { BrowserMultiFormatReader } from "@zxing/browser";
-import { BarcodeFormat, DecodeHintType } from "@zxing/library";
+import type { BarcodeFormat, DecodeHintType } from "@zxing/library";
 import {
   MACRO_BAR_BG,
   MACRO_MENU_TEXT,
@@ -659,6 +658,12 @@ function MenuItemDrawer({
         }
       } else {
         try {
+          const [{ BrowserMultiFormatReader }, { BarcodeFormat, DecodeHintType }] =
+            await Promise.all([import("@zxing/browser"), import("@zxing/library")]);
+          if (stopped) {
+            stream.getTracks().forEach((t) => t.stop());
+            return;
+          }
           const hints = new Map<DecodeHintType, BarcodeFormat[]>();
           hints.set(DecodeHintType.POSSIBLE_FORMATS, [
             BarcodeFormat.EAN_13,


### PR DESCRIPTION
## 概要
[#145](https://github.com/kzkski/ketolog/issues/145) **Phase 3**（@zxing の遅延読み込み）。

## 変更内容
- `BrowserMultiFormatReader` と `BarcodeFormat` / `DecodeHintType` の**実行時**参照を、ネイティブ `BarcodeDetector` が無い場合のフォールバック分岐内で `Promise.all([import("@zxing/browser"), import("@zxing/library")])` に変更（`cameraOn` かつカメラ起動〜スキャン開始の流れの中でのみ読み込み）
- `Map` の型用に `import type { BarcodeFormat, DecodeHintType } from "@zxing/library"` のみ残し、実行時バンドルにライブラリ本体を載せない

## バージョン
- `1.29.3`（patch）

## 関連
- Ref #145（Phase 3 のみ。Phase 4 は `fix/today-dynamic-dndkit`）

Made with [Cursor](https://cursor.com)