### PR TITLE
fix: /api/health を認証プロキシのリダイレクト対象外にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.30.1] - 2026-04-13
+
+### Fixed
+
+- **監視**: 認証用 `proxy` ミドルウェアが `/api/health` を `/login` へリダイレクトしていたため、外形監視で 307 になる問題を修正した。`/api/health` は未ログインでも Route Handler まで到達する。
+
 ## [1.30.0] - 2026-04-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.30.0",
+      "version": "1.30.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.30.0",
+  "version": "1.30.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -12,6 +12,11 @@ export async function proxy(request: NextRequest) {
     return NextResponse.next();
   }
 
+  // 監視・外形チェック用（未認証でも 200/503 を返す）
+  if (pathname === "/api/health") {
+    return NextResponse.next();
+  }
+
   let supabaseResponse = NextResponse.next({ request });
 
   const supabase = createServerClient(


### PR DESCRIPTION
## Summary
- 認証用 `proxy` ミドルウェアが未ログインの `/api/health` を `/login` へ 307 リダイレクトしていたため、ヘルスチェックが失敗していた
- `/api/health` をミドルウェアで `NextResponse.next()` し、Route Handler まで到達させる

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

refs #170
refs #166

Made with [Cursor](https://cursor.com)