### PR TITLE
docs: ROADMAP に Issue #54 と既存実装の関係を追記

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- **ROADMAP**: Phase 2-2 に、[Issue #54](https://github.com/kzkski/ketolog/issues/54)（最近スキャン・検索した市販品の一覧 UI）と既存の OFF／メニュー／お気に入りとの関係を追記した（[#212](https://github.com/kzkski/ketolog/pull/212)）。
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,6 +80,7 @@
 - `shared_products` キャッシュ基盤と `menu_items.shared_barcode` 参照を導入
 - スキャン結果をメニュー追加に接続（OFF 未ヒット時は手入力で `shared_products` にも登録し他ユーザーと共有。RLS 本格は [#190](https://github.com/kzkski/ketolog/issues/190)）
 - メニュー登録なしで食事ログへ記録（スナップショット）、食事タブ行右端の記録「＋」、カートの食事区分連動
+- 「最近スキャン・検索した市販品だけを一覧する」**専用 UI／データ設計**は [#54](https://github.com/kzkski/ketolog/issues/54) で検討中。現状は OFF ルックアップと `shared_products`、メニュー行の `shared_barcode`、お気に入りで再選択を補助できるが、**時系列の「最近」一覧**そのものは未実装（仕様・優先度は Issue 側で未合意）。
 
 ### 2-3 後日
 - 食材名検索（文部科学省食品成分表）


### PR DESCRIPTION
Phase 2-2 に、[Issue #54](https://github.com/kzkski/ketolog/issues/54) で検討中の「最近スキャン・検索した市販品の一覧」と、現状の OFF／メニュー／お気に入りとの関係を一文で整理した。

Related to #54

Made with [Cursor](https://cursor.com)