### PR TITLE
fix: /api/health のdiagnostic抽出を強化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.30.3] - 2026-04-13
+
+### Fixed
+
+- **監視**: `/api/health` の `diagnostic` が `unknown_error` になるケースを減らすため、`Error` サブクラス（`PostgrestError` 等）を優先して `message` / `code` / `details` / `hint` / `cause` を抽出するようにした。
+
 ## [1.30.2] - 2026-04-13
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.30.2",
+      "version": "1.30.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -12,7 +12,12 @@ type HealthResponse = {
   timestamp: string;
   error?: "supabase_unavailable" | "healthcheck_misconfigured";
   /** PostgREST 等の表層メッセージ（機密は含めない想定）。503 時のみ。 */
-  diagnostic?: { code?: string; message: string };
+  diagnostic?: {
+    code?: string;
+    message: string;
+    details?: string;
+    hint?: string;
+  };
 };
 
 export const runtime = "nodejs";
@@ -22,20 +27,80 @@ function getTimestamp() {
   return new Date().toISOString();
 }
 
-function pickHttpDiagnostic(error: unknown): { code?: string; message: string } | undefined {
-  if (!error || typeof error !== "object") {
-    return undefined;
+function pickHttpDiagnostic(error: unknown): {
+  code?: string;
+  message: string;
+  details?: string;
+  hint?: string;
+} {
+  if (error == null) {
+    return { message: "caught_null_or_undefined" };
   }
-  const o = error as Record<string, unknown>;
-  const code = typeof o.code === "string" ? o.code : undefined;
-  const message = typeof o.message === "string" ? o.message : undefined;
-  if (message) {
-    return { code, message };
+  if (typeof error === "string") {
+    return { message: error.slice(0, 800) };
   }
-  if (error instanceof Error && error.message) {
-    return { message: error.message };
+  if (typeof error === "number" || typeof error === "boolean") {
+    return { message: String(error) };
   }
-  return undefined;
+
+  if (error instanceof Error) {
+    const code =
+      "code" in error && typeof (error as { code?: unknown }).code === "string"
+        ? (error as { code: string }).code
+        : undefined;
+    const details =
+      "details" in error && typeof (error as { details?: unknown }).details === "string"
+        ? (error as { details: string }).details
+        : undefined;
+    const hint =
+      "hint" in error && typeof (error as { hint?: unknown }).hint === "string"
+        ? (error as { hint: string }).hint
+        : undefined;
+    const base =
+      (error.message && error.message.trim()) || error.name || "Error_without_message";
+    let message = base;
+    const { cause } = error;
+    if (cause instanceof Error && cause.message) {
+      message = `${message} | cause: ${cause.message}`;
+    }
+    return {
+      code,
+      details,
+      hint,
+      message: message.slice(0, 800),
+    };
+  }
+
+  if (typeof error === "object") {
+    const o = error as Record<string, unknown>;
+    const code = typeof o.code === "string" ? o.code : undefined;
+    const details = typeof o.details === "string" ? o.details : undefined;
+    const hint = typeof o.hint === "string" ? o.hint : undefined;
+    const msg =
+      (typeof o.message === "string" && o.message) ||
+      (typeof o.error_description === "string" && o.error_description) ||
+      (typeof o.msg === "string" && o.msg);
+    if (msg) {
+      return { code, details, hint, message: msg.slice(0, 800) };
+    }
+    try {
+      const keys = Object.keys(o).slice(0, 12);
+      const brief = keys
+        .map((k) => {
+          const v = o[k];
+          if (v == null) return `${k}=null`;
+          if (typeof v === "string") return `${k}=${v.slice(0, 160)}`;
+          if (typeof v === "number" || typeof v === "boolean") return `${k}=${v}`;
+          return `${k}=${typeof v}`;
+        })
+        .join("; ");
+      return { message: brief || "empty_object" };
+    } catch {
+      return { message: Object.prototype.toString.call(error) };
+    }
+  }
+
+  return { message: String(error).slice(0, 800) };
 }
 
 function getSupabaseClient() {
@@ -111,7 +176,7 @@ export async function GET() {
       timestamp: getTimestamp(),
       error: message,
       ...(message === "supabase_unavailable"
-        ? { diagnostic: pickHttpDiagnostic(error) ?? { message: "unknown_error" } }
+        ? { diagnostic: pickHttpDiagnostic(error) }
         : {}),
     };
 


### PR DESCRIPTION
## Summary
- `pickHttpDiagnostic` が `PostgrestError` 等で `unknown_error` になるケースを減らすため、`instanceof Error` を優先し `code` / `details` / `hint` / `cause` を含めて返す
- プリミティブ・プレーンオブジェクトも最低限文字列化する

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

refs #170

Made with [Cursor](https://cursor.com)