### PR TITLE
docs: ステージング手順とベータ向けIssue追跡を整理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- **ドキュメント / リリース運用**: ステージング環境（Supabase + Vercel Preview + OAuth Redirect）の手順を `docs/release/staging-setup.md` に追加し、`docs/release/README.md`・`beta-checklist.md`・`operations-and-costs.md`・`quality-and-ci.md`・`ROADMAP.md`・`README.md` と GitHub Issue [#250](https://github.com/kzkski/ketolog/issues/250)〜[#253](https://github.com/kzkski/ketolog/issues/253) を整合させた。
 - **ドキュメント**: `ROADMAP.md` を公開向けのマイルストーン構成（v1/v2/v3）へ再編し、市場調査は公開サマリー中心に整理した。詳細な戦略レポートは公開リポジトリ管理の対象外にした。
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- **ドキュメント / リリース運用**: ステージング環境（Supabase + Vercel Preview + OAuth Redirect）の手順を `docs/release/staging-setup.md` に追加し、`docs/release/README.md`・`beta-checklist.md`・`operations-and-costs.md`・`quality-and-ci.md`・`ROADMAP.md`・`README.md` と GitHub Issue [#250](https://github.com/kzkski/ketolog/issues/250)〜[#253](https://github.com/kzkski/ketolog/issues/253) を整合させた。
+- **ドキュメント / リリース運用**: ステージング環境（Supabase + Vercel Preview + OAuth Redirect）の手順を `docs/release/staging-setup.md` に追加し、`docs/release/README.md`・`beta-checklist.md`・`operations-and-costs.md`・`quality-and-ci.md`・`ROADMAP.md`・`README.md` と GitHub Issue [#250](https://github.com/kzkski/ketolog/issues/250)〜[#253](https://github.com/kzkski/ketolog/issues/253)・[#255](https://github.com/kzkski/ketolog/issues/255) を整合させた。
 - **ドキュメント**: `ROADMAP.md` を公開向けのマイルストーン構成（v1/v2/v3）へ再編し、市場調査は公開サマリー中心に整理した。詳細な戦略レポートは公開リポジトリ管理の対象外にした。
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 外食・自炊・コンビニのPFC（タンパク質・脂質・糖質）をリアルタイムに記録・管理する。市販の汎用ダイエットアプリでは対応しにくい「外食メニューの登録」「PFC目標の柔軟な設定」「JSONプリセットによるデータ共有」に対応。
 
-**注意**: 現時点では **一般向けには公開していません**（テスト用途のデプロイ）。認証・公開範囲の詳細と今後の予定は [ROADMAP.md](ROADMAP.md) を参照。ベータ・一般公開に向けた運用チェックリストは [docs/release/README.md](docs/release/README.md)（開発者向け）。市場調査は公開サマリーを [docs/research/README.md](docs/research/README.md) に記載しています。
+**注意**: 現時点では **一般向けには公開していません**（テスト用途のデプロイ）。認証・公開範囲の詳細と今後の予定は [ROADMAP.md](ROADMAP.md) を参照。ベータ・一般公開に向けた運用チェックリストは [docs/release/README.md](docs/release/README.md)（開発者向け）。**ステージング Supabase と Vercel Preview** の準備手順は [docs/release/staging-setup.md](docs/release/staging-setup.md)。市場調査は公開サマリーを [docs/research/README.md](docs/research/README.md) に記載しています。
 
 ## 主な機能
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,7 +50,8 @@
 - Ketolog単体の記録体験を磨きつつ、将来の Ketovisor 連携価値（分析支援）の前提データ品質を高める。
 
 ### 優先トラック
-- 品質ゲート強化（CI: lint/test/build/typecheck、回帰テスト拡張）
+- 品質ゲート強化（CI: lint/test/build/typecheck、回帰テスト拡張）— [#253](https://github.com/kzkski/ketolog/issues/253)
+- ステージング（本番と別 Supabase + Vercel Preview をステージング向け）— [docs/release/staging-setup.md](docs/release/staging-setup.md) / [#250](https://github.com/kzkski/ketolog/issues/250)
 - ベータ運用手順の固定（障害対応、ロールバック、サポート導線）
 - 公開チェックリスト整備（法務・コスト・コンプライアンス）
 - Ketovisor 連携向けデータ契約の固定（`contractVersion`・スキーマ・互換ポリシー）

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -13,7 +13,7 @@
 
 | 状況 | 読む順 |
 |------|--------|
-| **ベータを切りたい** | [beta-checklist.md](beta-checklist.md) → [quality-and-ci.md](quality-and-ci.md)（CI 最低ライン）→ [sentry-alerts-slack.md](sentry-alerts-slack.md)（アラート）→ [sentry-operations-runbook.md](sentry-operations-runbook.md)（発報時 Runbook）→ 必要なら [third-party-compliance.md](third-party-compliance.md) |
+| **ベータを切りたい** | [staging-setup.md](staging-setup.md)（Preview + ステージング DB）→ [beta-checklist.md](beta-checklist.md) → [quality-and-ci.md](quality-and-ci.md)（CI 最低ライン）→ [sentry-alerts-slack.md](sentry-alerts-slack.md)（アラート）→ [sentry-operations-runbook.md](sentry-operations-runbook.md)（発報時 Runbook）→ 必要なら [third-party-compliance.md](third-party-compliance.md) |
 | **一般公開（GA）を切りたい** | [general-availability-checklist.md](general-availability-checklist.md) → [operations-and-costs.md](operations-and-costs.md) → [quality-and-ci.md](quality-and-ci.md) → [v3-native-feasibility.md](v3-native-feasibility.md)（事前検討） |
 | **課金・枠の見直しだけ** | [operations-and-costs.md](operations-and-costs.md)（表の数値は公式を再確認すること） |
 | **テスト・CI を整備する** | [quality-and-ci.md](quality-and-ci.md) |
@@ -24,6 +24,7 @@
 | ファイル | 内容 |
 |----------|------|
 | [beta-checklist.md](beta-checklist.md) | 限定的ユーザー増：アクセス制御、認証設定、ベータ法務、運用、Ketovisor 連携向けデータ契約。§9 は参考（非ブロッキング） |
+| [staging-setup.md](staging-setup.md) | ステージング Supabase + Vercel Preview（ステージング DB 向け）+ OAuth Redirect 手順、任意の staging 用 `db push` CI |
 | [general-availability-checklist.md](general-availability-checklist.md) | GA：アカウント削除、濫用対策、本番法務、コミュニケーション |
 | [operations-and-costs.md](operations-and-costs.md) | Vercel / Supabase の枠、課金検討の目安、信頼性 |
 | [quality-and-ci.md](quality-and-ci.md) | CI 現状、lint/build、テストの段階、E2E（Issue #59）、リリース前確認 |
@@ -48,6 +49,6 @@
 
 ## メンテナンス
 
-- **更新頻度が高い**: `beta-checklist.md`（ゲート方式）、`quality-and-ci.md`（CI 変更時）。
+- **更新頻度が高い**: `beta-checklist.md`（ゲート方式）、`staging-setup.md`（Preview・ステージング手順）、`quality-and-ci.md`（CI 変更時）。
 - **四半期やトラフィック変化時**: `operations-and-costs.md`（文内の「最終確認日」を更新）。
 - Cursor の計画ファイル（`.cursor/plans/` 等）は作業用。**確定した方針は本ディレクトリへ反映**し、リポジトリを正本とする。

--- a/docs/release/beta-checklist.md
+++ b/docs/release/beta-checklist.md
@@ -12,6 +12,7 @@
 
 - **利用者制限**: [`src/proxy.ts`](../../src/proxy.ts) でログイン後メールが `@civictech.tv` でないユーザーは `signOut` し、[`src/app/login/page.tsx`](../../src/app/login/page.tsx) に専用エラーメッセージがある。**ベータ／一般開放の最優先はこのゲートの設計変更**。
 - **認証 UI**: メール／パスワードと Google OAuth は既に [`signup`](../../src/app/signup/page.tsx) / [`login`](../../src/app/login/page.tsx) にある。実際に誰が入れるかは **Supabase 側のプロバイダ設定** と **アプリ側の追加チェック** の組み合わせ。
+- **ステージング**: 本番とは別の Supabase にマイグレーションを当て、Vercel Preview をその DB に向ける手順は [staging-setup.md](staging-setup.md)（[#250](https://github.com/kzkski/ketolog/issues/250)）。OAuth は Supabase の Redirect URL に `https://*-.vercel.app/**` を含める等、[公式の Redirect URLs](https://supabase.com/docs/guides/auth/redirect-urls) に従う。
 - **データ削除**: `auth.users` 削除時にユーザー行は `ON DELETE CASCADE`（[`supabase/migrations/20260211120000_baseline.sql`](../../supabase/migrations/20260211120000_baseline.sql)）。**アプリから Auth ユーザーを削除するフローは別途 GA 向けに [general-availability-checklist.md](general-availability-checklist.md) を参照**。
 - **エクスポート**: 設定から全データ JSON ダウンロードあり（[`TodayClient.tsx`](../../src/app/today/TodayClient.tsx) 設定ドロワー）。持ち出しは可能だが「アカウント削除」とは別。
 - **共有キャッシュ**: `shared_products` の RLS は認証ユーザーがキャッシュ書き込み可能。OFF 未ヒット時の手動登録（[#191](https://github.com/kzkski/ketolog/issues/191)）を除き、**書き込みポリシー本格の見直しは [Issue #190](https://github.com/kzkski/ketolog/issues/190)**。利用者増に伴う論点は [general-availability-checklist.md](general-availability-checklist.md) と [Issue #2](https://github.com/kzkski/ketolog/issues/2)。
@@ -38,20 +39,20 @@ flowchart LR
 **Tracking**
 - Status: Not started
 - Track: v2-1
-- Tracking Issue: TBD
+- Tracking Issue: [#251](https://github.com/kzkski/ketolog/issues/251)
 - Owner: TBD
-- DoD: ドメイン固定（`@civictech.tv`）依存を外し、ベータ許可方式を1つに確定して本番で有効化できる。
+- DoD: ドメイン固定（`@civictech.tv`）依存を外し、ベータ許可方式を1つに確定して本番で有効化できる（許可リストと招待コードの併用などは #251 で決め、実装する）。
 
 ## 2. 登録・認証（実装＋ Supabase ダッシュボード）
 
-- **Redirect URL**: 本番 URL を Supabase Auth（Google 含む）の許可リストに登録。
+- **Redirect URL**: 本番 URL を Supabase Auth（Google 含む）の許可リストに登録。**Vercel Preview を使う場合**は `https://*-.vercel.app/**` を追加し、アプリの `redirectTo` を `VERCEL_URL` / `SITE_URL` で組み立てる（[staging-setup.md](staging-setup.md)、[Supabase Redirect URLs](https://supabase.com/docs/guides/auth/redirect-urls)）。
 - **メール確認**: ベータでは「確認メール必須」にするとスパム登録が減りやすい。
 - **ログイン画面文言**: 「civictech 専用」から **ベータ参加者向け説明**へ差し替え（[`login/page.tsx`](../../src/app/login/page.tsx)）。
 
 **Tracking**
 - Status: Not started
 - Track: v2-1
-- Tracking Issue: TBD
+- Tracking Issue: [#252](https://github.com/kzkski/ketolog/issues/252)
 - Owner: TBD
 - DoD: メール/Google の導線と Supabase 設定が一致し、対象ユーザーが想定どおりログインできる。
 
@@ -63,7 +64,7 @@ flowchart LR
 **Tracking**
 - Status: Not started
 - Track: 共通
-- Tracking Issue: TBD
+- Tracking Issue: [#252](https://github.com/kzkski/ketolog/issues/252)（§2 と同一 Issue で進め、PR は分割してよい）
 - Owner: TBD
 - DoD: 規約/プライバシーのページとUI導線が実装され、同意の取得方式が明文化されている。
 
@@ -84,7 +85,7 @@ flowchart LR
 **Tracking**
 - Status: In progress
 - Track: 共通
-- Tracking Issue: TBD
+- Tracking Issue: [#166](https://github.com/kzkski/ketolog/issues/166)（Sentry・アラート・Slack）。ヘルスルート実装・経緯は [#170](https://github.com/kzkski/ketolog/issues/170)。
 - Owner: TBD
 - DoD: `/api/health`・定期監視・アラート運用・問い合わせ導線が本番前提で確認済みである。
 
@@ -95,7 +96,7 @@ flowchart LR
 **Tracking**
 - Status: Not started
 - Track: 共通
-- Tracking Issue: TBD
+- Tracking Issue: [#2](https://github.com/kzkski/ketolog/issues/2)（OFF・`shared_products`・第三者コンプライアンス全体）
 - Owner: TBD
 - DoD: OFF 利用条件・連絡先・User-Agent 運用が現行実装と一致している。
 
@@ -117,9 +118,9 @@ flowchart LR
 **Tracking**
 - Status: Not started
 - Track: 共通
-- Tracking Issue: TBD
+- Tracking Issue: [#253](https://github.com/kzkski/ketolog/issues/253)
 - Owner: TBD
-- DoD: PR で品質ゲート（最低 `lint` + `test` + `build`）が自動実行される。
+- DoD: PR で品質ゲート（最低 `lint` + `test` + `build` + `typecheck`）が自動実行される。
 
 ## 8. Ketovisor 連携向けデータ契約（実装）
 
@@ -152,6 +153,7 @@ v2-2（連携ベータ）で JSON エクスポートを分析に使う前提と�
 
 ## フェーズ横断（ベータ前後で進めてよいこと）
 
+- ステージング Supabase と Vercel Preview の向き先は [staging-setup.md](staging-setup.md)（[#250](https://github.com/kzkski/ketolog/issues/250)）。
 - 新設する `ALLOWED_*` や `BETA_MODE` を [`.env.example`](../../.env.example) と README に追記。
 - ROADMAP と README の Phase 2-2 表現の整合（[CONTRIBUTING.md](../../CONTRIBUTING.md) に従う）。
 

--- a/docs/release/beta-checklist.md
+++ b/docs/release/beta-checklist.md
@@ -96,7 +96,7 @@ flowchart LR
 **Tracking**
 - Status: Not started
 - Track: 共通
-- Tracking Issue: [#2](https://github.com/kzkski/ketolog/issues/2)（OFF・`shared_products`・第三者コンプライアンス全体）
+- Tracking Issue: [#255](https://github.com/kzkski/ketolog/issues/255)（ベータ前棚卸し）。方針の出自は完了済み [#2](https://github.com/kzkski/ketolog/issues/2)。
 - Owner: TBD
 - DoD: OFF 利用条件・連絡先・User-Agent 運用が現行実装と一致している。
 

--- a/docs/release/operations-and-costs.md
+++ b/docs/release/operations-and-costs.md
@@ -23,7 +23,7 @@
 - **ダウンタイム・ポーズを避けたい**、**PITR・長期バックアップ**、**サポート・ログ保持**を伸ばしたい。
 - **ステージング + 本番 +（E2E 用など）**で無料の **2 プロジェクト**を超える → 別オーガナイゼーション分離か有料化の判断。
 
-関連イシュー: [#72](https://github.com/kzkski/ketolog/issues/72)（マイグレーション／ベースライン・環境複製の文脈）。
+関連イシュー: [#72](https://github.com/kzkski/ketolog/issues/72)（マイグレーション／ベースライン・環境複製の文脈）。**本番 + ステージング**の2プロジェクト運用の手順は [staging-setup.md](staging-setup.md)（[#250](https://github.com/kzkski/ketolog/issues/250)）。
 
 ## Vercel（Hobby vs Pro）
 

--- a/docs/release/quality-and-ci.md
+++ b/docs/release/quality-and-ci.md
@@ -77,6 +77,6 @@ CI で `npm test` は実行できているが、`lint` / `build` / `typecheck` �
 
 - Status: Not started
 - Track: 共通
-- Tracking Issue: TBD
+- Tracking Issue: [#253](https://github.com/kzkski/ketolog/issues/253)
 - Owner: TBD
 - DoD: PR で `test` `lint` `build` `typecheck` が実行され、リリース前手動チェックの運用記録が残る。

--- a/docs/release/staging-setup.md
+++ b/docs/release/staging-setup.md
@@ -1,0 +1,71 @@
+# ステージング環境の準備（Supabase + Vercel Preview）
+
+本番とは別の Supabase プロジェクトにマイグレーションを当て、**Vercel の Preview デプロイがそのステージング DB を向く**ようにする手順の正本。ベータ前のリハーサル、OAuth を含む動作確認、本番マイグレーション前の検証に使う。
+
+関連: [operations-and-costs.md](operations-and-costs.md)（無料枠2プロジェクト）、[beta-checklist.md](beta-checklist.md)（登録・認証）、[quality-and-ci.md](quality-and-ci.md)（テスト用 DB）。マイグレーション履歴の整理は [#72](https://github.com/kzkski/ketolog/issues/72)。
+
+## 目的
+
+- **`main` にマージする前**に、リポジトリの `supabase/migrations/` を**本番に近い環境**へ適用し、アプリと RLS を確認する。
+- Vercel の **Preview を再度有効化**し、**プレビュー URL が変わっても OAuth が通る**ようにする（Supabase の Redirect URL ワイルドカード）。
+- 本番の [`prod-db-migrate.yml`](../../.github/workflows/prod-db-migrate.yml) の運用（`main` マージ後の本番 `db push`）は維持する。
+
+## 前提
+
+- Supabase の**無料枠はオーケあたりプロジェクト数に上限がある**（目安は2。詳細は [operations-and-costs.md](operations-and-costs.md) と[公式の Billing](https://supabase.com/docs/guides/platform/billing-on-supabase)）。
+- **本番用とステージング用でプロジェクトを分ける**と、無料2枠をほぼ使い切る。E2E 専用の3つ目が必要になったら別オーガまたは有料の判断が出る（[quality-and-ci.md](quality-and-ci.md)）。
+
+## 手順 1: ステージング用 Supabase プロジェクト
+
+1. Supabase で新規プロジェクトを作成（例: `ketolog-staging`）。リージョンは本番に合わせると差分が減る。
+2. ローカルからリンクし、マイグレーションを適用する。
+   - `npx supabase login`
+   - `npx supabase link --project-ref <staging の Project ref>`
+   - `npx supabase db push`（リポジトリの [`supabase/migrations/`](../../supabase/migrations/) が正本）
+3. **Auth（URL Configuration）**（ステージングダッシュボード）
+   - **Site URL**: 運用方針に合わせて設定する（固定の staging ドメインを使うならその URL。プレビューのみなら本番 URL でもよいが、メールテンプレの挙動は [Supabase の案内](https://supabase.com/docs/guides/auth/redirect-urls)に従い確認する）。
+   - **Redirect URLs** に少なくとも次を追加する。
+     - `http://localhost:3000/**`（ローカル）
+     - **`https://*-.vercel.app/**`**（Vercel Preview 用。公式: [Redirect URLs — Vercel preview URLs](https://supabase.com/docs/guides/auth/redirect-urls)）
+     - カスタムドメインの Preview を使う場合は、そのオリジンも明示的に追加する。
+4. **Google OAuth 等を使う場合**
+   - Google Cloud の OAuth クライアントに、**ステージング Supabase** の `https://<staging-ref>.supabase.co/auth/v1/callback` を**本番用コールバックとは別に**承認済みリダイレクト URI として追加する（プロジェクト ref が異なるため）。
+5. ステージングの **`NEXT_PUBLIC_SUPABASE_URL`** と **`NEXT_PUBLIC_SUPABASE_ANON_KEY`** を控える（Vercel の Preview 環境変数に使う）。
+
+## 手順 2: Vercel（Preview をステージング DB に向ける）
+
+1. プロジェクト設定で **デプロイプレビュー（Preview）を有効化**する（無効化している場合）。
+2. **Settings → Environment Variables** で、**Preview** 環境にのみ次を設定する。
+   - `NEXT_PUBLIC_SUPABASE_URL` … ステージングの URL
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY` … ステージングの anon key
+3. **Production** 環境の同一名は**本番 Supabase のまま**にし、誤って Preview と共有しない。
+4. OAuth の `redirectTo` は、本番では `NEXT_PUBLIC_SITE_URL`、Preview では Vercel が注入する `VERCEL_URL` を使うなど、[Supabase の `getURL()` 例](https://supabase.com/docs/guides/auth/redirect-urls)に沿って組み立てる（コード変更が必要な場合は実装 Issue で追う）。
+
+## 手順 3: 動作確認（最小チェックリスト）
+
+- [ ] 任意の PR の Preview URL で、メールまたは Google のログインが最後まで通る。
+- [ ] 本番 URL のデプロイが、引き続き本番 Supabase を向いている。
+- [ ] ステージングに本番の個人データを入れない（必要なら匿名化した少量のみ）。
+
+## 手順 4: GitHub Actions（任意・次の実装）
+
+本番の [`prod-db-migrate.yml`](../../.github/workflows/prod-db-migrate.yml) に対し、**ステージング専用**のワークフローを追加する案。
+
+- **トリガー**: `workflow_dispatch` を必須にし、必要なら `pull_request`（paths: `supabase/migrations/**`）はノイズとコストを見てから。
+- **Secrets 例**: `STAGING_SUPABASE_PROJECT_REF`、`SUPABASE_ACCESS_TOKEN`（本番と共用可）、必要なら `STAGING_DATABASE_URL`（バックアップを取る場合）。
+- **手順**: checkout → setup-cli → `supabase link`（staging ref）→ `supabase db push`（本番 workflow と同型）。
+
+運用ルールの例: **ステージングで `db push` 成功と Preview で smoke を確認してから `main` にマージする**。
+
+## 未決定事項（ドキュメントに残す）
+
+次は Issue または運用メモで決める。
+
+- **プレビューごとに staging に自動 `db push` するか**、**マージ直前に手動だけか**。
+- **`*.vercel.app` を Redirect に含める広さ**と、**固定 staging ブランチ＋カスタムドメインだけに絞るか**のトレードオフ。
+- **ベータ参加者向けの許可リスト＋招待コード**（[beta-checklist.md](beta-checklist.md) セクション1）の実装と、ステージング上での検証の順序。
+
+## Tracking（実装・インフラ作業）
+
+- **Tracking Issue**: [#250](https://github.com/kzkski/ketolog/issues/250)（インフラ・Vercel・Supabase ダッシュボード・任意 GHA）
+- ベータゲート全体は [beta-checklist.md](beta-checklist.md)。アクセス制御 [#251](https://github.com/kzkski/ketolog/issues/251)、認証・法務 [#252](https://github.com/kzkski/ketolog/issues/252)、CI 強化 [#253](https://github.com/kzkski/ketolog/issues/253)。

--- a/docs/release/staging-setup.md
+++ b/docs/release/staging-setup.md
@@ -68,4 +68,4 @@
 ## Tracking（実装・インフラ作業）
 
 - **Tracking Issue**: [#250](https://github.com/kzkski/ketolog/issues/250)（インフラ・Vercel・Supabase ダッシュボード・任意 GHA）
-- ベータゲート全体は [beta-checklist.md](beta-checklist.md)。アクセス制御 [#251](https://github.com/kzkski/ketolog/issues/251)、認証・法務 [#252](https://github.com/kzkski/ketolog/issues/252)、CI 強化 [#253](https://github.com/kzkski/ketolog/issues/253)。
+- ベータゲート全体は [beta-checklist.md](beta-checklist.md)。アクセス制御 [#251](https://github.com/kzkski/ketolog/issues/251)、認証・法務 [#252](https://github.com/kzkski/ketolog/issues/252)、CI 強化 [#253](https://github.com/kzkski/ketolog/issues/253)、OFF 棚卸し [#255](https://github.com/kzkski/ketolog/issues/255)。


### PR DESCRIPTION
## 概要
ベータ展開に向けた合意内容を `docs/release/staging-setup.md` に手順として正本化し、既存チェックリストと ROADMAP / README を整合した。

## 新規・更新ドキュメント
- **新規** [`docs/release/staging-setup.md`](docs/release/staging-setup.md): Supabase ステージング、Vercel Preview をステージング DB に向ける、Auth Redirect（`*.vercel.app`）、任意の staging 用 `db push` CI
- [`docs/release/README.md`](docs/release/README.md): 読む順・一覧・メンテ頻度
- [`docs/release/beta-checklist.md`](docs/release/beta-checklist.md): Tracking Issue を #251〜#253 / #255 / #166 に紐づけ、Redirect URL とステージング前提を追記
- [`docs/release/operations-and-costs.md`](docs/release/operations-and-costs.md)、[`docs/release/quality-and-ci.md`](docs/release/quality-and-ci.md)、[`ROADMAP.md`](ROADMAP.md)、[`README.md`](README.md)、[`CHANGELOG.md`](CHANGELOG.md)

## GitHub Issue
- 新規: [#250](https://github.com/kzkski/ketolog/issues/250) ステージング整備、[#251](https://github.com/kzkski/ketolog/issues/251) アクセス制御、[#252](https://github.com/kzkski/ketolog/issues/252) 認証・法務、[#253](https://github.com/kzkski/ketolog/issues/253) CI lint/build/typecheck、[#255](https://github.com/kzkski/ketolog/issues/255) OFF 棚卸し
- 既存 [#72](https://github.com/kzkski/ketolog/issues/72) / [#166](https://github.com/kzkski/ketolog/issues/166) にコメントで関連付け

Refs #250
Refs #251
Refs #252
Refs #253
Refs #255