### PR TITLE
fix: Today メニュー一覧を rank 順で安定表示（#188）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.31.1] - 2026-04-13
+
+### Fixed
+
+- **Today**: メニュー一覧を `rank`（◎〜✕）順で安定表示するようにした。`order_count` には依存せず、同ランク内は名前順などで決定的に並べる（[#188](https://github.com/kzkski/ketolog/issues/188)）。
+
 ## [1.31.0] - 2026-04-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.31.0",
+  "version": "1.31.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -20,6 +20,7 @@ import {
 import type { MealType } from "@/lib/meal-timezone";
 import { isSnapshotRestaurant } from "@/lib/snapshot-restaurant";
 import { RESTAURANT_NAME_MAX_LENGTH } from "@/lib/restaurant-limits";
+import { sortMenuItemsForListOrder } from "@/lib/menu-item-sort";
 import { createClient } from "@/lib/supabase/client";
 import {
   saveMealToLog,
@@ -2952,8 +2953,8 @@ export default function TodayClient({
         });
     }
 
-    const items = menuItems.filter(
-      (item) => item.restaurant_id === selectedRestaurantIdResolved
+    const items = sortMenuItemsForListOrder(
+      menuItems.filter((item) => item.restaurant_id === selectedRestaurantIdResolved)
     );
     const groupMap = new Map<string | null, MenuGroup>();
 
@@ -3032,8 +3033,9 @@ export default function TodayClient({
   function handleItemSaved(saved: MenuItem) {
     setMenuItems((prev) => {
       const idx = prev.findIndex((m) => m.id === saved.id);
-      if (idx >= 0) return prev.map((m) => m.id === saved.id ? saved : m);
-      return [...prev, saved]; // 追加の場合
+      const next =
+        idx >= 0 ? prev.map((m) => (m.id === saved.id ? saved : m)) : [...prev, saved];
+      return sortMenuItemsForListOrder(next);
     });
     setFavoriteGroups((prev) =>
       prev.map((g) => ({
@@ -3804,7 +3806,7 @@ export default function TodayClient({
           onClose={() => setRestaurantAddSheet(null)}
           onImported={(restaurant, items) => {
             setRestaurants((prev) => sortRestaurants([...prev, restaurant]));
-            setMenuItems((prev) => [...prev, ...items]);
+            setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
             setSelectedRestaurantId(restaurant.id);
             setRestaurantAddSheet(null);
           }}
@@ -3818,7 +3820,7 @@ export default function TodayClient({
           onClose={() => setRestaurantAddSheet(null)}
           onImported={(restaurant, items) => {
             setRestaurants((prev) => sortRestaurants([...prev, restaurant]));
-            setMenuItems((prev) => [...prev, ...items]);
+            setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
             setSelectedRestaurantId(restaurant.id);
             setRestaurantAddSheet(null);
           }}
@@ -3831,7 +3833,7 @@ export default function TodayClient({
           restaurant={selectedRestaurant}
           onClose={() => setShowImportMenuItems(false)}
           onImported={(items) => {
-            setMenuItems((prev) => [...prev, ...items]);
+            setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
             setShowImportMenuItems(false);
           }}
         />

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -24,7 +24,9 @@ export default async function TodayPage() {
         .select("*")
         .eq("user_id", user.id)
         .order("rank")
-        .order("order_count", { ascending: false }),
+        .order("name")
+        .order("created_at", { ascending: true })
+        .order("id"),
       supabase
         .from("food_log")
         .select("*")

--- a/src/lib/menu-item-sort.ts
+++ b/src/lib/menu-item-sort.ts
@@ -1,0 +1,21 @@
+import type { MenuItem } from "@/types/database";
+
+/**
+ * Today のメニュー一覧用の全順序付け。`src/app/today/page.tsx` の `menu_items` 取得
+ * `.order(...)` と同じ意味に揃える（`order_count` は使わない）。
+ *
+ * @see https://github.com/kzkski/ketolog/issues/188
+ */
+export function compareMenuItemsForListOrder(a: MenuItem, b: MenuItem): number {
+  if (a.rank !== b.rank) return a.rank - b.rank;
+  const nameCmp = a.name.localeCompare(b.name, "ja");
+  if (nameCmp !== 0) return nameCmp;
+  const ac = a.created_at ?? "";
+  const bc = b.created_at ?? "";
+  if (ac !== bc) return ac < bc ? -1 : 1;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+export function sortMenuItemsForListOrder<T extends MenuItem>(items: T[]): T[] {
+  return [...items].sort(compareMenuItemsForListOrder);
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -29,6 +29,8 @@ export type MenuItem = {
   shared_barcode?: string | null;
   /** 文科省標準成分表の食品番号（5桁） */
   standard_food_code?: string | null;
+  /** `select('*')` で付与。一覧の決定的ソート用 */
+  created_at?: string;
 };
 
 /** お気に入りエントリ（menu_items 行への参照） */


### PR DESCRIPTION
## 概要

- `menu_items` の取得から `order_count` ソートをやめ、`rank` → `name` → `created_at` → `id` で決定的に並べる（[#188](https://github.com/kzkski/ketolog/issues/188)）。
- クライアントは `sortMenuItemsForListOrder` を `menuGroups`（店舗タブ）と、追加・インポート・保存後の `menuItems` 状態更新に適用。

## バージョン

- 1.31.1（パッチ）

closes #188

Made with [Cursor](https://cursor.com)