### PR TITLE
chore: migration workflowをNode24強制実行に変更

### DIFF
--- a/.github/workflows/prod-db-migrate.yml
+++ b/.github/workflows/prod-db-migrate.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: production
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- `Prod DB Migration (manual + backup)` workflow に `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` を追加
- JavaScript Actions を Node.js 24 で先行実行し、Node.js 20 廃止警告に対応

## Test plan
- [x] workflow 構文確認
- [ ] Actions を手動実行し、Node.js 20 deprecation 警告が出ないことを確認
- [ ] migration workflow が従来どおり成功することを確認

closes #156

Made with [Cursor](https://cursor.com)