### PR TITLE
fix: insights のビルド型エラーを修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.35.1] - 2026-04-14
+
+### Fixed
+
+- **分析画面（/insights）**: Vercel 本番ビルド時に `recharts` の型差異で TypeScript エラーになりデプロイ失敗する問題を修正した。凡例カスタムとツールチップの型互換を調整して、環境差異があってもビルドが通るようにした（[#201](https://github.com/kzkski/ketolog/pull/201)）。
+
 ## [1.35.0] - 2026-04-14
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.35.0",
+      "version": "1.35.1",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.35.0",
+  "version": "1.35.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/insights/InsightsChart.tsx
+++ b/src/app/insights/InsightsChart.tsx
@@ -10,7 +10,6 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { LegendProps } from "recharts";
 
 type Point = {
   date: string;
@@ -23,7 +22,12 @@ function dateLabel(date: string): string {
   return date.slice(5);
 }
 
-function LegendContent(props: LegendProps) {
+type LegendItem = {
+  value?: string | number;
+  color?: string;
+};
+
+function LegendContent(props: { payload?: LegendItem[] }) {
   const payload = props.payload ?? [];
   const ordered = ["P", "F", "C"]
     .map((name) => payload.find((p) => p.value === name))
@@ -58,7 +62,7 @@ export default function InsightsChart({ data }: { data: Point[] }) {
           />
           <YAxis stroke="#9ca3af" tick={{ fontSize: 11 }} />
           <Tooltip
-            formatter={(value: number) => value.toFixed(1)}
+            formatter={(value) => (typeof value === "number" ? value.toFixed(1) : String(value ?? ""))}
             labelFormatter={(label) => `${label}`}
             contentStyle={{ backgroundColor: "#111827", border: "1px solid #374151" }}
           />


### PR DESCRIPTION
## Summary
- `recharts` の型差異で Vercel 本番ビルドが落ちる問題を修正
- 凡例カスタムの props 型を互換的にし、Tooltip formatter を `undefined` 含みでも安全に処理
- リリース用に `1.35.1` へパッチ更新し、CHANGELOG を追加

## Test plan
- [x] `npm run lint`
- [x] `npm run build`


Made with [Cursor](https://cursor.com)