### PR TITLE
feat: OFF未ヒット時に shared_products へ手動登録（#191）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.32.0] - 2026-04-13
+
+### Added
+
+- **Today / バーコード**: Open Food Facts にないバーコードでも、商品名と栄養を入力して保存すると `shared_products` に手動登録され（`source` は `manual_entry`、`created_by` で記録）、同じバーコードを後から読んだ利用者にもヒットしやすくなった。共有行とメニュー行はデータベースのトランザクションでまとめて追加する（[#191](https://github.com/kzkski/ketolog/issues/191)）。
+
 ## [1.31.1] - 2026-04-13
 
 ### Fixed

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,7 +78,7 @@
 ### 2-2 進行中（Phase1実装）
 - バーコード検索（Open Food Facts API）で市販品を取得
 - `shared_products` キャッシュ基盤と `menu_items.shared_barcode` 参照を導入
-- スキャン結果をメニュー追加に接続（Not Found時は手入力へフォールバック）
+- スキャン結果をメニュー追加に接続（OFF 未ヒット時は手入力で `shared_products` にも登録し他ユーザーと共有。RLS 本格は [#190](https://github.com/kzkski/ketolog/issues/190)）
 - メニュー登録なしで食事ログへ記録（スナップショット）、食事タブ行右端の記録「＋」、カートの食事区分連動
 
 ### 2-3 後日

--- a/docs/release/beta-checklist.md
+++ b/docs/release/beta-checklist.md
@@ -8,7 +8,7 @@
 - **認証 UI**: メール／パスワードと Google OAuth は既に [`signup`](../../src/app/signup/page.tsx) / [`login`](../../src/app/login/page.tsx) にある。実際に誰が入れるかは **Supabase 側のプロバイダ設定** と **アプリ側の追加チェック** の組み合わせ。
 - **データ削除**: `auth.users` 削除時にユーザー行は `ON DELETE CASCADE`（[`supabase/migrations/20260211120000_baseline.sql`](../../supabase/migrations/20260211120000_baseline.sql)）。**アプリから Auth ユーザーを削除するフローは別途 GA 向けに [general-availability-checklist.md](general-availability-checklist.md) を参照**。
 - **エクスポート**: 設定から全データ JSON ダウンロードあり（[`TodayClient.tsx`](../../src/app/today/TodayClient.tsx) 設定ドロワー）。持ち出しは可能だが「アカウント削除」とは別。
-- **共有キャッシュ**: `shared_products` の RLS は認証ユーザーがキャッシュ書き込み可能。利用者増に伴う論点は [general-availability-checklist.md](general-availability-checklist.md) と [Issue #2](https://github.com/kzkski/ketolog/issues/2)。
+- **共有キャッシュ**: `shared_products` の RLS は認証ユーザーがキャッシュ書き込み可能。OFF 未ヒット時の手動登録（[#191](https://github.com/kzkski/ketolog/issues/191)）を除き、**書き込みポリシー本格の見直しは [Issue #190](https://github.com/kzkski/ketolog/issues/190)**。利用者増に伴う論点は [general-availability-checklist.md](general-availability-checklist.md) と [Issue #2](https://github.com/kzkski/ketolog/issues/2)。
 
 ```mermaid
 flowchart LR

--- a/docs/release/general-availability-checklist.md
+++ b/docs/release/general-availability-checklist.md
@@ -14,7 +14,7 @@
 ## 2. 濫用・セキュリティ（実装＋設定）
 
 - **サインアップ濫用対策**: Supabase の **CAPTCHA**、**レート制限**、必要なら招待制の維持。
-- **`shared_products`**: 書き込みポリシーの見直し（サーバー経由のみ、不正バーコードの抑制、監査ログ）。関連: [Issue #2](https://github.com/kzkski/ketolog/issues/2)。
+- **`shared_products`**: 書き込みポリシーの見直し（サーバー経由のみ、不正バーコードの抑制、監査ログ）。**RLS の全面収斂・登録レート制限などの本格対応は [Issue #190](https://github.com/kzkski/ketolog/issues/190) で追う**（[#191](https://github.com/kzkski/ketolog/issues/191) で手動登録は RPC トランザクションと `created_by` により監査しやすくした）。関連: [Issue #2](https://github.com/kzkski/ketolog/issues/2)。
 - **RLS・権限の再監査**: `GRANT ... TO anon` 等が本番で必要な範囲か確認。
 - **シークレット管理**: 本番キーのローテーション、Vercel / ローカルの権限。
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.31.1",
+  "version": "1.32.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -26,6 +26,7 @@ import {
   saveMealToLog,
   updateMenuItem,
   addMenuItem,
+  addMenuItemWithManualSharedProduct,
   deleteMenuItem,
   addMenuItemToFavorites,
   removeMenuItemFromFavorites,
@@ -509,6 +510,8 @@ function MenuItemDrawer({
   const [scanLoading, setScanLoading] = useState(false);
   const [cameraOn, setCameraOn] = useState(false);
   const [cameraResult, setCameraResult] = useState<SharedProduct | null>(null);
+  /** OFF 未ヒット後に保存すると RPC で shared_products へ載せる（Issue #191） */
+  const [manualSharedProductPending, setManualSharedProductPending] = useState(false);
   const [lastLookup, setLastLookup] = useState<{ barcode: string; at: number } | null>(null);
   const [servingHint, setServingHint] = useState<string | null>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
@@ -553,10 +556,24 @@ function MenuItemDrawer({
     setLastLookup({ barcode: normalized, at: Date.now() });
     const res = await lookupSharedProductByBarcode(normalized);
     setScanLoading(false);
-    if (res.status === "error" || !res.product) {
-      setScanError(res.error ?? "OFFで商品が見つかりませんでした");
+    if (res.status === "error") {
+      setManualSharedProductPending(false);
+      setScanError(res.error ?? "バーコードの照会に失敗しました");
       return;
     }
+    if (res.status === "not_found" || !res.product) {
+      setCameraResult(null);
+      setServingHint(null);
+      setSharedBarcode(normalized);
+      setStandardFoodCode(null);
+      setManualSharedProductPending(true);
+      setScanError(
+        "Open Food Facts にこのバーコードはありませんでした。商品名と栄養を入力して保存すると、アプリ内で共有されます（写真は不要です）。"
+      );
+      return;
+    }
+    setManualSharedProductPending(false);
+    setScanError(null);
     setCameraResult(res.product);
     setSharedBarcode(res.product.barcode);
     setStandardFoodCode(null);
@@ -807,7 +824,10 @@ function MenuItemDrawer({
         return;
       }
       const restaurantId = state.kind === "add" ? state.restaurantId : "";
-      const result = await addMenuItem(restaurantId, data);
+      const result =
+        manualSharedProductPending && sharedBarcode
+          ? await addMenuItemWithManualSharedProduct(restaurantId, sharedBarcode, data)
+          : await addMenuItem(restaurantId, data);
       if (result.error || !result.data) { setError(result.error ?? "追加に失敗しました"); setSaving(false); return; }
       onSaved(result.data);
     }
@@ -942,6 +962,11 @@ function MenuItemDrawer({
                 </p>
               )}
               {scanError && <p className="text-xs text-amber-300">{scanError}</p>}
+              {manualSharedProductPending && sharedBarcode && (
+                <p className="text-xs text-emerald-300/90">
+                  共有に使うバーコード: <span className="font-mono">{sharedBarcode}</span>
+                </p>
+              )}
               {servingHint && <p className="text-xs text-amber-300">{servingHint}</p>}
               <p className="text-[11px] text-gray-500">
                 Data source: Open Food Facts (ODbL)

--- a/src/app/today/actions.ts
+++ b/src/app/today/actions.ts
@@ -20,6 +20,11 @@ import {
   type PhaseProfiles,
 } from "@/lib/diet-phase";
 import { STANDARD_FOOD_SEARCH_PAGE_SIZE } from "@/lib/standard-food-search";
+import {
+  MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES,
+  SHARED_PRODUCT_SOURCE_MANUAL_ENTRY,
+  SHARED_PRODUCT_SOURCE_OPEN_FOOD_FACTS,
+} from "@/lib/shared-product-source";
 
 export type SaveItem = {
   menuItemId: string | null;
@@ -341,6 +346,7 @@ async function upsertSharedProduct(
       carbs_per_100g: product.carbs_per_100g,
       serving_size: product.serving_size,
       serving_size_grams: product.serving_size_grams,
+      source: SHARED_PRODUCT_SOURCE_OPEN_FOOD_FACTS,
       last_checked_at: new Date().toISOString(),
       updated_at: new Date().toISOString(),
       raw_json: product,
@@ -359,13 +365,19 @@ export async function lookupSharedProductByBarcode(rawBarcode: string): Promise<
 
   const { data: cached } = await supabase
     .from("shared_products")
-    .select("barcode, product_name, brand, protein_per_100g, fat_per_100g, carbs_per_100g, serving_size, serving_size_grams, last_checked_at")
+    .select(
+      "barcode, product_name, brand, protein_per_100g, fat_per_100g, carbs_per_100g, serving_size, serving_size_grams, last_checked_at, source"
+    )
     .eq("barcode", barcode)
     .maybeSingle();
 
   if (cached) {
+    const source =
+      cached.source === SHARED_PRODUCT_SOURCE_MANUAL_ENTRY
+        ? SHARED_PRODUCT_SOURCE_MANUAL_ENTRY
+        : SHARED_PRODUCT_SOURCE_OPEN_FOOD_FACTS;
     const stale = Date.now() - new Date(cached.last_checked_at).getTime() > SHARED_PRODUCT_TTL_MS;
-    if (stale) {
+    if (stale && source === SHARED_PRODUCT_SOURCE_OPEN_FOOD_FACTS) {
       void (async () => {
         const refreshed = await fetchOffProduct(barcode);
         if (refreshed) {
@@ -373,7 +385,7 @@ export async function lookupSharedProductByBarcode(rawBarcode: string): Promise<
         }
       })();
     }
-    return { status: "ok", product: cached as SharedProduct, error: null };
+    return { status: "ok", product: { ...cached, source } as SharedProduct, error: null };
   }
 
   try {
@@ -438,6 +450,93 @@ export async function addSharedProductMenuItem(input: {
 
   if (insert.error) return { data: null, error: insert.error.message };
   return { data: insert.data as MenuItem, error: null };
+}
+
+/**
+ * OFF 未ヒットのバーコードを手入力で登録するとき、`shared_products` と `menu_items` を
+ * DB トランザクション（RPC）でまとめて追加する（Issue #191）。
+ */
+export async function addMenuItemWithManualSharedProduct(
+  restaurantId: string,
+  barcodeRaw: string,
+  data: MenuItemUpdate
+): Promise<{ data: MenuItem | null; error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { data: null, error: "認証が必要です" };
+
+  const barcode = normalizeBarcode(barcodeRaw);
+  if (!barcode) return { data: null, error: "バーコードが不正です" };
+
+  const trimmedName = data.name.trim();
+  if (!trimmedName) return { data: null, error: "名前を入力してください" };
+
+  if (data.standard_food_code) {
+    return { data: null, error: "標準成分表とバーコードの同時指定はできません" };
+  }
+
+  const rank = data.rank;
+  if (!Number.isFinite(rank) || rank < 1 || rank > 4) {
+    return { data: null, error: "ランクの値が不正です" };
+  }
+
+  const groupName = data.group_name?.trim() || null;
+  const groupOrder = await resolveMenuItemGroupOrder(
+    supabase,
+    user.id,
+    restaurantId,
+    groupName
+  );
+
+  const notes = data.notes?.trim() || MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES;
+
+  const { data: menuId, error: rpcError } = await supabase.rpc(
+    "add_menu_item_with_manual_shared_product",
+    {
+      p_restaurant_id: restaurantId,
+      p_barcode: barcode,
+      p_shared_product_name: trimmedName,
+      p_shared_brand: null,
+      p_shared_protein: data.protein_per_100g,
+      p_shared_fat: data.fat_per_100g,
+      p_shared_carbs: data.carbs_per_100g,
+      p_shared_serving_size: null,
+      p_shared_serving_size_grams: null,
+      p_menu_name: trimmedName,
+      p_menu_protein: data.protein_per_100g,
+      p_menu_fat: data.fat_per_100g,
+      p_menu_carbs: data.carbs_per_100g,
+      p_default_grams: data.default_grams,
+      p_rank: rank,
+      p_notes: notes,
+      p_group_name: groupName,
+      p_group_order: groupOrder,
+    }
+  );
+
+  if (rpcError) {
+    const msg = rpcError.message ?? "";
+    if (msg.includes("menu_item_barcode_exists")) {
+      return { data: null, error: "このお店に同じバーコードのメニューがあります" };
+    }
+    if (msg.includes("restaurant not found")) {
+      return { data: null, error: "お店が見つかりません" };
+    }
+    return { data: null, error: msg };
+  }
+
+  if (!menuId) return { data: null, error: "メニューの追加に失敗しました" };
+
+  const { data: row, error: fetchErr } = await supabase
+    .from("menu_items")
+    .select("*")
+    .eq("id", menuId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (fetchErr || !row) {
+    return { data: null, error: fetchErr?.message ?? "メニューの取得に失敗しました" };
+  }
+  return { data: row as MenuItem, error: null };
 }
 
 // ─── 文科省標準成分表（standard_food_items）────────────────────────────────────

--- a/src/lib/shared-product-source.ts
+++ b/src/lib/shared-product-source.ts
@@ -1,0 +1,11 @@
+/** `shared_products.source` — 英語スネークケース（Issue #191）。マジックストリング禁止用。 */
+export const SHARED_PRODUCT_SOURCE_OPEN_FOOD_FACTS = "open_food_facts" as const;
+export const SHARED_PRODUCT_SOURCE_MANUAL_ENTRY = "manual_entry" as const;
+
+export type SharedProductSource =
+  | typeof SHARED_PRODUCT_SOURCE_OPEN_FOOD_FACTS
+  | typeof SHARED_PRODUCT_SOURCE_MANUAL_ENTRY;
+
+/** メニュー `notes` 初期値（OFF 由来でないことが利用者に伝わる文言）。 */
+export const MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES =
+  "アプリ内の手入力（Open Food Facts 未登録。他の利用者と共有されます）";

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -60,6 +60,8 @@ export type SharedProduct = {
   serving_size: string | null;
   serving_size_grams: number | null;
   last_checked_at: string;
+  /** `shared_products.source`（lookup の SELECT に含むときのみ） */
+  source?: string | null;
 };
 
 export type TodayConsumed = {

--- a/supabase/migrations/20260417120000_shared_products_manual_entry_rpc.sql
+++ b/supabase/migrations/20260417120000_shared_products_manual_entry_rpc.sql
@@ -1,0 +1,145 @@
+-- Issue #191: manual shared_products row + menu_items insert in one transaction (RPC).
+-- Adds audit column created_by; user-registered rows use source = manual_entry.
+
+ALTER TABLE public.shared_products
+  ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES auth.users (id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN public.shared_products.created_by IS
+  '初回 INSERT 時の登録ユーザー（手動登録行）。OFF 由来の行は NULL のまま。';
+
+CREATE OR REPLACE FUNCTION public.add_menu_item_with_manual_shared_product(
+  p_restaurant_id uuid,
+  p_barcode text,
+  p_shared_product_name text,
+  p_shared_brand text,
+  p_shared_protein numeric,
+  p_shared_fat numeric,
+  p_shared_carbs numeric,
+  p_shared_serving_size text,
+  p_shared_serving_size_grams numeric,
+  p_menu_name text,
+  p_menu_protein numeric,
+  p_menu_fat numeric,
+  p_menu_carbs numeric,
+  p_default_grams numeric,
+  p_rank smallint,
+  p_notes text,
+  p_group_name text,
+  p_group_order integer
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_menu_id uuid;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'add_menu_item_manual_shared: not authenticated';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.restaurants r
+    WHERE r.id = p_restaurant_id AND r.user_id = v_uid
+  ) THEN
+    RAISE EXCEPTION 'add_menu_item_manual_shared: restaurant not found';
+  END IF;
+
+  IF p_barcode IS NULL OR btrim(p_barcode) = '' THEN
+    RAISE EXCEPTION 'add_menu_item_manual_shared: invalid barcode';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.menu_items mi
+    WHERE mi.user_id = v_uid
+      AND mi.restaurant_id = p_restaurant_id
+      AND mi.shared_barcode = btrim(p_barcode)
+  ) THEN
+    RAISE EXCEPTION 'add_menu_item_manual_shared: menu_item_barcode_exists';
+  END IF;
+
+  INSERT INTO public.shared_products (
+    barcode,
+    product_name,
+    brand,
+    protein_per_100g,
+    fat_per_100g,
+    carbs_per_100g,
+    serving_size,
+    serving_size_grams,
+    source,
+    raw_json,
+    last_checked_at,
+    created_by,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    btrim(p_barcode),
+    p_shared_product_name,
+    NULLIF(btrim(COALESCE(p_shared_brand, '')), ''),
+    p_shared_protein,
+    p_shared_fat,
+    p_shared_carbs,
+    NULLIF(btrim(COALESCE(p_shared_serving_size, '')), ''),
+    p_shared_serving_size_grams,
+    'manual_entry',
+    NULL,
+    now(),
+    v_uid,
+    now(),
+    now()
+  )
+  ON CONFLICT (barcode) DO NOTHING;
+
+  INSERT INTO public.menu_items (
+    user_id,
+    restaurant_id,
+    name,
+    protein_per_100g,
+    fat_per_100g,
+    carbs_per_100g,
+    default_grams,
+    order_count,
+    rank,
+    notes,
+    group_name,
+    group_order,
+    shared_barcode,
+    standard_food_code
+  )
+  VALUES (
+    v_uid,
+    p_restaurant_id,
+    p_menu_name,
+    p_menu_protein,
+    p_menu_fat,
+    p_menu_carbs,
+    p_default_grams,
+    0,
+    p_rank,
+    p_notes,
+    NULLIF(btrim(COALESCE(p_group_name, '')), ''),
+    p_group_order,
+    btrim(p_barcode),
+    NULL
+  )
+  RETURNING id INTO v_menu_id;
+
+  RETURN v_menu_id;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.add_menu_item_with_manual_shared_product IS
+  'Issue #191: OFF 未ヒットの手動登録で shared_products（初回のみ）と menu_items を同一トランザクションで追加。';
+
+REVOKE ALL ON FUNCTION public.add_menu_item_with_manual_shared_product(
+  uuid, text, text, text, numeric, numeric, numeric, text, numeric,
+  text, numeric, numeric, numeric, numeric, smallint, text, text, integer
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.add_menu_item_with_manual_shared_product(
+  uuid, text, text, text, numeric, numeric, numeric, text, numeric,
+  text, numeric, numeric, numeric, numeric, smallint, text, text, integer
+) TO authenticated;


### PR DESCRIPTION
## 概要

Open Food Facts にないバーコードでも、手入力で保存すると `shared_products`（`source=manual_entry`, `created_by`）と `menu_items` を同一トランザクション（RPC）で追加する。

## 変更要点

- マイグレーション: `created_by` 列 + `add_menu_item_with_manual_shared_product` RPC
- Today: スキャン not_found 時の案内・保存動線、`manual_entry` 行は OFF の TTL バックグラウンド更新対象外
- ドキュメント（GA/beta/ROADMAP）、CHANGELOG 1.32.0

closes #191

Made with [Cursor](https://cursor.com)