### PR TITLE
fix: お気に入りがリロードで消える不具合（保存スキップ）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,12 @@
 - **開発運用**: `CONTRIBUTING.md` / `AGENTS.md` / `.cursor/rules/github-flow.mdc` に、`gh pr merge --admin` などブランチ保護バイパス操作の原則禁止と、例外時の事前承認必須ルールを追加した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 - **開発運用**: 通常マージ失敗時の待機手順（停止→ブロッカー確認→60〜120秒待機→再確認→通常マージ再試行）を追加し、待機前に `--admin` へ進まない運用を明文化した（[#186](https://github.com/kzkski/ketolog/issues/186)）。
 
+## [1.37.1] - 2026-04-15
+
+### Fixed
+
+- **Today / お気に入り**: メニューの☆でお気に入りに追加しても、再読み込みすると消えてしまうことがあった不具合を修正した（楽観更新の直後にサーバー保存が走らない経路を `flushSync` で塞ぐ）。
+
 ## [1.37.0] - 2026-04-15
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.37.0",
+  "version": "1.37.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/_hooks/useRestaurantState.ts
+++ b/src/app/today/_hooks/useRestaurantState.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import type { DragEndEvent } from "@dnd-kit/core";
 import { arrayMove } from "@dnd-kit/sortable";
 import type {
@@ -267,45 +268,49 @@ export function useRestaurantState({
     let snapshotBefore: FavoriteGroupPayload[] | null = null;
     let removeFavorite = false;
 
-    setFavoriteGroups((prev) => {
-      snapshotBefore = prev;
-      const was = prev.some((g) =>
-        g.entries.some((e) => e.menu_item_id === id)
-      );
-      if (was) {
-        removeFavorite = true;
-        return prev
-          .map((g) => ({
-            ...g,
-            entries: g.entries.filter((e) => e.menu_item_id !== id),
-          }))
-          .filter((g) => g.entries.length > 0);
-      }
-      removeFavorite = false;
-      const restaurant = restaurants.find((r) => r.id === item.restaurant_id);
-      const groupName = restaurant?.name ?? "その他";
-      const existingGroup = prev.find((g) => g.name === groupName);
-      const tempEntry = {
-        id: `temp-${id}`,
-        favorite_group_id: existingGroup?.id ?? `temp-group-${id}`,
-        menu_item_id: id,
-        display_order: existingGroup ? existingGroup.entries.length : 0,
-        menu_item: item,
-      };
-      if (existingGroup) {
-        return prev.map((g) =>
-          g.id === existingGroup.id ? { ...g, entries: [...g.entries, tempEntry] } : g
+    // React 19 では setState の関数更新が直後の行より遅れることがあり、
+    // snapshotBefore が未設定のまま return するとサーバーへの保存がスキップされる。
+    flushSync(() => {
+      setFavoriteGroups((prev) => {
+        snapshotBefore = prev;
+        const was = prev.some((g) =>
+          g.entries.some((e) => e.menu_item_id === id)
         );
-      }
-      return [
-        ...prev,
-        {
-          id: `temp-group-${id}`,
-          name: groupName,
-          display_order: prev.length,
-          entries: [tempEntry],
-        },
-      ];
+        if (was) {
+          removeFavorite = true;
+          return prev
+            .map((g) => ({
+              ...g,
+              entries: g.entries.filter((e) => e.menu_item_id !== id),
+            }))
+            .filter((g) => g.entries.length > 0);
+        }
+        removeFavorite = false;
+        const restaurant = restaurants.find((r) => r.id === item.restaurant_id);
+        const groupName = restaurant?.name ?? "その他";
+        const existingGroup = prev.find((g) => g.name === groupName);
+        const tempEntry = {
+          id: `temp-${id}`,
+          favorite_group_id: existingGroup?.id ?? `temp-group-${id}`,
+          menu_item_id: id,
+          display_order: existingGroup ? existingGroup.entries.length : 0,
+          menu_item: item,
+        };
+        if (existingGroup) {
+          return prev.map((g) =>
+            g.id === existingGroup.id ? { ...g, entries: [...g.entries, tempEntry] } : g
+          );
+        }
+        return [
+          ...prev,
+          {
+            id: `temp-group-${id}`,
+            name: groupName,
+            display_order: prev.length,
+            entries: [tempEntry],
+          },
+        ];
+      });
     });
 
     if (snapshotBefore === null) return;


### PR DESCRIPTION
## 原因
`useRestaurantState` の `handleToggleFavorite` で、楽観更新用の `setFavoriteGroups` のコールバック内で `snapshotBefore` を代入し、その直後に `snapshotBefore === null` なら return していました。React 19 ではこの関数更新が**常に**同期的に完了するとは限らず、`return` に入ると `addMenuItemToFavorites` / `removeMenuItemFromFavorites` が**一度も呼ばれない**経路があり得ます（画面上は楽観表示だけ残り、DB には書かれない）。

## 対応
`react-dom` の `flushSync` で楽観更新の `setFavoriteGroups` を同期的に確定させ、`snapshotBefore` と `removeFavorite` が外側の非同期処理に渡る前に必ず設定されるようにしました。

## リリース
- `CHANGELOG.md` に `## [1.37.1]` を追加
- パッチバージョンを `1.37.1` に更新（別コミット）

## 確認
- `npm run build` / `npm test` 成功

Made with [Cursor](https://cursor.com)