### PR TITLE
chore: 1.38.0 リリース整理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ## [Unreleased]
 
+## [1.38.0] - 2026-04-15
+
 ### Added
 
 - **開発**: Vitest を導入し、`npm test` で `src/lib` のユニットテスト（日付・PFC・セマンティックバージョン比較・ダイエットフェーズ・食事区分・メニュー一覧ソートなど）を実行できるようにした（[#217](https://github.com/kzkski/ketolog/issues/217)）。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.37.1",
+  "version": "1.38.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Summary
- `package.json` のバージョンを `1.37.1` から `1.38.0` に更新
- `CHANGELOG.md` の `## [Unreleased]` に溜まっていた項目を `## [1.38.0] - 2026-04-15` へ移動
- `Unreleased` は空に戻し、次回リリース分を積み上げる状態に整理

## Test plan
- [x] `npm test`

## Note
- `refactor/docs/test` 系の #213 ラインは互換性を壊す変更ではないため、メジャーではなくマイナー更新とした
- related to #213


Made with [Cursor](https://cursor.com)