### PR TITLE
refactor: PFC 合算を sumPfc に集約（#216）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- **内部**: PFC（g）の合算を `src/lib/pfc.ts` の `sumPfc()` に集約し、Today・食事ログ取得・分析集計の重複加算を整理した（[#216](https://github.com/kzkski/ketolog/issues/216)）。
 - **Today / コード整理**: Server Actions の参照先を `src/app/today/actions/*` の責務別エントリへ分割し、食事区分定数と JST 日付ユーティリティを `src/lib/constants/meal.ts` / `src/lib/date.ts` に集約した（[#215](https://github.com/kzkski/ketolog/issues/215)）。
 - **開発運用**: コードベース責務分割・パフォーマンス改善の設計をドキュメント化した（`AGENTS.md` / `CONTRIBUTING.md` にディレクトリ配置規約・Server Actions import ルールを追記、`ROADMAP.md` に技術的改善セクションを追加、`docs/plans/issue-213-refactor-codebase.md` を新規作成）（[#213](https://github.com/kzkski/ketolog/issues/213)）。
 - **ROADMAP**: Phase 2-2 に、[Issue #54](https://github.com/kzkski/ketolog/issues/54)（最近スキャン・検索した市販品の一覧 UI）と既存の OFF／メニュー／お気に入りとの関係を追記した（[#212](https://github.com/kzkski/ketolog/pull/212)）。

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -27,6 +27,7 @@ import {
   type PhaseProfiles,
 } from "@/lib/diet-phase";
 import type { MealType } from "@/lib/meal-timezone";
+import { sumPfc, type PfcGrams } from "@/lib/pfc";
 import { isSnapshotRestaurant } from "@/lib/snapshot-restaurant";
 import { RESTAURANT_NAME_MAX_LENGTH } from "@/lib/restaurant-limits";
 import { sortMenuItemsForListOrder } from "@/lib/menu-item-sort";
@@ -3202,28 +3203,30 @@ export default function TodayClient({
 
   // ── カート計算 ──────────────────────────────────────────────────────────────
   const cartPFC = useMemo(() => {
-    let p = 0, f = 0, c = 0;
-    cart.forEach((entry) => {
+    let acc: PfcGrams = { p: 0, f: 0, c: 0 };
+    for (const entry of cart.values()) {
       const g = entry.gramsPerServing * entry.count;
-      if (entry.kind === "menu") {
-        p += (entry.item.protein_per_100g ?? 0) * g / 100;
-        f += (entry.item.fat_per_100g ?? 0) * g / 100;
-        c += (entry.item.carbs_per_100g ?? 0) * g / 100;
-      } else {
-        const v = pfcFromPer100(entry.protein_per_100g, entry.fat_per_100g, entry.carbs_per_100g, g);
-        p += v.p;
-        f += v.f;
-        c += v.c;
-      }
-    });
-    return { p, f, c };
+      const part: PfcGrams =
+        entry.kind === "menu"
+          ? {
+              p: ((entry.item.protein_per_100g ?? 0) * g) / 100,
+              f: ((entry.item.fat_per_100g ?? 0) * g) / 100,
+              c: ((entry.item.carbs_per_100g ?? 0) * g) / 100,
+            }
+          : pfcFromPer100(entry.protein_per_100g, entry.fat_per_100g, entry.carbs_per_100g, g);
+      acc = sumPfc(acc, part);
+    }
+    return acc;
   }, [cart]);
 
-  const totalPFC = {
-    p: consumedForDate.protein + cartPFC.p,
-    f: consumedForDate.fat + cartPFC.f,
-    c: consumedForDate.carbs + cartPFC.c,
-  };
+  const totalPFC = sumPfc(
+    {
+      p: consumedForDate.protein,
+      f: consumedForDate.fat,
+      c: consumedForDate.carbs,
+    },
+    cartPFC
+  );
 
   const [headerHintTimeTick, setHeaderHintTimeTick] = useState(0);
 

--- a/src/app/today/actions/food-log.ts
+++ b/src/app/today/actions/food-log.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import { sumPfc, type PfcGrams } from "@/lib/pfc";
 import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import type { FoodLogEntry, TodayConsumed } from "@/types/database";
 
@@ -77,14 +78,20 @@ export async function getFoodLogForDate(date: string): Promise<{
   if (error) return { entries: [], consumed: { protein: 0, fat: 0, carbs: 0 }, error: error.message };
 
   const entries = (data ?? []) as FoodLogEntry[];
-  const consumed = entries.reduce(
-    (acc, row) => ({
-      protein: acc.protein + (row.protein_g ?? 0),
-      fat: acc.fat + (row.fat_g ?? 0),
-      carbs: acc.carbs + (row.carbs_g ?? 0),
-    }),
-    { protein: 0, fat: 0, carbs: 0 }
+  const summed = entries.reduce<PfcGrams>(
+    (acc, row) =>
+      sumPfc(acc, {
+        p: row.protein_g ?? 0,
+        f: row.fat_g ?? 0,
+        c: row.carbs_g ?? 0,
+      }),
+    { p: 0, f: 0, c: 0 }
   );
+  const consumed: TodayConsumed = {
+    protein: summed.p,
+    fat: summed.f,
+    carbs: summed.c,
+  };
   return { entries, consumed, error: null };
 }
 

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -6,6 +6,7 @@ import { getOrCreateSnapshotRestaurant } from "./actions/restaurant";
 import { fetchFavoriteGroupsPayload } from "./actions/favorites";
 import type { FoodLogEntry, MenuItem, Restaurant, UserSettings, TodayConsumed } from "@/types/database";
 import { normalizeUserSettings } from "@/lib/diet-phase";
+import { sumPfc, type PfcGrams } from "@/lib/pfc";
 import { loadPresets } from "@/lib/presets-server";
 
 export type { PresetMeta } from "@/lib/presets-server";
@@ -63,14 +64,20 @@ export default async function TodayPage() {
   const menuItems: MenuItem[] = menuItemsRes.data ?? [];
 
   const logEntries: FoodLogEntry[] = (foodLogRes.data ?? []) as FoodLogEntry[];
-  const todayConsumed: TodayConsumed = logEntries.reduce(
-    (acc, row) => ({
-      protein: acc.protein + (row.protein_g ?? 0),
-      fat: acc.fat + (row.fat_g ?? 0),
-      carbs: acc.carbs + (row.carbs_g ?? 0),
-    }),
-    { protein: 0, fat: 0, carbs: 0 }
+  const summed = logEntries.reduce<PfcGrams>(
+    (acc, row) =>
+      sumPfc(acc, {
+        p: row.protein_g ?? 0,
+        f: row.fat_g ?? 0,
+        c: row.carbs_g ?? 0,
+      }),
+    { p: 0, f: 0, c: 0 }
   );
+  const todayConsumed: TodayConsumed = {
+    protein: summed.p,
+    fat: summed.f,
+    carbs: summed.c,
+  };
 
   const presets = loadPresets();
   const initialFavoriteGroups = favoritePayload.error ? [] : favoritePayload.data;

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,4 +1,5 @@
 import { addDaysJst, eachDate, toJstDateString } from "@/lib/date";
+import { sumPfc } from "@/lib/pfc";
 export { addDaysJst };
 
 export type InsightFoodLogEntry = {
@@ -68,9 +69,13 @@ export function buildInsights(
   for (const entry of entries) {
     const bucket = byDate.get(entry.date);
     if (!bucket) continue;
-    bucket.protein += toNum(entry.protein_g);
-    bucket.fat += toNum(entry.fat_g);
-    bucket.carbs += toNum(entry.carbs_g);
+    const merged = sumPfc(
+      { p: bucket.protein, f: bucket.fat, c: bucket.carbs },
+      { p: toNum(entry.protein_g), f: toNum(entry.fat_g), c: toNum(entry.carbs_g) }
+    );
+    bucket.protein = merged.p;
+    bucket.fat = merged.f;
+    bucket.carbs = merged.c;
     bucket.entries.push(entry);
   }
 
@@ -86,9 +91,13 @@ export function buildInsights(
   const dailyDesc = [...dailyAsc].reverse();
 
   const dayCount = dailyAsc.length || 1;
-  const sumProtein = dailyAsc.reduce((acc, d) => acc + d.protein, 0);
-  const sumFat = dailyAsc.reduce((acc, d) => acc + d.fat, 0);
-  const sumCarbs = dailyAsc.reduce((acc, d) => acc + d.carbs, 0);
+  const periodTotals = dailyAsc.reduce(
+    (acc, d) => sumPfc(acc, { p: d.protein, f: d.fat, c: d.carbs }),
+    { p: 0, f: 0, c: 0 }
+  );
+  const sumProtein = periodTotals.p;
+  const sumFat = periodTotals.f;
+  const sumCarbs = periodTotals.c;
 
   const topMap = new Map<string, TopItem>();
   for (const entry of entries) {

--- a/src/lib/pfc.ts
+++ b/src/lib/pfc.ts
@@ -1,0 +1,22 @@
+/**
+ * PFC（タンパク / 脂質 / 糖質）の gram 値を成分単位で扱う。
+ * DB や画面の `protein` / `fat` / `carbs` などとはキー名が異なるため、呼び出し側でマッピングする。
+ */
+export type PfcGrams = {
+  p: number;
+  f: number;
+  c: number;
+};
+
+/** 複数の PFC を成分ごとに合算する（純粋関数）。 */
+export function sumPfc(...parts: PfcGrams[]): PfcGrams {
+  let p = 0;
+  let f = 0;
+  let c = 0;
+  for (const part of parts) {
+    p += part.p;
+    f += part.f;
+    c += part.c;
+  }
+  return { p, f, c };
+}


### PR DESCRIPTION
## 概要

Issue #213 フェーズ 1b として、`src/lib/pfc.ts` に純粋関数 `sumPfc()` を追加し、PFC（g）の成分加算の重複を削減する。

## 変更内容

- `PfcGrams` 型（`p` / `f` / `c`）と `sumPfc()` を新設
- `TodayClient` のカート集計・確定＋カート合算、`today/page` と `getFoodLogForDate` のログ行集計、`buildInsights` の日次バケットおよび期間合計で利用（DB・画面側の `protein` / `fat` / `carbs` は呼び出し側でマッピング）

## 確認

- `npm run build` 成功

closes #216
related to #213

Made with [Cursor](https://cursor.com)