### PR TITLE
chore: 本番バックアップをsupabase db dumpへ切替

### DIFF
--- a/.github/workflows/prod-db-migrate.yml
+++ b/.github/workflows/prod-db-migrate.yml
@@ -19,9 +19,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup PostgreSQL client
-        run: sudo apt-get update && sudo apt-get install -y postgresql-client
-
       - name: Setup Supabase CLI
         uses: supabase/setup-cli@v1
         with:
@@ -33,13 +30,13 @@ jobs:
         run: |
           set -eu
           ts="$(date -u +%Y%m%dT%H%M%SZ)"
-          pg_dump "$DATABASE_URL" --format=custom --file="pre-${ts}.dump"
+          supabase db dump --db-url "$DATABASE_URL" -s public -f "pre-${ts}.sql"
 
       - name: Upload pre-migration backup
         uses: actions/upload-artifact@v4
         with:
           name: pre-migration-backup
-          path: pre-*.dump
+          path: pre-*.sql
           retention-days: 14
 
       - name: Link production project
@@ -60,12 +57,12 @@ jobs:
         run: |
           set -eu
           ts="$(date -u +%Y%m%dT%H%M%SZ)"
-          pg_dump "$DATABASE_URL" --format=custom --file="post-${ts}.dump"
+          supabase db dump --db-url "$DATABASE_URL" -s public -f "post-${ts}.sql"
 
       - name: Upload post-migration backup
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: post-migration-backup
-          path: post-*.dump
+          path: post-*.sql
           retention-days: 14


### PR DESCRIPTION
## Summary
- `prod-db-migrate.yml` の pre/post backup を `pg_dump` から `supabase db dump --db-url` に置換
- PostgreSQL client インストール手順を削除し、Supabase CLI のみでバックアップ実行
- artifact 拡張子を `.dump` から `.sql` に変更

## Test plan
- [x] ワークフロー差分確認（`pg_dump` 参照の除去）
- [ ] Actions で手動実行し pre/post backup が成功することを確認

closes #154

Made with [Cursor](https://cursor.com)