### PR TITLE
feat: メニュードロワー栄養素トグルの初期を1回分にする

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.36.0] - 2026-04-15
+
+### Changed
+
+- **Today / メニュー**: メニュー追加・編集ドロワーの栄養素トグル初期値を「1回分」にした。一覧と同様に「その時点の 1 回の量」を基準に入力でき、保存は従来どおり 100g 換算で記録する（[#206](https://github.com/kzkski/ketolog/issues/206)）。
+
 ## [1.35.2] - 2026-04-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.35.2",
+  "version": "1.36.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -526,7 +526,7 @@ function MenuItemDrawer({
       ? "文科省標準成分表（利用可能炭水化物・質量計）"
       : (existing?.notes ?? "")
   );
-  const [mode, setMode]       = useState<NutrientMode>("per100g");
+  const [mode, setMode]       = useState<NutrientMode>("perServing");
   const [rawP, setRawP]       = useState<string | null>(null);
   const [rawF, setRawF]       = useState<string | null>(null);
   const [rawC, setRawC]       = useState<string | null>(null);
@@ -746,7 +746,7 @@ function MenuItemDrawer({
     setServingHint(null);
     setScanError(null);
     setError(null);
-    setMode("per100g");
+    setMode("perServing");
     setRawP(null);
     setRawF(null);
     setRawC(null);


### PR DESCRIPTION
## 概要

メニュー追加・編集ドロワー（`MenuItemDrawer`）の栄養素トグル初期値を **`perServing`（1回分）** に変更した。メニュー一覧の PFC 表示（1回分基準）と入力の意味を揃える。保存形式（100g 換算の `protein_per_100g` 等）は変更しない。

## 変更内容

- `mode` の `useState` 初期値: `per100g` → `perServing`
- メニュー共有 QR 取り込みでフォームを埋めたあとの `setMode` も `perServing` に統一

## リリース

- `package.json` を **1.36.0**（マイナー）に更新
- `CHANGELOG.md` に `## [1.36.0]` を追加

## 確認

- `npm run lint` / `npm run build` 成功

closes #206

Made with [Cursor](https://cursor.com)