### PR TITLE
fix: 分析グラフのツールチップでPFCをP→F→Cの順に (#203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.36.1] - 2026-04-15
+
+### Fixed
+
+- **分析画面（/insights）**: 日次PFC推移グラフのツールチップで、系列名がアルファベット順（C→F→P）になっていた問題を修正した。P→F→C の順で表示する（[#203](https://github.com/kzkski/ketolog/issues/203)）。
+
 ## [1.36.0] - 2026-04-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.36.0",
+  "version": "1.36.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/insights/InsightsChart.tsx
+++ b/src/app/insights/InsightsChart.tsx
@@ -27,6 +27,9 @@ type LegendItem = {
   color?: string;
 };
 
+/** Recharts Tooltip の既定 itemSorter は name（アルファベット順）で、P/F/C が C→F→P と並ぶ。PFC の表示順に合わせる。 */
+const PFC_TOOLTIP_ORDER: Record<string, number> = { P: 0, F: 1, C: 2 };
+
 function LegendContent(props: { payload?: LegendItem[] }) {
   const payload = props.payload ?? [];
   const ordered = ["P", "F", "C"]
@@ -65,6 +68,7 @@ export default function InsightsChart({ data }: { data: Point[] }) {
             formatter={(value) => (typeof value === "number" ? value.toFixed(1) : String(value ?? ""))}
             labelFormatter={(label) => `${label}`}
             contentStyle={{ backgroundColor: "#111827", border: "1px solid #374151" }}
+            itemSorter={(item) => PFC_TOOLTIP_ORDER[String(item.name ?? "")] ?? 99}
           />
           <Legend content={<LegendContent />} />
           <Line type="monotone" dataKey="protein" name="P" stroke="#60a5fa" strokeWidth={2} dot={false} />


### PR DESCRIPTION
## 原因
Recharts 3 の `Tooltip` は `itemSorter` 既定が `name`（アルファベット順）のため、系列名 `P` / `F` / `C` が **C → F → P** と並び、凡例・記録画面の **P → F → C** と逆に見えていました（Issue 添付のオーバーレイはこのツールチップの想定）。

## 対応
`itemSorter` で P→F→C の順序を明示。

## バージョン
パッチ `1.36.1`

closes #203

Made with [Cursor](https://cursor.com)