### PR TITLE
fix: manual_entry のメニューノート初期値を長文で統一

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.32.1] - 2026-04-14
+
+### Fixed
+
+- **Today / バーコード**: 手動共有（`manual_entry`）の商品を後からバーコードで読んだときも、メモ欄の初期文言を「OFF連携」ではなく手動共有の説明文に統一した（[#194](https://github.com/kzkski/ketolog/issues/194)）。
+
 ## [1.32.0] - 2026-04-13
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.32.0",
+  "version": "1.32.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -48,6 +48,10 @@ import {
   type FoodLogExportEntry,
 } from "./actions";
 import type { SharedProduct } from "@/types/database";
+import {
+  MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES,
+  SHARED_PRODUCT_SOURCE_MANUAL_ENTRY,
+} from "@/lib/shared-product-source";
 import type { BarcodeFormat, DecodeHintType } from "@zxing/library";
 import {
   MACRO_BAR_BG,
@@ -590,7 +594,11 @@ function MenuItemDrawer({
       setServingHint(null);
     }
     if (!notes.trim()) {
-      setNotes(res.product.brand ? `OFF: ${res.product.brand}` : "OFF連携");
+      if (res.product.source === SHARED_PRODUCT_SOURCE_MANUAL_ENTRY) {
+        setNotes(MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES);
+      } else {
+        setNotes(res.product.brand ? `OFF: ${res.product.brand}` : "OFF連携");
+      }
     }
   }, [lastLookup, notes]);
 

--- a/src/app/today/actions.ts
+++ b/src/app/today/actions.ts
@@ -439,7 +439,12 @@ export async function addSharedProductMenuItem(input: {
       carbs_per_100g: lookup.product.carbs_per_100g,
       default_grams: input.defaultGrams > 0 ? input.defaultGrams : 100,
       rank: input.rank ?? 2,
-      notes: lookup.product.brand ? `OFF: ${lookup.product.brand}` : "OFF連携",
+      notes:
+        lookup.product.source === SHARED_PRODUCT_SOURCE_MANUAL_ENTRY
+          ? MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES
+          : lookup.product.brand
+            ? `OFF: ${lookup.product.brand}`
+            : "OFF連携",
       group_name: null,
       group_order: 0,
       shared_barcode: barcode,


### PR DESCRIPTION
## 概要
手動共有（`manual_entry`）のバーコードを後から読んだとき、空のメモ欄に「OFF連携」が入らず、初回手動登録時と同じ `MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES` に揃える。

## 変更
- `TodayClient.tsx` の `handleLookupBarcode`: `source === manual_entry` のとき長文をセット
- `addSharedProductMenuItem`: 同条件で同じノート文言（将来の呼び出しとも整合）

closes #194

Made with [Cursor](https://cursor.com)