### PR TITLE
fix: /api/health が shared_products.barcode を参照する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 フォーマットは [Keep a Changelog](https://keepachangelog.com/) を参考にしています。
 
+## [1.30.6] - 2026-04-13
+
+### Fixed
+
+- **監視**: `/api/health` が存在しない `shared_products.id` を参照して 503 になっていたのを、主キー列 `barcode` を参照するように修正した。
+
 ## [1.30.5] - 2026-04-13
 
 ### Fixed

--- a/docs/release/beta-checklist.md
+++ b/docs/release/beta-checklist.md
@@ -43,7 +43,7 @@ flowchart LR
 ## 4. 運用・観測
 
 - **エラー・パフォーマンス**: Vercel のログ、必要なら Sentry 等（任意）。
-- **ヘルスチェック**: `GET /api/health` でアプリ生存 + Supabase 疎通（`shared_products` への **`GET` で `id` を 1 件だけ取得する軽量クエリ**。PostgREST の `HEAD` は環境によって失敗しうるため使わない）を返せるようにする。`200` は `{ ok: true, checks: { app: \"ok\", supabase: \"ok\" }, db_latency_ms, timestamp }`、失敗時は `503` と `error`（`supabase_unavailable` / `healthcheck_misconfigured`）を返し、Sentry へ送信する。`supabase_unavailable` のときは切り分け用に `diagnostic`（PostgREST の `code` / `message` 相当）を付ける場合がある。Vercel サーバーレスでは Sentry 送信後に `flush` する。
+- **ヘルスチェック**: `GET /api/health` でアプリ生存 + Supabase 疎通（`shared_products` への **`GET` で主キー `barcode` を 1 件だけ取得する軽量クエリ**。同テーブルに `id` 列はない。PostgREST の `HEAD` は環境によって失敗しうるため使わない）を返せるようにする。`200` は `{ ok: true, checks: { app: \"ok\", supabase: \"ok\" }, db_latency_ms, timestamp }`、失敗時は `503` と `error`（`supabase_unavailable` / `healthcheck_misconfigured`）を返し、Sentry へ送信する。`supabase_unavailable` のときは切り分け用に `diagnostic`（PostgREST の `code` / `message` 相当）を付ける場合がある。Vercel サーバーレスでは Sentry 送信後に `flush` する。
 - **問い合わせ先**: フッターや設定に **連絡メールまたはフォーム URL**。
 - **バージョン・変更履歴**: `NEXT_PUBLIC_CHANGELOG_URL`（[README.md](../../README.md)）。ベータ向けに「既知の制限」を短く書くと期待値調整に有効。
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.30.5",
+  "version": "1.30.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.30.5",
+      "version": "1.30.6",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.30.5",
+  "version": "1.30.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -176,8 +176,8 @@ export async function GET() {
   try {
     const supabase = getSupabaseClient();
     // `head: true` は PostgREST へ HEAD になり、環境によっては失敗する（Vercel の External API ログで HEAD が赤くなる）。
-    // 軽量の GET + limit(1) で疎通だけ確認する。
-    const { error } = await supabase.from("shared_products").select("id").limit(1);
+    // `shared_products` の主キーは `barcode`（`id` 列はない）。軽量の GET + limit(1) で疎通だけ確認する。
+    const { error } = await supabase.from("shared_products").select("barcode").limit(1);
 
     if (error) {
       throw error;


### PR DESCRIPTION
## Summary
- `shared_products` に `id` 列はなく主キーは `barcode` のため、ヘルスチェックの `select` を修正した

## Test plan
- [x] `npm run lint`
- [x] `npm run build`

closes #170

Made with [Cursor](https://cursor.com)