### PR TITLE
refactor: Ph-3 初期ロード最適化（#223）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### Changed
 
+- **パフォーマンス（Today）**: `next.config.ts` に `experimental.optimizePackageImports` を追加し、メニュー追加・編集ドロワー（`MenuItemDrawer`）を `next/dynamic` で遅延読み込みするようにした。お店タブの並べ替えは従来どおり `RestaurantTabsLazy` 経由で dnd-kit を遅延読み込み（[#223](https://github.com/kzkski/ketolog/issues/223)）。
 - **内部（Today）**: メニュー追加・編集ドロワーを `ItemDrawer.tsx`（`MenuItemDrawer`）に、お気に入りタブの空状態案内を `FavoritesPanel.tsx` に切り出した。メニュー PFC 換算は `src/lib/menu-item-pfc.ts` に集約。お気に入りの表示・トグル・ドロワー操作の挙動は従来どおり（[#222](https://github.com/kzkski/ketolog/issues/222)）。
 - **内部（Today）**: `TodayClient` からレストランタブ列を `RestaurantPanel` に、メニュー一覧・成分表パネル・店ごとの JSON 導線を `MenuItemList` に、店・メニュー・お気に入りタブ周りの状態と処理を `useRestaurantState` に切り出した。並び替え・編集・追加などの挙動は従来どおり（[#221](https://github.com/kzkski/ketolog/issues/221)）。
 - **内部（Today）**: `TodayClient` からカート UI（折りたたみバー・展開パネル・記録ボタン）を `CartPanel` に、日付切替・ログ一覧・削除・再取得の状態と処理を `useMealLog` に切り出した。画面の挙動は従来どおり（[#220](https://github.com/kzkski/ketolog/issues/220)）。

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,14 @@ const withBundleAnalyzer = bundleAnalyzer({
 const { version } = require("./package.json") as { version: string };
 
 const nextConfig: NextConfig = {
+  experimental: {
+    optimizePackageImports: [
+      "recharts",
+      "@dnd-kit/core",
+      "@dnd-kit/sortable",
+      "@dnd-kit/utilities",
+    ],
+  },
   env: {
     NEXT_PUBLIC_APP_VERSION: version,
     // Vercel はビルド時に VERCEL_GIT_COMMIT_SHA を渡す。ダッシュボードに

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import dynamic from "next/dynamic";
 import {
   useState,
   useMemo,
@@ -29,14 +30,6 @@ import { pfcGramsFromMenuItem, pfcGramsFromNullablePer100 } from "@/lib/menu-ite
 import { isSnapshotRestaurant } from "@/lib/snapshot-restaurant";
 import { RESTAURANT_NAME_MAX_LENGTH } from "@/lib/restaurant-limits";
 import { createClient } from "@/lib/supabase/client";
-import {
-  addMenuItem,
-  addMenuItemWithManualSharedProduct,
-  deleteMenuItem,
-  lookupSharedProductByBarcode,
-  updateMenuItem,
-  type MenuItemUpdate,
-} from "./actions/menu-item";
 import { addRestaurant } from "./actions/restaurant";
 import {
   importMenuItemsToRestaurant,
@@ -51,21 +44,20 @@ import {
   type SaveItem,
 } from "./actions/food-log";
 import { updateUserSettings } from "./actions/settings";
-import type { SharedProduct } from "@/types/database";
-import {
-  MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES,
-  SHARED_PRODUCT_SOURCE_MANUAL_ENTRY,
-} from "@/lib/shared-product-source";
 import { computeHeaderHintText, getActiveHintSlot } from "@/lib/header-hint";
 import { useAppUpdateBanner } from "@/hooks/useAppUpdateBanner";
-import { buildMenuQrPayloadJson, parseMenuSharePayload } from "@/lib/menu-qr-payload";
 import { MEAL_LABELS, MEAL_TAB_STYLES } from "@/lib/constants/meal";
 import { PfcHeader } from "./_components/PfcHeader";
-import { BarcodeScanner } from "./_components/BarcodeScanner";
 import { CartPanel, type CartEntry } from "./_components/CartPanel";
 import { MenuItemList } from "./_components/MenuItemList";
 import { RestaurantPanel } from "./_components/RestaurantPanel";
-import { MenuItemDrawer, type ItemDrawerState } from "./_components/ItemDrawer";
+import type { ItemDrawerState, MenuItemDrawerProps } from "./_components/ItemDrawer";
+
+const MenuItemDrawer = dynamic<MenuItemDrawerProps>(
+  () =>
+    import("./_components/ItemDrawer").then((m) => ({ default: m.MenuItemDrawer })),
+  { ssr: false }
+);
 import { formatNavDate, useMealLog } from "./_hooks/useMealLog";
 import {
   FAVORITES_TAB_ID,
@@ -1354,9 +1346,7 @@ export default function TodayClient({
   const {
     restaurants,
     menuItems,
-    selectedRestaurantId,
     setSelectedRestaurantId,
-    compositionTargetRestaurantId,
     setCompositionTargetRestaurantId,
     lastRealRestaurantTabIdRef,
     deletingRestaurant,

--- a/src/app/today/_components/ItemDrawer.tsx
+++ b/src/app/today/_components/ItemDrawer.tsx
@@ -69,25 +69,7 @@ function toServing(val: string, gramsStr: string): string {
   return parseFloat((v * g / 100).toFixed(2)).toString();
 }
 
-export function MenuItemDrawer({
-  state,
-  existingGroupNames,
-  onClose,
-  onSaved,
-  onDeleted,
-  mealTypeForLog,
-  logDate,
-  snapshotRestaurantId,
-  onAfterSnapshotLog,
-  onSnapshotCart,
-  registerTargets,
-  registerTargetRestaurantId,
-  onRegisterTargetChange,
-  registerTargetRestaurantName,
-  canRegisterMenu,
-  registerDisabledReason,
-  onOpenStandardFoodSearch,
-}: {
+export type MenuItemDrawerProps = {
   state: ItemDrawerState;
   existingGroupNames: string[];
   onClose: () => void;
@@ -115,7 +97,27 @@ export function MenuItemDrawer({
   registerTargetRestaurantId: string;
   onRegisterTargetChange: (restaurantId: string) => void;
   onOpenStandardFoodSearch?: () => void;
-}) {
+};
+
+export function MenuItemDrawer({
+  state,
+  existingGroupNames,
+  onClose,
+  onSaved,
+  onDeleted,
+  mealTypeForLog,
+  logDate,
+  snapshotRestaurantId,
+  onAfterSnapshotLog,
+  onSnapshotCart,
+  registerTargets,
+  registerTargetRestaurantId,
+  onRegisterTargetChange,
+  registerTargetRestaurantName,
+  canRegisterMenu,
+  registerDisabledReason,
+  onOpenStandardFoodSearch,
+}: MenuItemDrawerProps) {
   const MEMO_MIN_ROWS = 3;
   const MEMO_MAX_ROWS = 10;
   const isEdit = state.kind === "edit";


### PR DESCRIPTION
## 概要
Issue #223（#213 Ph-3）対応。初期ロード向けにバンドル分割とパッケージ import 最適化を行います。

## 変更内容
- `next.config.ts` に `experimental.optimizePackageImports` を追加（`recharts`、`@dnd-kit/core`、`@dnd-kit/sortable`、`@dnd-kit/utilities`）
- `TodayClient` で `MenuItemDrawer` を `next/dynamic`（`ssr: false`）により遅延読み込み
- `MenuItemDrawerProps` を `ItemDrawer.tsx` からエクスポートし、`dynamic` の型付けを維持
- `ItemDrawer` 移管後に不要になっていた `TodayClient` の import / 分割代入を整理

## dnd-kit について
お店タブの並べ替えは既存の `RestaurantTabsLazy` により `SortableRestaurantTabs`（dnd-kit）を遅延 import 済みのため、追加のコード変更はしていません。

## 検証
- `npm run lint` / `npm run build` / `npm test`
- `ANALYZE=true npm run build`（Turbopack のため analyzer レポートは出ず警告のみ。従来どおり `npm run analyze` で webpack 解析可）

closes #223

Made with [Cursor](https://cursor.com)