### PR TITLE
docs: #213 リファクタリング設計をドキュメントに反映

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,44 @@ This version has breaking changes — APIs, conventions, and file structure may 
 - ブランチ保護のバイパス操作（例: `gh pr merge --admin`）は原則禁止。通常マージ失敗時は停止し、ブロッカー確認と60〜120秒待機後の再確認を行う。必要時は実行前に理由と影響を示し、明示承認を得る。
 
 Cursor では **`.cursor/rules/github-flow.mdc`** が常時適用され、上記と同じ方針が補強される。
+
+## src/ ディレクトリ規約
+
+新しいファイルを追加する前に、以下の配置規約に従う。
+
+### today ページ内（`src/app/today/`）
+
+| フォルダ | 対象 |
+|---|---|
+| `_components/` | そのページ専用の UI コンポーネント（Next.js の private folder 規約） |
+| `_hooks/` | そのページ専用の React hooks |
+| `actions/` | Server Actions（`"use server"` 宣言付きファイル。**バレル index.ts は作らない**） |
+
+> **Server Actions の import**: `"use server"` が宣言されたファイルから**直接インポート**すること。バレル（index.ts）経由の再エクスポートは Next.js で正常に動作しない場合がある。
+>
+> ```typescript
+> // ✅ 正しい
+> import { saveMealToLog } from './actions/food-log';
+> // ❌ 避ける
+> import { saveMealToLog } from './actions';
+> ```
+
+### lib/（`src/lib/`）
+
+| フォルダ / ファイル | 対象 |
+|---|---|
+| `lib/constants/` | アプリ全体で共有する定数（`meal.ts` など） |
+| `lib/supabase/` | DB クライアントファクトリ（変更不要） |
+| `lib/*.ts` | ドメイン固有のビジネスロジック・ユーティリティ（UI に依存しない） |
+
+### 共通コンポーネント・hooks
+
+| フォルダ | 対象 |
+|---|---|
+| `components/` | 複数ページで使う共通 UI コンポーネント |
+| `hooks/` | 複数ページで使う共通 React hooks |
+
+### types/（`src/types/`）
+
+- DB テーブルの TypeScript 型定義の正は `database.ts`。新しい DB 関連の型はここに追加する
+- ページ固有の型は各コンポーネントファイルまたは `_hooks/` 内で定義してよい

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- **開発運用**: コードベース責務分割・パフォーマンス改善の設計をドキュメント化した（`AGENTS.md` / `CONTRIBUTING.md` にディレクトリ配置規約・Server Actions import ルールを追記、`ROADMAP.md` に技術的改善セクションを追加、`docs/plans/issue-213-refactor-codebase.md` を新規作成）（[#213](https://github.com/kzkski/ketolog/issues/213)）。
 - **ROADMAP**: Phase 2-2 に、[Issue #54](https://github.com/kzkski/ketolog/issues/54)（最近スキャン・検索した市販品の一覧 UI）と既存の OFF／メニュー／お気に入りとの関係を追記した（[#212](https://github.com/kzkski/ketolog/pull/212)）。
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,35 @@
 | ドキュメント | `docs/` | `docs/update-readme` |
 | リファクタリング | `refactor/` | `refactor/preset-api` |
 | 雑務・設定 | `chore/` | `chore/bump-version` |
+| テスト追加 | `test/` | `test/lib-unit` |
+
+---
+
+## ディレクトリ配置規約
+
+新しいファイルを追加する際は以下の規約に従う。詳細は [AGENTS.md](AGENTS.md) も参照。
+
+| 置き場 | 対象 |
+|---|---|
+| `src/app/<page>/_components/` | そのページ専用の UI コンポーネント |
+| `src/app/<page>/_hooks/` | そのページ専用の React hooks |
+| `src/app/<page>/actions/` | Server Actions（責務別ファイルに分割・バレル index.ts は作らない） |
+| `src/components/` | 複数ページで使う共通 UI コンポーネント |
+| `src/hooks/` | 複数ページで使う共通 React hooks |
+| `src/lib/` | ビジネスロジック・ユーティリティ（UI に依存しない pure な関数） |
+| `src/lib/constants/` | アプリ全体で共有する定数 |
+| `src/types/` | 型定義（DB スキーマ型は `database.ts` を正とする） |
+
+### Server Actions の import ルール
+
+`"use server"` が宣言されたファイルは**バレル経由でなく直接インポート**すること。
+
+```typescript
+// ✅ 正しい
+import { saveMealToLog } from './actions/food-log';
+// ❌ 避ける（バレル経由）
+import { saveMealToLog } from './actions';
+```
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -123,6 +123,18 @@
 
 ---
 
+## 技術的改善（内部品質）
+
+- **コードベースのリファクタリング**（[#213](https://github.com/kzkski/ketolog/issues/213)）
+  - `TodayClient.tsx`（4,440行）を責務別コンポーネントに段階分割（`_components/` + `_hooks/`）
+  - `actions.ts`（1,433行）をドメイン別ファイルに分割（`actions/` フォルダ）
+  - 重複定数・ユーティリティを `lib/constants/` と `lib/date.ts` に統合
+  - **Vitest** によるユニットテスト導入（`lib/` pure functions から段階的に）
+  - バンドル最適化による初期ロード改善（目標: 5秒 → 2秒以下）
+  - 詳細な実装計画: [docs/plans/issue-213-refactor-codebase.md](docs/plans/issue-213-refactor-codebase.md)
+
+---
+
 ## 公開・運用（ベータ／一般公開）
 
 機能ロードマップとは別に、**リリースゲート・法務・インフラコスト・CI/QA・第三者コンプライアンス**のチェックリストは [docs/release/README.md](docs/release/README.md) を正とする。

--- a/docs/plans/issue-213-refactor-codebase.md
+++ b/docs/plans/issue-213-refactor-codebase.md
@@ -1,0 +1,248 @@
+# Issue #213：コードベース責務分割・パフォーマンス改善 実装計画
+
+[Issue #213](https://github.com/kzkski/ketolog/issues/213) の詳細実装手順書。
+
+---
+
+## 設計方針の決定事項
+
+| 項目 | 決定 |
+|---|---|
+| コンポーネント間の状態共有 | **props 経由**（TodayClient が state を持ち、子に props として渡す） |
+| テストランナー | **Vitest**（設定軽量、ESM 対応良好、Next.js 16 + React 19 との相性が優れる） |
+| Ph-2 着手前の設計 | **状態フロー設計ドキュメントを先に作成**（`docs/plans/issue-213-today-state-design.md`） |
+| Server Actions のバレルエクスポート | **採用しない**。`"use server"` ファイルから直接インポートする |
+
+---
+
+## フェーズ一覧
+
+| フェーズ | ブランチ | 概要 |
+|---|---|---|
+| Doc | `docs/refactor-plan-213` | ドキュメント追記（本ファイルを含む） |
+| Ph-1 | `refactor/actions-and-lib` | `actions/` 分割 + `lib/constants/meal.ts` / `lib/date.ts` 新設 |
+| Ph-1b | `refactor/lib-pfc` | `lib/pfc.ts` 新設 |
+| Ph-1.5 | `test/lib-unit` | Vitest セットアップ + lib/ pure functions ユニットテスト |
+| Ph-2 設計 | `docs/today-state-design` | TodayClient 状態フロー設計ドキュメント作成 |
+| Ph-2a | `refactor/today-2a` | PfcHeader・BarcodeScanner 切り出し |
+| Ph-2b | `refactor/today-2b` | CartPanel + useMealLog 切り出し |
+| Ph-2c | `refactor/today-2c` | RestaurantPanel + MenuItemList + useRestaurantState 切り出し |
+| Ph-2d | `refactor/today-2d` | ItemDrawer + FavoritesPanel 切り出し |
+| Ph-3 | `refactor/performance` | next.config.ts 最適化・遅延化 |
+| Ph-4 | 別 Issue | コンポーネント・Server Actions テスト |
+
+> `refactor/` ・`docs/` ・`test/` ブランチは CONTRIBUTING.md 規約によりバージョン更新不要。
+
+---
+
+## Ph-1: `actions/` 分割 + `lib/` 統合
+
+### 変更ファイル
+
+| 操作 | ファイル |
+|---|---|
+| 削除 | `src/app/today/actions.ts` |
+| 新規 | `src/app/today/actions/restaurant.ts` |
+| 新規 | `src/app/today/actions/menu-item.ts` |
+| 新規 | `src/app/today/actions/food-log.ts` |
+| 新規 | `src/app/today/actions/favorites.ts` |
+| 新規 | `src/app/today/actions/import-export.ts` |
+| 新規 | `src/app/today/actions/settings.ts` |
+| 新規 | `src/lib/constants/meal.ts` |
+| 新規 | `src/lib/date.ts` |
+| 更新 | `src/app/today/TodayClient.tsx`（import パス変更のみ） |
+| 更新 | `src/app/insights/InsightsClient.tsx`（`MEAL_LABELS` を `lib/constants/meal.ts` から参照） |
+| 更新 | `src/lib/header-hint.ts`（JST 関数を `lib/date.ts` から参照） |
+| 更新 | `src/lib/insights.ts`（JST 関数を `lib/date.ts` から参照） |
+
+### 各 actions ファイルの担当関数
+
+**restaurant.ts**（`"use server"` 宣言必須）
+- `createRestaurant()`
+- `updateRestaurant()`
+- `deleteRestaurant()`
+- `reorderRestaurants()`
+- `getOrCreateSnapshotRestaurant()`
+
+**menu-item.ts**（`"use server"` 宣言必須）
+- `createMenuItem()`
+- `updateMenuItem()`
+- `deleteMenuItem()`
+- `reorderMenuItems()`
+- `setMenuItemRank()`
+
+**food-log.ts**（`"use server"` 宣言必須）
+- `saveMealToLog()`
+- `deleteFoodLogEntry()`
+- `getFoodLogForDate()`
+- `searchProductByBarcode()`
+
+**favorites.ts**（`"use server"` 宣言必須）
+- `fetchFavoriteGroupsPayloadInternal()`
+- favorite group の CRUD・並び替え
+- favorite entry の CRUD・並び替え
+
+**import-export.ts**（`"use server"` 宣言必須）
+- `importMenuFromJson()`
+- `exportMenuAsJson()`
+- QR ペイロード解析・生成のサーバー側処理
+
+**settings.ts**（`"use server"` 宣言必須）
+- `getUserSettings()`
+- `updateUserSettings()`
+- ダイエットフェーズ更新
+
+### lib/ の新規ファイル
+
+**lib/constants/meal.ts**
+```typescript
+// 現在 TodayClient.tsx と InsightsClient.tsx に重複している定数を集約
+export const MEAL_LABELS: Record<MealType, string> = { ... }
+export const MEAL_TYPES: MealType[] = [...]
+export const MEAL_TAB_STYLES: Record<MealType, { ... }> = { ... }
+```
+
+**lib/date.ts**
+```typescript
+// 現在 insights.ts と header-hint.ts に分散している JST 日付ユーティリティを統合
+export function toJstDateString(date?: Date): string { ... }
+export function addDaysJst(dateStr: string, n: number): string { ... }
+export function getTokyoHourMinute(): { hour: number; minute: number } { ... }
+export function eachDate(start: string, end: string): string[] { ... }
+```
+
+### 確認事項
+- `TodayClient.tsx` の import パスが全て更新されていること
+- `"use server"` ディレクティブが各 actions ファイルの先頭にあること
+- バレル（index.ts）を作らないこと
+- `npm run build` でエラーなし
+
+---
+
+## Ph-1b: `lib/pfc.ts` 新設
+
+### 方針
+
+`CartEntry`（カート）と `FoodLogEntry`（DB記録）は型が異なるため、単純統合は避ける。**純粋な数値計算のみ**を担い、型変換は呼び出し元に残す。
+
+```typescript
+// lib/pfc.ts
+export interface PfcValues {
+  protein: number;
+  fat: number;
+  carbs: number;
+}
+
+export interface PfcTotal extends PfcValues {}
+
+export function sumPfc(items: PfcValues[]): PfcTotal {
+  return items.reduce(
+    (acc, item) => ({
+      protein: acc.protein + item.protein,
+      fat: acc.fat + item.fat,
+      carbs: acc.carbs + item.carbs,
+    }),
+    { protein: 0, fat: 0, carbs: 0 }
+  );
+}
+```
+
+呼び出し元での型変換例:
+```typescript
+// TodayClient.tsx 側
+const total = sumPfc(cartEntries.map(e => ({ protein: e.protein * e.qty, fat: e.fat * e.qty, carbs: e.carbs * e.qty })));
+
+// insights.ts 側
+const total = sumPfc(logEntries.map(e => ({ protein: e.protein, fat: e.fat, carbs: e.carbs })));
+```
+
+---
+
+## Ph-1.5: Vitest セットアップ + ユニットテスト
+
+### セットアップ手順
+
+1. `vitest` + `@vitest/coverage-v8` をインストール
+2. `vitest.config.ts` を作成（`tsconfig.json` のパスエイリアス `@/*` を解決する設定を含む）
+3. `package.json` に `"test": "vitest"` スクリプトを追加
+
+### テスト対象ファイル（Mock 不要な pure functions）
+
+| テストファイル | 対象 |
+|---|---|
+| `src/lib/semver-compare.test.ts` | `semverCompare()` |
+| `src/lib/pfc.test.ts` | `sumPfc()` |
+| `src/lib/meal-timezone.test.ts` | `getMealTypeForTimeZone()` |
+| `src/lib/menu-item-sort.test.ts` | `compareMenuItemsForListOrder()` |
+| `src/lib/date.test.ts` | `toJstDateString()`, `addDaysJst()`, `eachDate()` |
+
+---
+
+## Ph-2 設計: TodayClient 状態フロー設計ドキュメント
+
+### 作成ファイル
+
+`docs/plans/issue-213-today-state-design.md`
+
+### 記述内容
+
+- 現在の TodayClient.tsx にある全 `useState` のリスト
+- 各 state の所有者（TodayClient に残すか、どの hook に移すか）
+- コンポーネント間の props フロー図（テキスト形式で可）
+- 各サブコンポーネントの props インターフェース（型定義案）
+
+このドキュメントを確認・承認してから Ph-2a に着手する。
+
+---
+
+## Ph-2a〜2d: TodayClient 分割
+
+### ターゲット構成
+
+```
+src/app/today/
+├── _components/
+│   ├── TodayClient.tsx        ← 300行程度に縮小
+│   ├── PfcHeader.tsx          ← Ph-2a
+│   ├── BarcodeScanner.tsx     ← Ph-2a
+│   ├── CartPanel.tsx          ← Ph-2b
+│   ├── MealTypeTabs.tsx       ← Ph-2b
+│   ├── RestaurantPanel.tsx    ← Ph-2c
+│   ├── MenuItemList.tsx       ← Ph-2c
+│   ├── ItemDrawer.tsx         ← Ph-2d
+│   └── FavoritesPanel.tsx     ← Ph-2d
+└── _hooks/
+    ├── useCart.ts             ← Ph-2b
+    ├── useMealLog.ts          ← Ph-2b
+    └── useRestaurantState.ts  ← Ph-2c
+```
+
+### 各フェーズの確認事項（共通）
+
+- `npm run build` でエラーなし
+- `/today` ページで手動操作（レストラン追加・メニュー追加・食事記録・お気に入り・QRスキャン・ドラッグ並び替え）が正常に動作すること
+
+---
+
+## Ph-3: パフォーマンス最適化
+
+### 変更内容
+
+**next.config.ts**
+```typescript
+optimizePackageImports: ['recharts', '@dnd-kit/core', '@dnd-kit/sortable'],
+```
+
+**SortableRestaurantTabs.tsx 内の dnd-kit import**
+- トップレベルの `import { ... } from '@dnd-kit/...'` を `next/dynamic` に変更
+- `RestaurantTabsLazy.tsx` の既存パターンに合わせる
+
+**ItemDrawer.tsx**
+```typescript
+const ItemDrawer = dynamic(() => import('./_components/ItemDrawer'), { ssr: false });
+```
+
+### 検証
+
+- `ANALYZE=true npm run build` で Bundle Analyzer を開き、クライアントバンドルサイズ減少を確認
+- Chrome DevTools Network タブで初期ロード時間を計測（目標: 5秒 → 2秒以下）


### PR DESCRIPTION
## Summary

closes #213 の Doc フェーズ

- `docs/plans/issue-213-refactor-codebase.md` を新規作成（フェーズ別実装手順書）
- `AGENTS.md` に `src/` ディレクトリ規約セクションを追加（`_components/` / `_hooks/` / `actions/` の配置ルール、Server Actions 直接インポート方針）
- `CONTRIBUTING.md` にディレクトリ配置規約・Server Actions import ルール・`test/` ブランチ種別を追記
- `ROADMAP.md` に技術的改善セクションを追加（#213 へのリンク付き）

## Test plan

- [ ] ドキュメントの内容が #213 の設計方針と整合していること
- [ ] CHANGELOG.md の `[Unreleased]` に追記があること
- [ ] CI（require-changelog）が通ること

https://claude.ai/code/session_01DCGdVUyaH1FNjYxVNkuhzJ