### PR TITLE
feat: /api/health でSupabase疎通を返すヘルスチェックを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
+# SUPABASE_SERVICE_ROLE_KEY=your-supabase-service-role-key
 
 # Sentry（監視）
 # NEXT_PUBLIC_SENTRY_DSN=https://<publicKey>@o<orgId>.ingest.sentry.io/<projectId>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.30.0] - 2026-04-13
+
+### Added
+
+- **監視**: `GET /api/health` を追加し、アプリ生存と Supabase 疎通（`shared_products` への軽量クエリ）を返すようにした。異常時は `503` を返し、Sentry にエラー送信する（[#170](https://github.com/kzkski/ketolog/issues/170)）。
+
 ## [1.29.7] - 2026-04-13
 
 ### Fixed

--- a/docs/release/beta-checklist.md
+++ b/docs/release/beta-checklist.md
@@ -43,6 +43,7 @@ flowchart LR
 ## 4. 運用・観測
 
 - **エラー・パフォーマンス**: Vercel のログ、必要なら Sentry 等（任意）。
+- **ヘルスチェック**: `GET /api/health` でアプリ生存 + Supabase 疎通（`shared_products` への軽量クエリ）を返せるようにする。`200` は `{ ok: true, checks: { app: \"ok\", supabase: \"ok\" }, db_latency_ms, timestamp }`、失敗時は `503` と `error`（`supabase_unavailable` / `healthcheck_misconfigured`）を返し、Sentry へ送信する。
 - **問い合わせ先**: フッターや設定に **連絡メールまたはフォーム URL**。
 - **バージョン・変更履歴**: `NEXT_PUBLIC_CHANGELOG_URL`（[README.md](../../README.md)）。ベータ向けに「既知の制限」を短く書くと期待値調整に有効。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.29.7",
+  "version": "1.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.29.7",
+      "version": "1.30.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.29.7",
+  "version": "1.30.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,96 @@
+import * as Sentry from "@sentry/nextjs";
+import { createClient } from "@supabase/supabase-js";
+import { NextResponse } from "next/server";
+
+type HealthResponse = {
+  ok: boolean;
+  checks: {
+    app: "ok";
+    supabase: "ok" | "error";
+  };
+  db_latency_ms: number;
+  timestamp: string;
+  error?: "supabase_unavailable" | "healthcheck_misconfigured";
+};
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function getTimestamp() {
+  return new Date().toISOString();
+}
+
+function getSupabaseClient() {
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error(
+      "Health check is missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY."
+    );
+  }
+
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}
+
+export async function GET() {
+  const startedAt = performance.now();
+
+  try {
+    const supabase = getSupabaseClient();
+    const { error } = await supabase
+      .from("shared_products")
+      .select("id", { head: true, count: "exact" })
+      .limit(1);
+
+    if (error) {
+      throw error;
+    }
+
+    const body: HealthResponse = {
+      ok: true,
+      checks: {
+        app: "ok",
+        supabase: "ok",
+      },
+      db_latency_ms: Math.round(performance.now() - startedAt),
+      timestamp: getTimestamp(),
+    };
+
+    return NextResponse.json(body, { status: 200 });
+  } catch (error) {
+    const message =
+      error instanceof Error && error.message.includes("missing")
+        ? "healthcheck_misconfigured"
+        : "supabase_unavailable";
+
+    Sentry.captureException(error, {
+      tags: {
+        check: "supabase",
+        route: "/api/health",
+      },
+      level: "error",
+      extra: {
+        db_latency_ms: Math.round(performance.now() - startedAt),
+      },
+    });
+
+    const body: HealthResponse = {
+      ok: false,
+      checks: {
+        app: "ok",
+        supabase: "error",
+      },
+      db_latency_ms: Math.round(performance.now() - startedAt),
+      timestamp: getTimestamp(),
+      error: message,
+    };
+
+    return NextResponse.json(body, { status: 503 });
+  }
+}


### PR DESCRIPTION
## Summary
- `GET /api/health` を追加し、アプリ生存と Supabase 疎通（`shared_products` への軽量クエリ）を返すようにしました
- 異常時は `503` を返し、Sentryに `check=supabase` タグ付きで例外送信する実装を追加しました
- 運用ドキュメントとして `docs/release/beta-checklist.md` にヘルスレスポンス仕様を追記しました
- `feat` ルールに沿って `package.json` を `1.30.0` に更新しました（単独コミット）

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

closes #170
refs #166

Made with [Cursor](https://cursor.com)