### PR TITLE
feat: メニュー共有QR（編集ドロワー）とカメラ転記（メニュー追加）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.34.2] - 2026-04-14
+
+### Fixed
+
+- **Today / メニュー**: QR でメニューを取り込んだあと「メニューを追加」ドロワーがすぐ閉じないようにした。取り込み成功メッセージをドロワー内に表示し、カメラは停止したままにする（[#198](https://github.com/kzkski/ketolog/issues/198)）。
+
 ## [1.34.1] - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.34.3] - 2026-04-14
+
+### Fixed
+
+- **Today / メニュー**: メニュー共有 QR を読んだとき、サーバーへ即保存せず **追加フォームに名前・PFC・量・ランク・メモなどを転記**するようにした。確定は「メニューに登録」「カートへ」「今すぐ食事ログに記録」と同じ流れで行う（[#198](https://github.com/kzkski/ketolog/issues/198)）。
+
 ## [1.34.2] - 2026-04-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.34.1] - 2026-04-14
+
+### Fixed
+
+- **Today / メニュー**: QR で取り込んだメニューが一覧に出ないことがあった問題を修正した。取り込み先のお店タブへ自動で切り替える（お気に入り表示中など、追加先と表示タブがずれていたのが原因）（[#198](https://github.com/kzkski/ketolog/issues/198)）。
+
 ## [1.34.0] - 2026-04-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.34.0] - 2026-04-14
+
+### Added
+
+- **Today / メニュー**: メニュー編集ドロワーから QR で共有（PNG 保存・画像コピー）。「メニューを追加」のカメラで共有 QR を読み取ると、選択中のお店に 1 件インポート。ペイロードはクライアント内 JSON（`v` / `kind` で将来拡張可能）。データが大きすぎて QR を生成できない場合は理由を表示。ネイティブ `BarcodeDetector` は QR を含む形式を指定、ZXing フォールバックは `QR_CODE` を追加（[#198](https://github.com/kzkski/ketolog/issues/198)）。
+
 ## [1.33.0] - 2026-04-13
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.30.6",
+  "version": "1.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.30.6",
+      "version": "1.33.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -19,6 +19,7 @@
         "@zxing/browser": "^0.1.5",
         "@zxing/library": "^0.21.3",
         "next": "16.2.3",
+        "qrcode": "^1.5.4",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
@@ -26,6 +27,7 @@
         "@next/bundle-analyzer": "^16.2.3",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
+        "@types/qrcode": "^1.5.6",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
@@ -3393,6 +3395,16 @@
         "@types/pg": "*"
       }
     },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
@@ -4420,11 +4432,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4826,6 +4846,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001787",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
@@ -4909,6 +4938,17 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/cmd-shim": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
@@ -4933,7 +4973,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4946,7 +4985,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/commander": {
@@ -5121,6 +5159,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5173,6 +5220,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -6157,6 +6210,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -6754,6 +6816,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -8071,6 +8142,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8183,6 +8263,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -8320,6 +8409,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -8423,6 +8529,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
@@ -8445,6 +8560,12 @@
       "engines": {
         "node": ">=9.3.0 || >=8.10.0 <9.0.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -8695,6 +8816,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -9006,6 +9133,26 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -9117,6 +9264,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-bom": {
@@ -9942,6 +10101,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -9992,6 +10157,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/write-file-atomic": {
@@ -10059,11 +10238,104 @@
         "node": ">=0.4"
       }
     },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/yargs/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yargs/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.34.2",
+  "version": "1.34.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.34.1",
+  "version": "1.34.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.33.0",
+  "version": "1.34.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@zxing/browser": "^0.1.5",
     "@zxing/library": "^0.21.3",
     "next": "16.2.3",
+    "qrcode": "^1.5.4",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },
@@ -31,6 +32,7 @@
     "@next/bundle-analyzer": "^16.2.3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
+    "@types/qrcode": "^1.5.6",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1,7 +1,15 @@
 "use client";
 
 import Image from "next/image";
-import { useState, useMemo, useRef, useId, useEffect, useLayoutEffect, useCallback } from "react";
+import {
+  useState,
+  useMemo,
+  useRef,
+  useId,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+} from "react";
 import { type DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import type {
@@ -64,6 +72,7 @@ import { STANDARD_FOOD_TAB_TITLE } from "@/lib/standard-food-groups";
 import { StandardFoodPanel } from "./StandardFoodPanel";
 import { MenuGroupCollapseSession } from "./MenuGroupCollapseSession";
 import { RestaurantTabsLazy } from "./RestaurantTabsLazy";
+import { buildMenuQrPayloadJson, parseMenuSharePayload } from "@/lib/menu-qr-payload";
 
 // ─── 型 ────────────────────────────────────────────────────────────────────────
 
@@ -455,6 +464,7 @@ function MenuItemDrawer({
   canRegisterMenu,
   registerDisabledReason,
   onOpenStandardFoodSearch,
+  onMenuItemsQrImported,
 }: {
   state: ItemDrawerState;
   existingGroupNames: string[];
@@ -483,6 +493,8 @@ function MenuItemDrawer({
   registerTargetRestaurantId: string;
   onRegisterTargetChange: (restaurantId: string) => void;
   onOpenStandardFoodSearch?: () => void;
+  /** QR 取り込み成功時（メニュー追加ドロワーでカメラから読んだとき） */
+  onMenuItemsQrImported?: (items: MenuItem[]) => void;
 }) {
   const MEMO_MIN_ROWS = 3;
   const MEMO_MAX_ROWS = 10;
@@ -538,6 +550,9 @@ function MenuItemDrawer({
   const [manualSharedProductPending, setManualSharedProductPending] = useState(false);
   const [lastLookup, setLastLookup] = useState<{ barcode: string; at: number } | null>(null);
   const [servingHint, setServingHint] = useState<string | null>(null);
+  const [shareQrDataUrl, setShareQrDataUrl] = useState<string | null>(null);
+  const [shareQrError, setShareQrError] = useState<string | null>(null);
+  const [shareToast, setShareToast] = useState<{ tone: "ok" | "err"; msg: string } | null>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const groupNameInputRef = useRef<HTMLInputElement>(null);
@@ -567,60 +582,206 @@ function MenuItemDrawer({
     if (field === "c") { setCarbs(stored);   setRawC(null); }
   }
 
-  const handleLookupBarcode = useCallback(async (rawBarcode: string) => {
-    const normalized = rawBarcode.replace(/[^\d]/g, "");
-    if (!normalized) {
-      setScanError("バーコードを読み取れませんでした。もう一度お試しください。");
-      return;
-    }
-    if (lastLookup?.barcode === normalized && Date.now() - lastLookup.at < 3000) return;
-
-    setScanLoading(true);
-    setScanError(null);
-    setLastLookup({ barcode: normalized, at: Date.now() });
-    const res = await lookupSharedProductByBarcode(normalized);
-    setScanLoading(false);
-    if (res.status === "error") {
-      setManualSharedProductPending(false);
-      setScanError(res.error ?? "バーコードの照会に失敗しました");
-      return;
-    }
-    if (res.status === "not_found" || !res.product) {
-      setCameraResult(null);
-      setServingHint(null);
-      setSharedBarcode(normalized);
-      setStandardFoodCode(null);
-      setManualSharedProductPending(true);
-      setScanError(
-        "Open Food Facts にこのバーコードはありませんでした。商品名と栄養を入力して保存すると、アプリ内で共有されます（写真は不要です）。"
-      );
-      return;
-    }
-    setManualSharedProductPending(false);
-    setScanError(null);
-    setCameraResult(res.product);
-    setSharedBarcode(res.product.barcode);
-    setStandardFoodCode(null);
-    setName(res.product.product_name);
-    setProtein(res.product.protein_per_100g?.toString() ?? "");
-    setFat(res.product.fat_per_100g?.toString() ?? "");
-    setCarbs(res.product.carbs_per_100g?.toString() ?? "");
-    if (res.product.serving_size_grams && res.product.serving_size_grams > 0) {
-      setGrams(res.product.serving_size_grams.toString());
-      setServingHint(`OFFの serving_size (${res.product.serving_size}) を1回量に仮入力しました。ラベルで必ず確認してください。`);
-    } else if (res.product.serving_size) {
-      setServingHint(`OFFの serving_size (${res.product.serving_size}) を取得しました。1回量(g)を手動で確認してください。`);
-    } else {
-      setServingHint(null);
-    }
-    if (!notes.trim()) {
-      if (res.product.source === SHARED_PRODUCT_SOURCE_MANUAL_ENTRY) {
-        setNotes(MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES);
-      } else {
-        setNotes(res.product.brand ? `OFF: ${res.product.brand}` : "OFF連携");
+  const lookupOffProductBarcode = useCallback(
+    async (rawBarcode: string) => {
+      const normalized = rawBarcode.replace(/[^\d]/g, "");
+      if (!normalized) {
+        setScanError("バーコードを読み取れませんでした。もう一度お試しください。");
+        return;
       }
+      if (lastLookup?.barcode === normalized && Date.now() - lastLookup.at < 3000) return;
+
+      setScanLoading(true);
+      setScanError(null);
+      setLastLookup({ barcode: normalized, at: Date.now() });
+      const res = await lookupSharedProductByBarcode(normalized);
+      setScanLoading(false);
+      if (res.status === "error") {
+        setManualSharedProductPending(false);
+        setScanError(res.error ?? "バーコードの照会に失敗しました");
+        return;
+      }
+      if (res.status === "not_found" || !res.product) {
+        setCameraResult(null);
+        setServingHint(null);
+        setSharedBarcode(normalized);
+        setStandardFoodCode(null);
+        setManualSharedProductPending(true);
+        setScanError(
+          "Open Food Facts にこのバーコードはありませんでした。商品名と栄養を入力して保存すると、アプリ内で共有されます（写真は不要です）。"
+        );
+        return;
+      }
+      setManualSharedProductPending(false);
+      setScanError(null);
+      setCameraResult(res.product);
+      setSharedBarcode(res.product.barcode);
+      setStandardFoodCode(null);
+      setName(res.product.product_name);
+      setProtein(res.product.protein_per_100g?.toString() ?? "");
+      setFat(res.product.fat_per_100g?.toString() ?? "");
+      setCarbs(res.product.carbs_per_100g?.toString() ?? "");
+      if (res.product.serving_size_grams && res.product.serving_size_grams > 0) {
+        setGrams(res.product.serving_size_grams.toString());
+        setServingHint(
+          `OFFの serving_size (${res.product.serving_size}) を1回量に仮入力しました。ラベルで必ず確認してください。`
+        );
+      } else if (res.product.serving_size) {
+        setServingHint(
+          `OFFの serving_size (${res.product.serving_size}) を取得しました。1回量(g)を手動で確認してください。`
+        );
+      } else {
+        setServingHint(null);
+      }
+      if (!notes.trim()) {
+        if (res.product.source === SHARED_PRODUCT_SOURCE_MANUAL_ENTRY) {
+          setNotes(MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES);
+        } else {
+          setNotes(res.product.brand ? `OFF: ${res.product.brand}` : "OFF連携");
+        }
+      }
+    },
+    [lastLookup, notes]
+  );
+
+  const importItemPreviewForQr = useMemo((): ImportRestaurantItem | null => {
+    if (!isEdit) return null;
+    if (!name.trim()) return null;
+    const gramsNum = parseFloat(grams) || 100;
+    const p = protein === "" ? null : parseFloat(protein);
+    const f = fat === "" ? null : parseFloat(fat);
+    const c = carbs === "" ? null : parseFloat(carbs);
+    return {
+      name: name.trim(),
+      protein_per_100g: p !== null && Number.isFinite(p) ? p : null,
+      fat_per_100g: f !== null && Number.isFinite(f) ? f : null,
+      carbs_per_100g: c !== null && Number.isFinite(c) ? c : null,
+      shared_barcode: sharedBarcode,
+      standard_food_code: standardFoodCode,
+      default_grams: gramsNum,
+      rank,
+      notes: notes.trim() || null,
+      group: groupName.trim() || null,
+    };
+  }, [
+    isEdit,
+    name,
+    protein,
+    fat,
+    carbs,
+    grams,
+    rank,
+    notes,
+    groupName,
+    sharedBarcode,
+    standardFoodCode,
+  ]);
+
+  useEffect(() => {
+    if (!isEdit) {
+      setShareQrDataUrl(null);
+      setShareQrError(null);
+      return;
     }
-  }, [lastLookup, notes]);
+    if (!importItemPreviewForQr) {
+      setShareQrDataUrl(null);
+      setShareQrError(null);
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      try {
+        const json = buildMenuQrPayloadJson(importItemPreviewForQr);
+        const QRCode = (await import("qrcode")).default;
+        const url = await QRCode.toDataURL(json, {
+          errorCorrectionLevel: "L",
+          margin: 1,
+          width: 220,
+          color: { dark: "#000000ff", light: "#ffffffff" },
+        });
+        if (!cancelled) {
+          setShareQrDataUrl(url);
+          setShareQrError(null);
+        }
+      } catch (e) {
+        if (!cancelled) {
+          setShareQrDataUrl(null);
+          setShareQrError(
+            e instanceof Error
+              ? `QRを生成できませんでした（${e.message}）。メモや名前を短くするか、項目を減らして保存内容を試してください。`
+              : "QRを生成できませんでした。メモや名前を短くしてください。"
+          );
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isEdit, importItemPreviewForQr]);
+
+  const handleDecodedScan = useCallback(
+    async (raw: string) => {
+      const trimmed = raw.trim();
+      if (!trimmed) {
+        setScanError("バーコードを読み取れませんでした。もう一度お試しください。");
+        return;
+      }
+      if (/^https?:\/\//i.test(trimmed)) {
+        setCameraOn(false);
+        setScanLoading(false);
+        setScanError("URLからの取り込みは、まだ対応していません。");
+        return;
+      }
+      if (trimmed.startsWith("{")) {
+        const parsed = parseMenuSharePayload(trimmed);
+        if (!parsed.ok) {
+          setCameraOn(false);
+          setScanLoading(false);
+          setScanError(parsed.error);
+          return;
+        }
+        if (!onMenuItemsQrImported) {
+          setCameraOn(false);
+          setScanLoading(false);
+          setScanError("QRの取り込みを続行できません。");
+          return;
+        }
+        if (!canRegisterMenu) {
+          setCameraOn(false);
+          setScanLoading(false);
+          setScanError(registerDisabledReason ?? "追加先のお店がありません。");
+          return;
+        }
+        const restaurantId = state.kind === "add" ? state.restaurantId : "";
+        if (!restaurantId) {
+          setCameraOn(false);
+          setScanLoading(false);
+          setScanError("お店が選択されていません。");
+          return;
+        }
+        setScanLoading(true);
+        setScanError(null);
+        const res = await importMenuItemsToRestaurant(restaurantId, [parsed.item]);
+        setScanLoading(false);
+        if (res.error) {
+          setScanError(res.error);
+          return;
+        }
+        onMenuItemsQrImported(res.newMenuItems);
+        onClose();
+        return;
+      }
+      await lookupOffProductBarcode(trimmed);
+    },
+    [
+      canRegisterMenu,
+      registerDisabledReason,
+      state,
+      onMenuItemsQrImported,
+      onClose,
+      lookupOffProductBarcode,
+    ]
+  );
 
   useEffect(() => {
     if (isEdit || !cameraOn || !cameraSupported) return;
@@ -685,7 +846,18 @@ function MenuItemDrawer({
 
       if (typeof w.BarcodeDetector !== "undefined") {
         try {
-          const detector = new w.BarcodeDetector();
+          type BarcodeDetectorCtor = new (opts?: { formats?: string[] }) => {
+            detect: (source: HTMLVideoElement) => Promise<Array<{ rawValue?: string }>>;
+          };
+          const Detector = w.BarcodeDetector as unknown as BarcodeDetectorCtor;
+          let detector: InstanceType<BarcodeDetectorCtor>;
+          try {
+            detector = new Detector({
+              formats: ["qr_code", "ean_13", "ean_8", "upc_a", "upc_e"],
+            });
+          } catch {
+            detector = new Detector();
+          }
           while (!stopped) {
             if (!videoRef.current) break;
             try {
@@ -693,7 +865,7 @@ function MenuItemDrawer({
               const value = detected[0]?.rawValue?.trim();
               if (value) {
                 setCameraOn(false);
-                void handleLookupBarcode(value);
+                void handleDecodedScan(value);
                 break;
               }
             } catch {
@@ -717,6 +889,7 @@ function MenuItemDrawer({
           }
           const hints = new Map<DecodeHintType, BarcodeFormat[]>();
           hints.set(DecodeHintType.POSSIBLE_FORMATS, [
+            BarcodeFormat.QR_CODE,
             BarcodeFormat.EAN_13,
             BarcodeFormat.EAN_8,
             BarcodeFormat.UPC_A,
@@ -729,7 +902,7 @@ function MenuItemDrawer({
             if (text) {
               ctrls.stop();
               setCameraOn(false);
-              void handleLookupBarcode(text);
+              void handleDecodedScan(text);
             }
           });
           stopZxing = () => controls.stop();
@@ -748,7 +921,7 @@ function MenuItemDrawer({
       stopZxing = null;
       if (stream) stream.getTracks().forEach((t) => t.stop());
     };
-  }, [isEdit, cameraOn, cameraSupported, handleLookupBarcode]);
+  }, [isEdit, cameraOn, cameraSupported, handleDecodedScan]);
 
   useEffect(() => {
     if (isEdit) return;
@@ -972,7 +1145,7 @@ function MenuItemDrawer({
                 className="w-full py-2.5 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm rounded-lg transition-colors inline-flex items-center justify-center gap-2"
               >
                 <span aria-hidden="true">{cameraOn ? "■" : "|||:"}</span>
-                <span>{cameraOn ? "読み取りを停止" : "バーコード読み取り"}</span>
+                <span>{cameraOn ? "読み取りを停止" : "バーコード / QR を読み取り"}</span>
               </button>
               {cameraOn && (
                 <video
@@ -997,7 +1170,7 @@ function MenuItemDrawer({
               )}
               {servingHint && <p className="text-xs text-amber-300">{servingHint}</p>}
               <p className="text-[11px] text-gray-500">
-                Data source: Open Food Facts (ODbL)
+                市販品バーコードは Open Food Facts (ODbL) を参照します。Ketolog のメニュー共有 QR も読み取れます。
               </p>
               {onOpenStandardFoodSearch && (
                 <button
@@ -1131,6 +1304,98 @@ function MenuItemDrawer({
               className="w-full resize-none px-3 py-2.5 sm:py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-base sm:text-sm focus:outline-none focus:border-emerald-500"
             />
           </div>
+
+          {isEdit && (
+            <div className="space-y-2 rounded-lg border border-gray-800 bg-gray-950/40 px-3 py-3">
+              <p className="text-xs text-gray-400">共有（QR）</p>
+              <p className="text-[11px] leading-snug text-gray-500">
+                入力中の内容を QR にします。相手は「メニューを追加」からカメラで読み取れます。
+              </p>
+              {!importItemPreviewForQr && (
+                <p className="text-xs text-amber-300">名前を入力すると QR を表示できます。</p>
+              )}
+              {shareQrError && <p className="text-xs text-amber-300">{shareQrError}</p>}
+              {shareQrDataUrl && importItemPreviewForQr && (
+                <>
+                  <div className="flex justify-center rounded-lg bg-white p-2">
+                    {/* eslint-disable-next-line @next/next/no-img-element -- data URL from qrcode */}
+                    <img
+                      src={shareQrDataUrl}
+                      alt=""
+                      width={220}
+                      height={220}
+                      className="h-44 w-44 max-w-full object-contain"
+                    />
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        if (!shareQrDataUrl) return;
+                        const slug =
+                          name
+                            .trim()
+                            .replace(/[\\/:*?"<>|]+/g, "_")
+                            .slice(0, 48) || "menu";
+                        const a = document.createElement("a");
+                        a.href = shareQrDataUrl;
+                        a.download = `ketolog-menu-${slug}.png`;
+                        a.click();
+                        setShareToast({ tone: "ok", msg: "PNG を保存しました" });
+                        window.setTimeout(() => setShareToast(null), 2800);
+                      }}
+                      className="flex-1 rounded-lg bg-gray-800 py-2.5 text-center text-sm text-gray-200 transition-colors hover:bg-gray-700"
+                    >
+                      PNG を保存
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        void (async () => {
+                          if (!shareQrDataUrl) return;
+                          try {
+                            const res = await fetch(shareQrDataUrl);
+                            const blob = await res.blob();
+                            if (!navigator.clipboard?.write || typeof ClipboardItem === "undefined") {
+                              setShareToast({
+                                tone: "err",
+                                msg: "このブラウザでは画像のコピーに対応していない可能性があります。",
+                              });
+                              window.setTimeout(() => setShareToast(null), 4000);
+                              return;
+                            }
+                            await navigator.clipboard.write([
+                              new ClipboardItem({ [blob.type]: blob }),
+                            ]);
+                            setShareToast({
+                              tone: "ok",
+                              msg: "画像をコピーしました（LINE などに貼り付けできます）",
+                            });
+                            window.setTimeout(() => setShareToast(null), 3500);
+                          } catch {
+                            setShareToast({ tone: "err", msg: "画像のコピーに失敗しました。" });
+                            window.setTimeout(() => setShareToast(null), 4000);
+                          }
+                        })();
+                      }}
+                      className="flex-1 rounded-lg border border-gray-600 py-2.5 text-center text-sm text-gray-200 transition-colors hover:border-gray-500"
+                    >
+                      画像をコピー
+                    </button>
+                  </div>
+                </>
+              )}
+              {shareToast && (
+                <p
+                  className={
+                    shareToast.tone === "ok" ? "text-xs text-emerald-300" : "text-xs text-amber-300"
+                  }
+                >
+                  {shareToast.msg}
+                </p>
+              )}
+            </div>
+          )}
 
           {error && <p className="text-red-400 text-sm">{error}</p>}
 
@@ -3829,6 +4094,10 @@ export default function TodayClient({
               });
               return next;
             });
+          }}
+          onMenuItemsQrImported={(items) => {
+            setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
+            setItemDrawer(null);
           }}
         />
       )}

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -464,7 +464,6 @@ function MenuItemDrawer({
   canRegisterMenu,
   registerDisabledReason,
   onOpenStandardFoodSearch,
-  onMenuItemsQrImported,
 }: {
   state: ItemDrawerState;
   existingGroupNames: string[];
@@ -493,8 +492,6 @@ function MenuItemDrawer({
   registerTargetRestaurantId: string;
   onRegisterTargetChange: (restaurantId: string) => void;
   onOpenStandardFoodSearch?: () => void;
-  /** QR 取り込み成功時（メニュー追加ドロワーでカメラから読んだとき） */
-  onMenuItemsQrImported?: (items: MenuItem[]) => void;
 }) {
   const MEMO_MIN_ROWS = 3;
   const MEMO_MAX_ROWS = 10;
@@ -721,6 +718,39 @@ function MenuItemDrawer({
     };
   }, [isEdit, importItemPreviewForQr]);
 
+  /** メニュー共有 QR のペイロードを「メニューを追加」フォームへ転記（DB 保存はメニューに登録などで行う） */
+  const applyImportRestaurantItemToForm = useCallback((item: ImportRestaurantItem) => {
+    setName(item.name);
+    setProtein(
+      item.protein_per_100g === null || item.protein_per_100g === undefined
+        ? ""
+        : String(item.protein_per_100g)
+    );
+    setFat(
+      item.fat_per_100g === null || item.fat_per_100g === undefined ? "" : String(item.fat_per_100g)
+    );
+    setCarbs(
+      item.carbs_per_100g === null || item.carbs_per_100g === undefined
+        ? ""
+        : String(item.carbs_per_100g)
+    );
+    setGrams(String(item.default_grams));
+    setRank(item.rank);
+    setGroupName(item.group ?? "");
+    setNotes(item.notes ?? "");
+    setSharedBarcode(item.shared_barcode ?? null);
+    setStandardFoodCode(item.standard_food_code ?? null);
+    setManualSharedProductPending(false);
+    setCameraResult(null);
+    setServingHint(null);
+    setScanError(null);
+    setMode("per100g");
+    setRawP(null);
+    setRawF(null);
+    setRawC(null);
+    setLastLookup(null);
+  }, []);
+
   const handleDecodedScan = useCallback(
     async (raw: string) => {
       const trimmed = raw.trim();
@@ -742,47 +772,23 @@ function MenuItemDrawer({
           setScanError(parsed.error);
           return;
         }
-        if (!onMenuItemsQrImported) {
-          setCameraOn(false);
-          setScanLoading(false);
-          setScanError("QRの取り込みを続行できません。");
-          return;
-        }
         if (!canRegisterMenu) {
           setCameraOn(false);
           setScanLoading(false);
           setScanError(registerDisabledReason ?? "追加先のお店がありません。");
           return;
         }
-        const restaurantId = state.kind === "add" ? state.restaurantId : "";
-        if (!restaurantId) {
-          setCameraOn(false);
-          setScanLoading(false);
-          setScanError("お店が選択されていません。");
-          return;
-        }
-        setMenuQrImportDone(null);
-        setScanLoading(true);
-        setScanError(null);
-        const res = await importMenuItemsToRestaurant(restaurantId, [parsed.item]);
-        setScanLoading(false);
-        if (res.error) {
-          setScanError(res.error);
-          return;
-        }
-        onMenuItemsQrImported(res.newMenuItems);
         setCameraOn(false);
-        const added = res.newMenuItems[0];
-        setMenuQrImportDone(
-          added
-            ? `「${added.name}」を追加しました。一覧は下で確認できます。続けて読み取るときは「バーコード / QR を読み取り」をもう一度タップしてください。`
-            : "メニューを追加しました。"
-        );
+        setScanLoading(false);
+        setMenuQrImportDone(null);
+        applyImportRestaurantItemToForm(parsed.item);
+        setMenuQrImportDone(`「${parsed.item.name}」をフォームに反映しました。`);
+        requestAnimationFrame(() => nameInputRef.current?.focus());
         return;
       }
       await lookupOffProductBarcode(trimmed);
     },
-    [canRegisterMenu, registerDisabledReason, state, onMenuItemsQrImported, lookupOffProductBarcode]
+    [canRegisterMenu, registerDisabledReason, applyImportRestaurantItemToForm, lookupOffProductBarcode]
   );
 
   useEffect(() => {
@@ -4100,11 +4106,6 @@ export default function TodayClient({
               });
               return next;
             });
-          }}
-          onMenuItemsQrImported={(items) => {
-            setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
-            const rid = items[0]?.restaurant_id;
-            if (rid) setSelectedRestaurantId(rid);
           }}
         />
       )}

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -553,6 +553,8 @@ function MenuItemDrawer({
   const [shareQrDataUrl, setShareQrDataUrl] = useState<string | null>(null);
   const [shareQrError, setShareQrError] = useState<string | null>(null);
   const [shareToast, setShareToast] = useState<{ tone: "ok" | "err"; msg: string } | null>(null);
+  /** QR 共有メニューの取り込み成功（ドロワーを閉じずに表示） */
+  const [menuQrImportDone, setMenuQrImportDone] = useState<string | null>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const nameInputRef = useRef<HTMLInputElement>(null);
   const groupNameInputRef = useRef<HTMLInputElement>(null);
@@ -759,6 +761,7 @@ function MenuItemDrawer({
           setScanError("お店が選択されていません。");
           return;
         }
+        setMenuQrImportDone(null);
         setScanLoading(true);
         setScanError(null);
         const res = await importMenuItemsToRestaurant(restaurantId, [parsed.item]);
@@ -768,19 +771,18 @@ function MenuItemDrawer({
           return;
         }
         onMenuItemsQrImported(res.newMenuItems);
-        onClose();
+        setCameraOn(false);
+        const added = res.newMenuItems[0];
+        setMenuQrImportDone(
+          added
+            ? `「${added.name}」を追加しました。一覧は下で確認できます。続けて読み取るときは「バーコード / QR を読み取り」をもう一度タップしてください。`
+            : "メニューを追加しました。"
+        );
         return;
       }
       await lookupOffProductBarcode(trimmed);
     },
-    [
-      canRegisterMenu,
-      registerDisabledReason,
-      state,
-      onMenuItemsQrImported,
-      onClose,
-      lookupOffProductBarcode,
-    ]
+    [canRegisterMenu, registerDisabledReason, state, onMenuItemsQrImported, lookupOffProductBarcode]
   );
 
   useEffect(() => {
@@ -1140,6 +1142,7 @@ function MenuItemDrawer({
                   setScanError(null);
                   setCameraResult(null);
                   setServingHint(null);
+                  setMenuQrImportDone(null);
                   setCameraOn((v) => !v);
                 }}
                 className="w-full py-2.5 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm rounded-lg transition-colors inline-flex items-center justify-center gap-2"
@@ -1157,6 +1160,9 @@ function MenuItemDrawer({
                 />
               )}
               {scanLoading && <p className="text-xs text-emerald-300">読み取り結果を検索中...</p>}
+              {menuQrImportDone && (
+                <p className="text-xs leading-relaxed text-emerald-300">{menuQrImportDone}</p>
+              )}
               {cameraResult && (
                 <p className="text-xs text-emerald-300">
                   読み取り完了: {cameraResult.product_name}（{cameraResult.barcode}）
@@ -4099,7 +4105,6 @@ export default function TodayClient({
             setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
             const rid = items[0]?.restaurant_id;
             if (rid) setSelectedRestaurantId(rid);
-            setItemDrawer(null);
           }}
         />
       )}

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -744,6 +744,7 @@ function MenuItemDrawer({
     setCameraResult(null);
     setServingHint(null);
     setScanError(null);
+    setError(null);
     setMode("per100g");
     setRawP(null);
     setRawF(null);

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -4097,6 +4097,8 @@ export default function TodayClient({
           }}
           onMenuItemsQrImported={(items) => {
             setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
+            const rid = items[0]?.restaurant_id;
+            if (rid) setSelectedRestaurantId(rid);
             setItemDrawer(null);
           }}
         />

--- a/src/app/today/actions.ts
+++ b/src/app/today/actions.ts
@@ -1384,6 +1384,7 @@ export async function importRestaurantData(data: ImportData): Promise<{
   return { added: newRestaurants.length, skipped, newRestaurants, newMenuItems, error: null };
 }
 
+/** 既存店にメニュー行を一括 INSERT する（「メニューをJSONで追加」ドロワー専用）。メニュー共有QRはクライアントでフォームに転記するだけで、ここは通らない。 */
 export async function importMenuItemsToRestaurant(
   restaurantId: string,
   items: ImportRestaurantItem[]

--- a/src/lib/menu-qr-payload.ts
+++ b/src/lib/menu-qr-payload.ts
@@ -1,0 +1,88 @@
+import type { ImportRestaurantItem } from "@/app/today/actions";
+import type { MenuItem } from "@/types/database";
+
+export const MENU_QR_PAYLOAD_VERSION = 1 as const;
+
+export type MenuQrPayloadV1 = {
+  v: 1;
+  kind: "menuItem";
+  item: ImportRestaurantItem;
+};
+
+export function menuItemToImportItem(m: MenuItem): ImportRestaurantItem {
+  return {
+    name: m.name,
+    protein_per_100g: m.protein_per_100g,
+    fat_per_100g: m.fat_per_100g,
+    carbs_per_100g: m.carbs_per_100g,
+    shared_barcode: m.shared_barcode ?? null,
+    standard_food_code: m.standard_food_code ?? null,
+    default_grams: m.default_grams,
+    rank: m.rank,
+    notes: m.notes,
+    group: m.group_name,
+  };
+}
+
+export function buildMenuQrPayloadJson(item: ImportRestaurantItem): string {
+  const payload: MenuQrPayloadV1 = {
+    v: MENU_QR_PAYLOAD_VERSION,
+    kind: "menuItem",
+    item,
+  };
+  return JSON.stringify(payload);
+}
+
+function validateImportRestaurantItemShape(item: ImportRestaurantItem): string | null {
+  const label = item.name?.trim() || "（無題）";
+  if (item.shared_barcode !== undefined && item.shared_barcode !== null && typeof item.shared_barcode !== "string") {
+    return `「${label}」の shared_barcode が不正です（文字列またはnull）`;
+  }
+  if (
+    item.standard_food_code !== undefined &&
+    item.standard_food_code !== null &&
+    (typeof item.standard_food_code !== "string" || !/^\d{5}$/.test(item.standard_food_code))
+  ) {
+    return `「${label}」の standard_food_code は5桁の数字文字列またはnullにしてください`;
+  }
+  if (item.rank < 1 || item.rank > 4 || !Number.isInteger(item.rank)) {
+    return `「${label}」の rank が不正です（1〜4の整数を指定してください）`;
+  }
+  if (typeof item.default_grams !== "number" || item.default_grams <= 0) {
+    return `「${label}」の default_grams が不正です（1以上の数値を指定してください）`;
+  }
+  return null;
+}
+
+/**
+ * メニュー共有 QR（クライアント内 JSON）の解釈。
+ * オブジェクトだが v/kind が一致しない場合は失敗（バーコードへフォールバックしない）。
+ */
+export function parseMenuSharePayload(text: string):
+  | { ok: true; item: ImportRestaurantItem }
+  | { ok: false; error: string } {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(text);
+  } catch {
+    return { ok: false, error: "QRのデータを読み取れませんでした（JSON形式ではありません）。" };
+  }
+  if (!raw || typeof raw !== "object") {
+    return { ok: false, error: "QRのデータ形式が不正です。" };
+  }
+  const o = raw as Record<string, unknown>;
+  if (o.v !== 1) {
+    return { ok: false, error: "このQRは対応していないバージョンです。" };
+  }
+  if (o.kind !== "menuItem") {
+    return { ok: false, error: "このQRはメニュー共有ではありません。" };
+  }
+  const item = o.item;
+  if (!item || typeof item !== "object") {
+    return { ok: false, error: "メニューデータが含まれていません。" };
+  }
+  const it = item as ImportRestaurantItem;
+  const err = validateImportRestaurantItemShape(it);
+  if (err) return { ok: false, error: err };
+  return { ok: true, item: it };
+}

--- a/src/lib/menu-qr-payload.ts
+++ b/src/lib/menu-qr-payload.ts
@@ -1,5 +1,4 @@
 import type { ImportRestaurantItem } from "@/app/today/actions";
-import type { MenuItem } from "@/types/database";
 
 export const MENU_QR_PAYLOAD_VERSION = 1 as const;
 
@@ -8,21 +7,6 @@ export type MenuQrPayloadV1 = {
   kind: "menuItem";
   item: ImportRestaurantItem;
 };
-
-export function menuItemToImportItem(m: MenuItem): ImportRestaurantItem {
-  return {
-    name: m.name,
-    protein_per_100g: m.protein_per_100g,
-    fat_per_100g: m.fat_per_100g,
-    carbs_per_100g: m.carbs_per_100g,
-    shared_barcode: m.shared_barcode ?? null,
-    standard_food_code: m.standard_food_code ?? null,
-    default_grams: m.default_grams,
-    rank: m.rank,
-    notes: m.notes,
-    group: m.group_name,
-  };
-}
 
 export function buildMenuQrPayloadJson(item: ImportRestaurantItem): string {
   const payload: MenuQrPayloadV1 = {


### PR DESCRIPTION
## 概要
Issue #198 の実装。メニュー編集から QR 共有、メニュー追加ドロワーで QR を読み取りフォームへ転記（確定は従来どおりメニューに登録／カート／ログ）。

## 変更要点
- `qrcode` による QR 生成、PNG 保存・画像コピー
- ペイロード `{ v, kind: menuItem, item }`（`src/lib/menu-qr-payload.ts`）
- BarcodeDetector / ZXing に QR 対応
- QR は DB 即保存せずフォーム転記のみ（`importMenuItemsToRestaurant` は JSON 一括取り込み専用である旨を JSDoc で明記）

closes #198

Made with [Cursor](https://cursor.com)