### PR TITLE
feat: 分析画面（/insights）を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.35.0] - 2026-04-14
+
+### Added
+
+- **分析画面（/insights）**: 過去7日を初期表示に、過去30日・カスタム（最大90日）で期間を切り替え、日次PFC推移グラフ・日別ログ（初期は全折りたたみ）・よく食べたアイテムTop10（回数）を確認できる専用ページを追加。期間内ログのJSONダウンロードにも対応（[#200](https://github.com/kzkski/ketolog/issues/200)）。
+- **Today / 設定**: 設定ドロワーに分析画面への導線を追加し、記録画面から期間分析へ遷移しやすくした（[#200](https://github.com/kzkski/ketolog/issues/200)）。
+
 ## [1.34.3] - 2026-04-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.34.3",
+  "version": "1.35.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.34.3",
+      "version": "1.35.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.33.0",
+  "version": "1.34.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.33.0",
+      "version": "1.34.3",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
@@ -21,7 +21,8 @@
         "next": "16.2.3",
         "qrcode": "^1.5.4",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^16.2.3",
@@ -1960,6 +1961,42 @@
         "module-details-from-path": "^1.0.4"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rollup/plugin-commonjs": {
       "version": "28.0.1",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-commonjs/-/plugin-commonjs-28.0.1.tgz",
@@ -2918,6 +2955,18 @@
         "webpack": ">=5.0.0"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/auth-js": {
       "version": "2.102.1",
       "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.102.1.tgz",
@@ -3316,6 +3365,69 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -3409,7 +3521,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -3433,6 +3545,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "8.18.1",
@@ -4949,6 +5067,15 @@
         "wrap-ansi": "^6.2.0"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cmd-shim": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/cmd-shim/-/cmd-shim-8.0.0.tgz",
@@ -5061,8 +5188,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -5167,6 +5415,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -5484,6 +5738,16 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -5916,6 +6180,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/events": {
       "version": "3.3.0",
@@ -6577,6 +6847,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -6632,6 +6912,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -8472,8 +8761,30 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/read-cmd-shim": {
       "version": "6.0.0",
@@ -8483,6 +8794,51 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -8566,6 +8922,12 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "license": "ISC"
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.6",
@@ -9477,6 +9839,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -9844,6 +10212,37 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/watchpack": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.34.3",
+  "version": "1.35.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "next": "16.2.3",
     "qrcode": "^1.5.4",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^16.2.3",

--- a/src/app/insights/InsightsChart.tsx
+++ b/src/app/insights/InsightsChart.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { LegendProps } from "recharts";
+
+type Point = {
+  date: string;
+  protein: number;
+  fat: number;
+  carbs: number;
+};
+
+function dateLabel(date: string): string {
+  return date.slice(5);
+}
+
+function LegendContent(props: LegendProps) {
+  const payload = props.payload ?? [];
+  const ordered = ["P", "F", "C"]
+    .map((name) => payload.find((p) => p.value === name))
+    .filter(Boolean);
+
+  return (
+    <div className="mt-1 flex items-center justify-center gap-4 text-sm">
+      {ordered.map((item) => (
+        <span key={item!.value as string} className="inline-flex items-center gap-1">
+          <span
+            className="inline-block h-2 w-2 rounded-full"
+            style={{ backgroundColor: item!.color ?? "#9ca3af" }}
+          />
+          <span>{item!.value as string}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default function InsightsChart({ data }: { data: Point[] }) {
+  return (
+    <div className="h-56 w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={data} margin={{ top: 8, right: 8, left: 0, bottom: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+          <XAxis
+            dataKey="date"
+            tickFormatter={dateLabel}
+            stroke="#9ca3af"
+            tick={{ fontSize: 11 }}
+          />
+          <YAxis stroke="#9ca3af" tick={{ fontSize: 11 }} />
+          <Tooltip
+            formatter={(value: number) => value.toFixed(1)}
+            labelFormatter={(label) => `${label}`}
+            contentStyle={{ backgroundColor: "#111827", border: "1px solid #374151" }}
+          />
+          <Legend content={<LegendContent />} />
+          <Line type="monotone" dataKey="protein" name="P" stroke="#60a5fa" strokeWidth={2} dot={false} />
+          <Line type="monotone" dataKey="fat" name="F" stroke="#facc15" strokeWidth={2} dot={false} />
+          <Line type="monotone" dataKey="carbs" name="C" stroke="#34d399" strokeWidth={2} dot={false} />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/app/insights/InsightsClient.tsx
+++ b/src/app/insights/InsightsClient.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import {
+  addDaysJst,
+  buildInsights,
+  getPresetRange,
+  type InsightFoodLogEntry,
+} from "@/lib/insights";
+import { getInsightsFoodLogForDateRange } from "./actions";
+
+const InsightsChart = dynamic(() => import("./InsightsChart"), {
+  ssr: false,
+  loading: () => <p className="text-xs text-gray-400">グラフを読み込み中...</p>,
+});
+
+const CUSTOM_RANGE_MAX_DAYS = 90;
+
+const MEAL_LABEL: Record<string, string> = {
+  breakfast: "朝食",
+  lunch: "昼食",
+  dinner: "夕食",
+  snack: "間食",
+};
+
+type Preset = "7d" | "30d" | "custom";
+
+function fmtNum(v: number): string {
+  return v.toFixed(1);
+}
+
+function ratioStyle(total: number, part: number): { width: string } {
+  if (total <= 0) return { width: "0%" };
+  return { width: `${Math.max(0, Math.min(100, (part / total) * 100))}%` };
+}
+
+function jstDateLabel(date: string): string {
+  const [y, m, d] = date.split("-").map(Number);
+  const weekday = ["日", "月", "火", "水", "木", "金", "土"][
+    new Date(Date.UTC(y, (m ?? 1) - 1, d ?? 1)).getUTCDay()
+  ];
+  return `${date}（${weekday}）`;
+}
+
+function toIsoNow() {
+  return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+export default function InsightsClient({
+  initialEntries,
+  today,
+}: {
+  initialEntries: InsightFoodLogEntry[];
+  today: string;
+}) {
+  const preset7 = getPresetRange(today, 7);
+  const [preset, setPreset] = useState<Preset>("7d");
+  const [start, setStart] = useState(preset7.start);
+  const [end, setEnd] = useState(preset7.end);
+  const [entries, setEntries] = useState(initialEntries);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const insight = useMemo(() => buildInsights(entries, start, end), [entries, start, end]);
+  const avgTotal = insight.summary.avgProtein + insight.summary.avgFat + insight.summary.avgCarbs;
+  const avgProteinPct = avgTotal > 0 ? (insight.summary.avgProtein / avgTotal) * 100 : 0;
+  const avgFatPct = avgTotal > 0 ? (insight.summary.avgFat / avgTotal) * 100 : 0;
+  const avgCarbsPct = avgTotal > 0 ? (insight.summary.avgCarbs / avgTotal) * 100 : 0;
+
+  async function loadRange(nextStart: string, nextEnd: string, nextPreset: Preset) {
+    setLoading(true);
+    setError(null);
+    const result = await getInsightsFoodLogForDateRange(nextStart, nextEnd);
+    setLoading(false);
+    if (result.error) {
+      setError(result.error);
+      return;
+    }
+    setPreset(nextPreset);
+    setStart(nextStart);
+    setEnd(nextEnd);
+    setEntries(result.entries);
+    setExpanded(new Set());
+  }
+
+  function toggleDate(date: string) {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(date)) next.delete(date);
+      else next.add(date);
+      return next;
+    });
+  }
+
+  function validateCustomRange(nextStart: string, nextEnd: string): string | null {
+    if (nextStart > nextEnd) return "開始日は終了日以前にしてください。";
+    if (nextEnd > today) return "終了日は今日以前にしてください。";
+    const maxEnd = addDaysJst(nextStart, CUSTOM_RANGE_MAX_DAYS - 1);
+    if (nextEnd > maxEnd) return `カスタム期間は最大${CUSTOM_RANGE_MAX_DAYS}日です。`;
+    return null;
+  }
+
+  function downloadPeriodJson() {
+    const payload = {
+      kind: "ketolog_insights_export",
+      version: 1,
+      period: { start, end, preset },
+      exportedAt: new Date().toISOString(),
+      entries,
+    };
+    const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `ketolog-insights-${start}-${end}-${toIsoNow()}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="min-h-dvh bg-gray-950 text-white">
+      <div className="mx-auto w-full max-w-4xl px-4 py-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <h1 className="text-lg font-semibold">分析</h1>
+          <Link
+            href="/today"
+            className="rounded-lg border border-gray-700 px-3 py-1.5 text-xs text-gray-200 hover:bg-gray-800 transition-colors"
+          >
+            閉じる
+          </Link>
+        </div>
+
+        <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3 space-y-3">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+            <button
+              type="button"
+              onClick={() => {
+                const range = getPresetRange(today, 7);
+                void loadRange(range.start, range.end, "7d");
+              }}
+              disabled={loading}
+              className={`rounded-lg px-3 py-2 text-sm transition-colors ${
+                preset === "7d" ? "bg-emerald-600 text-white" : "bg-gray-800 hover:bg-gray-700 text-gray-200"
+              }`}
+            >
+              過去7日
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const range = getPresetRange(today, 30);
+                void loadRange(range.start, range.end, "30d");
+              }}
+              disabled={loading}
+              className={`rounded-lg px-3 py-2 text-sm transition-colors ${
+                preset === "30d" ? "bg-emerald-600 text-white" : "bg-gray-800 hover:bg-gray-700 text-gray-200"
+              }`}
+            >
+              過去30日
+            </button>
+            <div className="rounded-lg border border-gray-800 bg-gray-950/70 px-3 py-2 text-center text-xs text-gray-400">
+              カスタム最大90日
+            </div>
+            <button
+              type="button"
+              onClick={downloadPeriodJson}
+              className="rounded-lg bg-gray-700 px-3 py-2 text-sm font-medium hover:bg-gray-600 transition-colors"
+            >
+              ダウンロード
+            </button>
+          </div>
+
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:items-end">
+            <label className="text-xs text-gray-300">
+              開始日
+              <input
+                type="date"
+                max={today}
+                value={start}
+                onChange={(e) => setStart(e.target.value)}
+                className="mt-1 block w-full rounded border border-gray-700 bg-gray-950 px-2 py-1 text-sm"
+              />
+            </label>
+            <label className="text-xs text-gray-300">
+              終了日
+              <input
+                type="date"
+                max={today}
+                value={end}
+                onChange={(e) => setEnd(e.target.value)}
+                className="mt-1 block w-full rounded border border-gray-700 bg-gray-950 px-2 py-1 text-sm"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={() => {
+                const v = validateCustomRange(start, end);
+                if (v) {
+                  setError(v);
+                  return;
+                }
+                void loadRange(start, end, "custom");
+              }}
+              disabled={loading}
+              className="rounded-lg bg-gray-700 px-3 py-2 text-sm hover:bg-gray-600 transition-colors sm:h-[2.25rem]"
+            >
+              カスタム適用
+            </button>
+          </div>
+          {loading && <p className="text-xs text-gray-400">読み込み中...</p>}
+          {error && <p className="text-xs text-red-400">{error}</p>}
+        </div>
+
+        <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3">
+          <h2 className="mb-2 text-sm font-medium text-white">平均PFCバランス</h2>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+              <p className="text-[11px] text-gray-400">たんぱく質 (P)</p>
+              <p className="text-sm font-semibold text-blue-300">{fmtNum(insight.summary.avgProtein)} g</p>
+              <p className="text-[11px] text-blue-200/90">{fmtNum(avgProteinPct)}%</p>
+            </div>
+            <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+              <p className="text-[11px] text-gray-400">脂質 (F)</p>
+              <p className="text-sm font-semibold text-yellow-300">{fmtNum(insight.summary.avgFat)} g</p>
+              <p className="text-[11px] text-yellow-200/90">{fmtNum(avgFatPct)}%</p>
+            </div>
+            <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+              <p className="text-[11px] text-gray-400">糖質 (C)</p>
+              <p className="text-sm font-semibold text-emerald-300">{fmtNum(insight.summary.avgCarbs)} g</p>
+              <p className="text-[11px] text-emerald-200/90">{fmtNum(avgCarbsPct)}%</p>
+            </div>
+          </div>
+          <div className="mt-2 h-2 w-full overflow-hidden rounded bg-gray-800">
+            <div className="flex h-full w-full">
+              <div className="bg-blue-400" style={ratioStyle(avgTotal, insight.summary.avgProtein)} />
+              <div className="bg-yellow-400" style={ratioStyle(avgTotal, insight.summary.avgFat)} />
+              <div className="bg-emerald-400" style={ratioStyle(avgTotal, insight.summary.avgCarbs)} />
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3">
+          <h2 className="mb-2 text-sm font-medium text-white">日次PFC推移</h2>
+          <InsightsChart data={insight.chart} />
+        </div>
+
+        <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3 space-y-2">
+          <h2 className="text-sm font-medium text-white">日ごとの食事一覧</h2>
+          {insight.daily.map((day) => {
+            const isOpen = expanded.has(day.date);
+            const total = day.protein + day.fat + day.carbs;
+            return (
+              <div key={day.date} className="rounded-lg border border-gray-800 bg-gray-950/60">
+                <button
+                  type="button"
+                  onClick={() => toggleDate(day.date)}
+                  className="flex w-full items-center justify-between px-3 py-2 text-left"
+                >
+                  <div className="min-w-0 flex-1 pr-3">
+                    <div className="grid grid-cols-[minmax(0,1fr)_4.2rem_4.2rem_4.2rem] items-center gap-1 text-xs">
+                      <p className="truncate text-sm text-white">
+                        {isOpen ? "▼" : "▶"} {jstDateLabel(day.date)}
+                      </p>
+                      <span className="text-right text-blue-300">{fmtNum(day.protein)}</span>
+                      <span className="text-right text-yellow-300">{fmtNum(day.fat)}</span>
+                      <span className="text-right text-emerald-300">{fmtNum(day.carbs)}</span>
+                    </div>
+                    <div className="mt-1.5 h-2 w-full overflow-hidden rounded bg-gray-800">
+                      <div className="flex h-full w-full">
+                        <div className="bg-blue-400" style={ratioStyle(total, day.protein)} />
+                        <div className="bg-yellow-400" style={ratioStyle(total, day.fat)} />
+                        <div className="bg-emerald-400" style={ratioStyle(total, day.carbs)} />
+                      </div>
+                    </div>
+                  </div>
+                  <span className="shrink-0 text-xs text-gray-500">{day.entries.length} 件</span>
+                </button>
+                {isOpen && (
+                  <div className="border-t border-gray-800 px-3 py-2 space-y-1.5">
+                    <div className="grid grid-cols-[minmax(0,1fr)_4.5rem_4.2rem_4.2rem_4.2rem] gap-1 text-[11px] text-gray-500">
+                      <span>項目</span>
+                      <span className="text-right">g</span>
+                      <span className="text-center text-blue-400">P</span>
+                      <span className="text-center text-yellow-400">F</span>
+                      <span className="text-center text-emerald-400">C</span>
+                    </div>
+                    {day.entries.length === 0 ? (
+                      <p className="text-xs text-gray-500">記録なし</p>
+                    ) : (
+                      day.entries.map((entry) => (
+                        <div
+                          key={entry.id}
+                          className="grid grid-cols-[minmax(0,1fr)_4.5rem_4.2rem_4.2rem_4.2rem] gap-1 rounded border border-gray-800 bg-gray-900/70 px-2 py-1.5 text-[12px]"
+                        >
+                          <div className="min-w-0 text-white">
+                            <p className="truncate">
+                              <span className="text-gray-400">[{MEAL_LABEL[entry.meal_type] ?? entry.meal_type}]</span>{" "}
+                              {entry.item_name}
+                            </p>
+                          </div>
+                          <span className="text-right text-gray-300">{fmtNum(entry.grams)}</span>
+                          <span className="text-center text-blue-300">{fmtNum(entry.protein_g ?? 0)}</span>
+                          <span className="text-center text-yellow-300">{fmtNum(entry.fat_g ?? 0)}</span>
+                          <span className="text-center text-emerald-300">{fmtNum(entry.carbs_g ?? 0)}</span>
+                        </div>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3">
+          <h2 className="mb-2 text-sm font-medium text-white">よく食べたアイテム Top10（回数）</h2>
+          {insight.top10.length === 0 ? (
+            <p className="text-xs text-gray-500">該当期間の記録がありません。</p>
+          ) : (
+            <ol className="space-y-1">
+              {insight.top10.map((item, idx) => (
+                <li key={item.key} className="flex items-center justify-between rounded border border-gray-800 bg-gray-950/60 px-2 py-1.5 text-sm">
+                  <span>{idx + 1}. {item.label}</span>
+                  <span className="text-gray-300">{item.count}回</span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/insights/actions.ts
+++ b/src/app/insights/actions.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
+import type { InsightFoodLogEntry } from "@/lib/insights";
+
+const INSIGHTS_PAGE_SIZE = 1000;
+
+export async function getInsightsFoodLogForDateRange(
+  start: string,
+  end: string
+): Promise<{ entries: InsightFoodLogEntry[]; error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { entries: [], error: "認証が必要です" };
+
+  const entries: InsightFoodLogEntry[] = [];
+  let offset = 0;
+
+  for (;;) {
+    const { data, error } = await supabase
+      .from("food_log")
+      .select(
+        "id, date, meal_type, eaten_at, item_name, grams, protein_g, fat_g, carbs_g, source, menu_item_id, created_at"
+      )
+      .eq("user_id", user.id)
+      .gte("date", start)
+      .lte("date", end)
+      .order("date", { ascending: true })
+      .order("eaten_at", { ascending: true })
+      .order("created_at", { ascending: true })
+      .range(offset, offset + INSIGHTS_PAGE_SIZE - 1);
+
+    if (error) return { entries: [], error: error.message };
+
+    const rows = data ?? [];
+    for (const row of rows) {
+      const r = row as Record<string, unknown>;
+      entries.push({
+        id: String(r.id),
+        date: String(r.date),
+        meal_type: String(r.meal_type),
+        eaten_at: String(r.eaten_at),
+        item_name: String(r.item_name),
+        grams: Number(r.grams),
+        protein_g: r.protein_g == null ? null : Number(r.protein_g),
+        fat_g: r.fat_g == null ? null : Number(r.fat_g),
+        carbs_g: r.carbs_g == null ? null : Number(r.carbs_g),
+        source: r.source == null ? null : String(r.source),
+        menu_item_id: r.menu_item_id == null ? null : String(r.menu_item_id),
+        created_at: String(r.created_at),
+      });
+    }
+
+    if (rows.length < INSIGHTS_PAGE_SIZE) break;
+    offset += INSIGHTS_PAGE_SIZE;
+  }
+
+  return { entries, error: null };
+}

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from "next/navigation";
+import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
+import { getPresetRange, getTodayJstDate } from "@/lib/insights";
+import { getInsightsFoodLogForDateRange } from "./actions";
+import InsightsClient from "./InsightsClient";
+
+export default async function InsightsPage() {
+  const { user } = await getSupabaseAuthForRequest();
+  if (!user) redirect("/login");
+
+  const today = getTodayJstDate();
+  const initialRange = getPresetRange(today, 7);
+  const result = await getInsightsFoodLogForDateRange(initialRange.start, initialRange.end);
+
+  return <InsightsClient initialEntries={result.entries} today={today} />;
+}

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import Link from "next/link";
 import {
   useState,
   useMemo,
@@ -2647,6 +2648,19 @@ function SettingsDrawer({
           </div>
 
           <div>
+            <h3 className="text-sm font-medium text-white mb-1">分析</h3>
+            <p className="text-xs text-gray-400 mb-3">
+              過去7日・30日・カスタム期間（最大90日）の食事ログを、日次集計と一覧で確認できます。
+            </p>
+            <a
+              href="/insights"
+              className="block w-full rounded-xl bg-gray-700 py-2.5 text-center text-sm font-medium text-white transition-colors hover:bg-gray-600"
+            >
+              分析画面を開く
+            </a>
+          </div>
+
+          <div>
             <h3 className="text-sm font-medium text-white mb-1">データソース</h3>
             <p className="text-xs text-gray-400">
               市販品データは Open Food Facts を利用しています（ODbL）。
@@ -3636,6 +3650,13 @@ export default function TodayClient({
               onClick={() => setShowLogEntries((v) => !v)}
               className="w-full flex items-center justify-end gap-2 px-3 sm:px-4 py-1 sm:py-2 text-[11px] sm:text-xs text-gray-400 hover:text-white transition-colors min-h-7 sm:min-h-0 leading-none"
             >
+              <Link
+                href="/insights"
+                className="rounded-md border border-gray-700 px-1.5 py-1 text-[10px] text-gray-300 hover:text-white hover:bg-gray-800 transition-colors"
+                onClick={(e) => e.stopPropagation()}
+              >
+                過去7日を見る
+              </Link>
               <span className="font-medium text-gray-300 text-right">
                 この日の記録（{logEntries.length}件）
               </span>

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,0 +1,143 @@
+export type InsightFoodLogEntry = {
+  id: string;
+  date: string;
+  meal_type: string;
+  eaten_at: string;
+  item_name: string;
+  grams: number;
+  protein_g: number | null;
+  fat_g: number | null;
+  carbs_g: number | null;
+  source: string | null;
+  menu_item_id: string | null;
+  created_at: string;
+};
+
+export type DailyInsight = {
+  date: string;
+  protein: number;
+  fat: number;
+  carbs: number;
+  entries: InsightFoodLogEntry[];
+};
+
+export type TopItem = {
+  key: string;
+  label: string;
+  count: number;
+};
+
+export function getTodayJstDate(): string {
+  return new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+}
+
+export function addDaysJst(dateStr: string, delta: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const date = new Date(Date.UTC(y, (m ?? 1) - 1, d ?? 1));
+  date.setUTCDate(date.getUTCDate() + delta);
+  return date.toISOString().slice(0, 10);
+}
+
+export function getPresetRange(today: string, days: 7 | 30): { start: string; end: string } {
+  return {
+    start: addDaysJst(today, -(days - 1)),
+    end: today,
+  };
+}
+
+function normalizeName(name: string): string {
+  return name.trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+function toNum(v: number | null): number {
+  return v ?? 0;
+}
+
+function eachDate(start: string, end: string): string[] {
+  const out: string[] = [];
+  let cursor = start;
+  while (cursor <= end) {
+    out.push(cursor);
+    cursor = addDaysJst(cursor, 1);
+  }
+  return out;
+}
+
+export function buildInsights(
+  entries: InsightFoodLogEntry[],
+  start: string,
+  end: string
+): {
+  daily: DailyInsight[];
+  summary: { avgProtein: number; avgFat: number; avgCarbs: number };
+  top10: TopItem[];
+  chart: Array<{ date: string; protein: number; fat: number; carbs: number }>;
+} {
+  const days = eachDate(start, end);
+  const byDate = new Map<string, DailyInsight>();
+  for (const day of days) {
+    byDate.set(day, { date: day, protein: 0, fat: 0, carbs: 0, entries: [] });
+  }
+
+  for (const entry of entries) {
+    const bucket = byDate.get(entry.date);
+    if (!bucket) continue;
+    bucket.protein += toNum(entry.protein_g);
+    bucket.fat += toNum(entry.fat_g);
+    bucket.carbs += toNum(entry.carbs_g);
+    bucket.entries.push(entry);
+  }
+
+  for (const day of byDate.values()) {
+    day.entries.sort((a, b) => {
+      const at = `${a.eaten_at ?? ""}|${a.created_at ?? ""}`;
+      const bt = `${b.eaten_at ?? ""}|${b.created_at ?? ""}`;
+      return at.localeCompare(bt);
+    });
+  }
+
+  const dailyAsc = days.map((d) => byDate.get(d)!);
+  const dailyDesc = [...dailyAsc].reverse();
+
+  const dayCount = dailyAsc.length || 1;
+  const sumProtein = dailyAsc.reduce((acc, d) => acc + d.protein, 0);
+  const sumFat = dailyAsc.reduce((acc, d) => acc + d.fat, 0);
+  const sumCarbs = dailyAsc.reduce((acc, d) => acc + d.carbs, 0);
+
+  const topMap = new Map<string, TopItem>();
+  for (const entry of entries) {
+    const key = entry.menu_item_id
+      ? `menu:${entry.menu_item_id}`
+      : `name:${normalizeName(entry.item_name)}`;
+    const existing = topMap.get(key);
+    if (!existing) {
+      topMap.set(key, {
+        key,
+        label: entry.item_name.trim() || "(名前なし)",
+        count: 1,
+      });
+      continue;
+    }
+    existing.count += 1;
+  }
+
+  const top10 = [...topMap.values()]
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label, "ja"))
+    .slice(0, 10);
+
+  return {
+    daily: dailyDesc,
+    summary: {
+      avgProtein: sumProtein / dayCount,
+      avgFat: sumFat / dayCount,
+      avgCarbs: sumCarbs / dayCount,
+    },
+    top10,
+    chart: dailyAsc.map((d) => ({
+      date: d.date,
+      protein: d.protein,
+      fat: d.fat,
+      carbs: d.carbs,
+    })),
+  };
+}


### PR DESCRIPTION
## Summary
- `/insights` を新設し、過去7日（初期）/30日/カスタム90日で food_log を集計表示できる分析画面を追加
- 日次PFC推移グラフ、日ごとの折りたたみ記録一覧、Top10（回数）と期間JSONダウンロードを実装
- Today からの導線（設定ドロワー・この日の記録行）を追加し、戻る導線やラベル/レイアウトを調整

## Test plan
- [x] `npm run lint`
- [x] `/today` から「過去7日を見る」で `/insights` へ遷移できる
- [x] `/insights` で期間切替（7日/30日/カスタム）が動く
- [x] 日次行の折りたたみ、PFC比率バー、表レイアウト表示が崩れない
- [x] 「ダウンロード」で期間JSONが取得できる

closes #200
refs #16

Made with [Cursor](https://cursor.com)