### PR TITLE
chore: 本番migration workflowを自動起動+フルバックアップ化

### DIFF
--- a/.github/workflows/prod-db-migrate.yml
+++ b/.github/workflows/prod-db-migrate.yml
@@ -1,4 +1,4 @@
-name: Prod DB Migration (manual + backup)
+name: Prod DB Migration (auto/manual + full backup)
 
 on:
   workflow_dispatch:
@@ -7,6 +7,11 @@ on:
         description: "Why this migration is needed"
         required: true
         type: string
+  push:
+    branches:
+      - main
+    paths:
+      - "supabase/migrations/**"
 
 jobs:
   migrate:
@@ -26,19 +31,19 @@ jobs:
         with:
           version: latest
 
-      - name: Pre-migration backup
+      - name: Pre-migration full backup
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
         run: |
           set -eu
           ts="$(date -u +%Y%m%dT%H%M%SZ)"
-          supabase db dump --db-url "$DATABASE_URL" -s public -f "pre-${ts}.sql"
+          supabase db dump --db-url "$DATABASE_URL" -f "pre-full-${ts}.sql"
 
-      - name: Upload pre-migration backup
+      - name: Upload pre-migration full backup
         uses: actions/upload-artifact@v4
         with:
-          name: pre-migration-backup
-          path: pre-*.sql
+          name: pre-migration-full-backup
+          path: pre-full-*.sql
           retention-days: 14
 
       - name: Link production project
@@ -52,19 +57,19 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
         run: supabase db push
 
-      - name: Post-migration backup
+      - name: Post-migration full backup
         if: success()
         env:
           DATABASE_URL: ${{ secrets.PROD_DATABASE_URL }}
         run: |
           set -eu
           ts="$(date -u +%Y%m%dT%H%M%SZ)"
-          supabase db dump --db-url "$DATABASE_URL" -s public -f "post-${ts}.sql"
+          supabase db dump --db-url "$DATABASE_URL" -f "post-full-${ts}.sql"
 
-      - name: Upload post-migration backup
+      - name: Upload post-migration full backup
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: post-migration-backup
-          path: post-*.sql
+          name: post-migration-full-backup
+          path: post-full-*.sql
           retention-days: 14

--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ CLI が使えない場合の代替として、同じ SQL を Supabase の SQL Ed
 
 DDL の正は `supabase/migrations/` とする。[`src/types/database.ts`](src/types/database.ts) はアプリ用の行型であり、スキーマ変更時は必要に応じて型を合わせる（`supabase gen types` の利用は任意）。
 
+### 本番 DB migration workflow（GitHub Actions）
+
+本番向けの migration は `.github/workflows/prod-db-migrate.yml` で実行する。次の条件で起動する。
+
+- 手動実行: `workflow_dispatch`
+- 自動実行: `main` に `supabase/migrations/**` を含む変更が入ったとき
+
+いずれも `environment: production` で動くため、GitHub 側で Required reviewers を設定していれば承認待ちで停止できる。
+
+この workflow は migration の前後で `supabase db dump --db-url` を実行し、フル論理バックアップ（`pre-full-*.sql` / `post-full-*.sql`）を artifact として保存する（`retention-days: 14`）。
+
+ただし、artifact 保存領域は有限で保持期間にも上限がある。長期保管や災害復旧の最終保険としては、Supabase の managed backup / PITR と併用すること。
+
 開発サーバー:
 
 ```bash


### PR DESCRIPTION
## Summary
- `prod-db-migrate.yml` に `push` トリガー（`main` + `supabase/migrations/**`）を追加し、自動起動に対応
- backup を `-s public` 付きからフル論理バックアップへ変更し、pre/post artifact 名を `full` に統一
- README に本番 workflow の起動条件、承認ゲート、artifact 制約、PITR との役割分担を追記

## Implementation plan (done)
1. Issue で背景・目的・受け入れ条件を定義
2. workflow のトリガーを manual + auto に変更
3. backup 範囲を full に変更
4. 運用上の説明（制約・PITR併用）を README に明記

## Test plan
- [x] workflow 定義差分の確認（trigger / backup command / artifact 名）
- [x] README 追記内容の確認
- [ ] `main` へ migration を含む変更をマージし、自動で workflow run が作成されることを確認
- [ ] `production` Environment の承認待ちで停止することを確認
- [ ] 実行後に pre/post full backup artifact が生成されることを確認

closes #158

Made with [Cursor](https://cursor.com)