### PR TITLE
chore: 本番DB migration手動ワークフローを追加

### DIFF
--- a/.github/workflows/prod-db-migrate.yml
+++ b/.github/workflows/prod-db-migrate.yml
@@ -1,0 +1,71 @@
+name: Prod DB Migration (manual + backup)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Why this migration is needed"
+        required: true
+        type: string
+
+jobs:
+  migrate:
+    name: Backup and apply production migrations
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: production
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+
+      - name: Setup Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Pre-migration backup
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+        run: |
+          set -eu
+          ts="$(date -u +%Y%m%dT%H%M%SZ)"
+          pg_dump "$DATABASE_URL" --format=custom --file="pre-${ts}.dump"
+
+      - name: Upload pre-migration backup
+        uses: actions/upload-artifact@v4
+        with:
+          name: pre-migration-backup
+          path: pre-*.dump
+          retention-days: 14
+
+      - name: Link production project
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
+        run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      - name: Apply migrations
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: supabase db push
+
+      - name: Post-migration backup
+        if: success()
+        env:
+          DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
+        run: |
+          set -eu
+          ts="$(date -u +%Y%m%dT%H%M%SZ)"
+          pg_dump "$DATABASE_URL" --format=custom --file="post-${ts}.dump"
+
+      - name: Upload post-migration backup
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: post-migration-backup
+          path: post-*.dump
+          retention-days: 14


### PR DESCRIPTION
## Summary
- GitHub Actions に `workflow_dispatch` の本番DB migrationワークフローを追加
- migration 実行の前後で `pg_dump` を取得し、artifact として保存
- `environment: production` と `SUPABASE_*` / `PROD_DATABASE_URL` secrets を使う実行フローに統一

## Test plan
- [x] ワークフローファイルの構文と参照 secrets 名を確認
- [ ] PRを `main` にマージ後、Actions の `Prod DB Migration (manual + backup)` から手動実行する
- [ ] 実行成功時に pre/post backup artifact が出ることを確認する
- [ ] production Environment の Required reviewers による承認ゲートが効くことを確認する

## Notes
- この workflow は `workflow_dispatch` のため、`main` にマージされるまで Actions 一覧には表示されない。

closes #152