### PR TITLE
fix: /api/health の503で診断情報とSentry flush

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.30.2] - 2026-04-13
+
+### Fixed
+
+- **監視**: `/api/health` が `503` のとき PostgREST 由来の `diagnostic`（`code` / `message`）を返し、Supabase 側の失敗理由を切り分けしやすくした。Vercel サーバーレス向けに Sentry 送信後に `flush` するようにした。`head` クエリから冗長な `.limit(1)` を外した。
+
 ## [1.30.1] - 2026-04-13
 
 ### Fixed

--- a/docs/release/beta-checklist.md
+++ b/docs/release/beta-checklist.md
@@ -43,7 +43,7 @@ flowchart LR
 ## 4. 運用・観測
 
 - **エラー・パフォーマンス**: Vercel のログ、必要なら Sentry 等（任意）。
-- **ヘルスチェック**: `GET /api/health` でアプリ生存 + Supabase 疎通（`shared_products` への軽量クエリ）を返せるようにする。`200` は `{ ok: true, checks: { app: \"ok\", supabase: \"ok\" }, db_latency_ms, timestamp }`、失敗時は `503` と `error`（`supabase_unavailable` / `healthcheck_misconfigured`）を返し、Sentry へ送信する。
+- **ヘルスチェック**: `GET /api/health` でアプリ生存 + Supabase 疎通（`shared_products` への軽量クエリ）を返せるようにする。`200` は `{ ok: true, checks: { app: \"ok\", supabase: \"ok\" }, db_latency_ms, timestamp }`、失敗時は `503` と `error`（`supabase_unavailable` / `healthcheck_misconfigured`）を返し、Sentry へ送信する。`supabase_unavailable` のときは切り分け用に `diagnostic`（PostgREST の `code` / `message` 相当）を付ける場合がある。Vercel サーバーレスでは Sentry 送信後に `flush` する。
 - **問い合わせ先**: フッターや設定に **連絡メールまたはフォーム URL**。
 - **バージョン・変更履歴**: `NEXT_PUBLIC_CHANGELOG_URL`（[README.md](../../README.md)）。ベータ向けに「既知の制限」を短く書くと期待値調整に有効。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.30.1",
+      "version": "1.30.2",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.30.1",
+  "version": "1.30.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -11,6 +11,8 @@ type HealthResponse = {
   db_latency_ms: number;
   timestamp: string;
   error?: "supabase_unavailable" | "healthcheck_misconfigured";
+  /** PostgREST 等の表層メッセージ（機密は含めない想定）。503 時のみ。 */
+  diagnostic?: { code?: string; message: string };
 };
 
 export const runtime = "nodejs";
@@ -18,6 +20,22 @@ export const dynamic = "force-dynamic";
 
 function getTimestamp() {
   return new Date().toISOString();
+}
+
+function pickHttpDiagnostic(error: unknown): { code?: string; message: string } | undefined {
+  if (!error || typeof error !== "object") {
+    return undefined;
+  }
+  const o = error as Record<string, unknown>;
+  const code = typeof o.code === "string" ? o.code : undefined;
+  const message = typeof o.message === "string" ? o.message : undefined;
+  if (message) {
+    return { code, message };
+  }
+  if (error instanceof Error && error.message) {
+    return { message: error.message };
+  }
+  return undefined;
 }
 
 function getSupabaseClient() {
@@ -45,8 +63,7 @@ export async function GET() {
     const supabase = getSupabaseClient();
     const { error } = await supabase
       .from("shared_products")
-      .select("id", { head: true, count: "exact" })
-      .limit(1);
+      .select("id", { head: true, count: "exact" });
 
     if (error) {
       throw error;
@@ -77,8 +94,12 @@ export async function GET() {
       level: "error",
       extra: {
         db_latency_ms: Math.round(performance.now() - startedAt),
+        ...pickHttpDiagnostic(error),
       },
     });
+
+    // Vercel サーバーレスではプロセス終了が早く、未 flush のイベントが落ちることがある
+    await Sentry.flush(2000);
 
     const body: HealthResponse = {
       ok: false,
@@ -89,6 +110,9 @@ export async function GET() {
       db_latency_ms: Math.round(performance.now() - startedAt),
       timestamp: getTimestamp(),
       error: message,
+      ...(message === "supabase_unavailable"
+        ? { diagnostic: pickHttpDiagnostic(error) ?? { message: "unknown_error" } }
+        : {}),
     };
 
     return NextResponse.json(body, { status: 503 });


### PR DESCRIPTION
## Summary
- `503` 時に PostgREST 由来の `diagnostic`（`code` / `message`）を JSON に含め、Supabase 失敗の切り分けをしやすくした
- Vercel サーバーレスで `captureException` だけだと Sentry に届かないことがあるため、`await Sentry.flush(2000)` を追加した
- `head: true` の `select` から `.limit(1)` を外した（不要かつ一部環境で不整合の原因になりうるため）

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

refs #170
refs #166

Made with [Cursor](https://cursor.com)