### PR TITLE
fix: VercelでSentryクライアントのreleaseを自動設定

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,12 @@ NEXT_PUBLIC_SUPABASE_ANON_KEY=your-supabase-anon-key
 # SENTRY_ORG=<org-slug>
 # SENTRY_PROJECT=<project-slug>
 # SENTRY_ENVIRONMENT=production
-# SENTRY_RELEASE=$VERCEL_GIT_COMMIT_SHA
 # NEXT_PUBLIC_APP_ENV=production
-# NEXT_PUBLIC_SENTRY_RELEASE=$VERCEL_GIT_COMMIT_SHA
+# リリース（Sentry の release）:
+# - Vercel: ビルド時の VERCEL_GIT_COMMIT_SHA が next.config 経由で NEXT_PUBLIC_SENTRY_RELEASE に入る（手入力不要）
+# - ローカル: 任意で SENTRY_RELEASE / NEXT_PUBLIC_SENTRY_RELEASE にコミットSHAや package 版を入れる
+# SENTRY_RELEASE=ecb1194...
+# NEXT_PUBLIC_SENTRY_RELEASE=ecb1194...
 
 # Optional: ヘッダーのバージョン番号クリックで開く先（例: GitHub上のCHANGELOG.md）
 # NEXT_PUBLIC_CHANGELOG_URL=https://github.com/<owner>/<repo>/blob/main/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.29.8] - 2026-04-13
+
+### Fixed
+
+- **監視（Sentry）**: Vercel 上で `NEXT_PUBLIC_SENTRY_RELEASE` を手入力しなくても、ビルド時の `VERCEL_GIT_COMMIT_SHA` がクライアント向け `release` に反映されるようにした。環境変数 UI に `$VERCEL_GIT_COMMIT_SHA` と入力しても展開されない点との齟齬を避ける。
+
 ## [1.29.7] - 2026-04-13
 
 ### Fixed

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,6 +12,11 @@ const { version } = require("./package.json") as { version: string };
 const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_APP_VERSION: version,
+    // Vercel はビルド時に VERCEL_GIT_COMMIT_SHA を渡す。ダッシュボードに
+    // `$VERCEL_GIT_COMMIT_SHA` と文字入力しても展開されないため、ここで確実に埋める。
+    ...(process.env.VERCEL_GIT_COMMIT_SHA && {
+      NEXT_PUBLIC_SENTRY_RELEASE: process.env.VERCEL_GIT_COMMIT_SHA,
+    }),
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.29.7",
+  "version": "1.29.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.29.7",
+      "version": "1.29.8",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.29.7",
+  "version": "1.29.8",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- Vercel の環境変数 UI に `$VERCEL_GIT_COMMIT_SHA` と入力しても展開されないため、ビルド時に `VERCEL_GIT_COMMIT_SHA` を `NEXT_PUBLIC_SENTRY_RELEASE` へ渡すようにした
- `.env.example` の誤解を招く記述を修正した

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

refs #166

Made with [Cursor](https://cursor.com)