### PR TITLE
fix: お気に入り星の連打レースを世代管理と直列化で防止 (#210)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.36.2] - 2026-04-15
+
+### Fixed
+
+- **Today**: お気に入り星の連打で、遅く返った非同期結果により表示が一瞬戻ったり星の状態が逆転する問題を修正した。同一メニュー項目ごとに世代管理とサーバー更新の直列化を行う（[#210](https://github.com/kzkski/ketolog/issues/210), [#204](https://github.com/kzkski/ketolog/issues/204)）。
+
 ## [1.36.1] - 2026-04-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.36.1",
+  "version": "1.36.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -2929,6 +2929,10 @@ export default function TodayClient({
   const [restaurants, setRestaurants] = useState<Restaurant[]>(initialRestaurants);
   const [menuItems, setMenuItems]     = useState<MenuItem[]>(initialMenuItems);
   const [favoriteGroups, setFavoriteGroups] = useState<FavoriteGroupPayload[]>(initialFavoriteGroups);
+  /** お気に入りトグルごとの世代。古い非同期結果で state を上書きしない。 */
+  const favoriteToggleGenRef = useRef<Map<string, number>>(new Map());
+  /** 同一 menu_item_id のサーバー更新を直列化（前段の失敗で後段を止めない）。 */
+  const favoriteToggleChainRef = useRef<Map<string, Promise<void>>>(new Map());
   const [selectedRestaurantId, setSelectedRestaurantId] = useState(() =>
     hasFavoriteEntries(initialFavoriteGroups)
       ? FAVORITES_TAB_ID
@@ -3134,47 +3138,83 @@ export default function TodayClient({
     }
   }
 
-  async function handleToggleFavorite(item: MenuItem) {
-    const was = favoriteMenuItemIds.has(item.id);
-    const previous = favoriteGroups;
+  const handleToggleFavorite = useCallback((item: MenuItem) => {
+    const id = item.id;
+    const myGen = (favoriteToggleGenRef.current.get(id) ?? 0) + 1;
+    favoriteToggleGenRef.current.set(id, myGen);
 
-    if (was) {
-      setFavoriteGroups(
-        favoriteGroups
-          .map(g => ({ ...g, entries: g.entries.filter(e => e.menu_item_id !== item.id) }))
-          .filter(g => g.entries.length > 0)
+    let snapshotBefore: FavoriteGroupPayload[] | null = null;
+    let removeFavorite = false;
+
+    setFavoriteGroups((prev) => {
+      snapshotBefore = prev;
+      const was = prev.some((g) =>
+        g.entries.some((e) => e.menu_item_id === id)
       );
-      const result = await removeMenuItemFromFavorites(item.id);
-      if (result.error) { alert(result.error); setFavoriteGroups(previous); return; }
-      if (result.data) setFavoriteGroups(result.data);
-    } else {
-      const restaurant = restaurants.find(r => r.id === item.restaurant_id);
+      if (was) {
+        removeFavorite = true;
+        return prev
+          .map((g) => ({
+            ...g,
+            entries: g.entries.filter((e) => e.menu_item_id !== id),
+          }))
+          .filter((g) => g.entries.length > 0);
+      }
+      removeFavorite = false;
+      const restaurant = restaurants.find((r) => r.id === item.restaurant_id);
       const groupName = restaurant?.name ?? "その他";
-      const existingGroup = favoriteGroups.find(g => g.name === groupName);
+      const existingGroup = prev.find((g) => g.name === groupName);
       const tempEntry = {
-        id: `temp-${item.id}`,
-        favorite_group_id: existingGroup?.id ?? `temp-group-${item.id}`,
-        menu_item_id: item.id,
+        id: `temp-${id}`,
+        favorite_group_id: existingGroup?.id ?? `temp-group-${id}`,
+        menu_item_id: id,
         display_order: existingGroup ? existingGroup.entries.length : 0,
         menu_item: item,
       };
       if (existingGroup) {
-        setFavoriteGroups(favoriteGroups.map(g =>
+        return prev.map((g) =>
           g.id === existingGroup.id ? { ...g, entries: [...g.entries, tempEntry] } : g
-        ));
-      } else {
-        setFavoriteGroups([...favoriteGroups, {
-          id: `temp-group-${item.id}`,
-          name: groupName,
-          display_order: favoriteGroups.length,
-          entries: [tempEntry],
-        }]);
+        );
       }
-      const result = await addMenuItemToFavorites(item.id);
-      if (result.error) { alert(result.error); setFavoriteGroups(previous); return; }
+      return [
+        ...prev,
+        {
+          id: `temp-group-${id}`,
+          name: groupName,
+          display_order: prev.length,
+          entries: [tempEntry],
+        },
+      ];
+    });
+
+    if (snapshotBefore === null) return;
+    const rollbackTarget = snapshotBefore;
+
+    const tail = favoriteToggleChainRef.current.get(id) ?? Promise.resolve();
+    const safeTail = tail.catch(() => {});
+
+    const work = async () => {
+      const result = removeFavorite
+        ? await removeMenuItemFromFavorites(id)
+        : await addMenuItemToFavorites(id);
+
+      if (favoriteToggleGenRef.current.get(id) !== myGen) return;
+
+      if (result.error) {
+        alert(result.error);
+        setFavoriteGroups((prev) => {
+          if (favoriteToggleGenRef.current.get(id) !== myGen) return prev;
+          return rollbackTarget;
+        });
+        return;
+      }
       if (result.data) setFavoriteGroups(result.data);
-    }
-  }
+    };
+
+    const next = safeTail.then(() => work());
+    favoriteToggleChainRef.current.set(id, next);
+    void next;
+  }, [restaurants]);
 
   // ── カート計算 ──────────────────────────────────────────────────────────────
   const cartPFC = useMemo(() => {


### PR DESCRIPTION
## 概要

お気に入りトグルを連打したとき、遅く返った `add` / `remove` の結果で `setFavoriteGroups(result.data)` が上書きし、星の表示が逆転する問題を修正した。

## 変更内容

- **世代管理**: `menu_item_id` ごとに単調増加する世代を `useRef` で保持。`await` 後に現在の世代と一致するときだけ成功時の反映・エラー時のロールバックを行う。
- **直列化**: 同一項目のサーバー更新を Promise チェーンで直列化。前段が reject しても `.catch(() => {})` で後段を止めない。

## 関連 Issue

closes #210
closes #204

Made with [Cursor](https://cursor.com)