### PR TITLE
fix: today初期ペイロードを軽量化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.38.6] - 2026-04-20
+
+### Fixed
+
+- **Today / 初期ロード**: `/today` の初期データ取得で `select('*')` をやめ、必要列に限定した。あわせてお気に入り取得時の `menu_items(*)` ネストを廃止し、初期ペイロードの重複を削減した（[#256](https://github.com/kzkski/ketolog/issues/256)）。
+
 ## [1.38.5] - 2026-04-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.38.5",
+  "version": "1.38.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/_hooks/useRestaurantState.ts
+++ b/src/app/today/_hooks/useRestaurantState.ts
@@ -46,7 +46,7 @@ function firstRestaurantIdWithFavoriteMenu(
   const withFavorite = new Set<string>();
   for (const g of groups) {
     for (const e of g.entries) {
-      withFavorite.add(e.menu_item.restaurant_id);
+      if (e.menu_item) withFavorite.add(e.menu_item.restaurant_id);
     }
   }
   return tabRestaurants.find((r) => withFavorite.has(r.id))?.id;
@@ -355,11 +355,13 @@ export function useRestaurantState({
             .sort((x, y) => x.display_order - y.display_order)
             .map((e) => {
               const live = menuItems.find((m) => m.id === e.menu_item_id) ?? e.menu_item;
+              if (!live) return null;
               const rname = restaurantNameById.get(live.restaurant_id) ?? "お店";
               const gn = live.group_name?.trim();
               originByItemId[live.id] = gn ? `${rname} · ${gn}` : rname;
               return live;
-            });
+            })
+            .filter((item): item is MenuItem => item !== null);
           return {
             sectionKey: `favg:${g.id}`,
             groupName: g.name,
@@ -450,6 +452,7 @@ export function useRestaurantState({
           ...g,
           entries: g.entries.filter((e) => {
             const it = menuItems.find((m) => m.id === e.menu_item_id) ?? e.menu_item;
+            if (!it) return false;
             return it.restaurant_id !== rid;
           }),
         }))

--- a/src/app/today/actions/favorites.ts
+++ b/src/app/today/actions/favorites.ts
@@ -5,7 +5,6 @@ import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import type {
   FavoriteEntryPayload,
   FavoriteGroupPayload,
-  MenuItem,
 } from "@/types/database";
 
 async function fetchFavoriteGroupsPayloadInternal(
@@ -23,8 +22,7 @@ async function fetchFavoriteGroupsPayloadInternal(
         id,
         favorite_group_id,
         menu_item_id,
-        display_order,
-        menu_items (*)
+        display_order
       )
     `
     )
@@ -42,7 +40,6 @@ async function fetchFavoriteGroupsPayloadInternal(
         favorite_group_id: e.favorite_group_id as string,
         menu_item_id: e.menu_item_id as string,
         display_order: e.display_order as number,
-        menu_item: e.menu_items as MenuItem,
       }))
       .sort((a, b) => a.display_order - b.display_order);
     return {

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -19,11 +19,20 @@ export default async function TodayPage() {
 
   const [settingsRes, restaurantsRes, menuItemsRes, foodLogRes, favoritePayload, snapshotRestaurant] =
     await Promise.all([
-      supabase.from("user_settings").select("*").eq("user_id", user.id).maybeSingle(),
-      supabase.from("restaurants").select("*").eq("user_id", user.id),
+      supabase
+        .from("user_settings")
+        .select("diet_phase, phase_profiles")
+        .eq("user_id", user.id)
+        .maybeSingle(),
+      supabase
+        .from("restaurants")
+        .select("id, name, category, order_count, display_order")
+        .eq("user_id", user.id),
       supabase
         .from("menu_items")
-        .select("*")
+        .select(
+          "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, standard_food_code, created_at"
+        )
         .eq("user_id", user.id)
         .order("rank")
         .order("name")
@@ -31,7 +40,7 @@ export default async function TodayPage() {
         .order("id"),
       supabase
         .from("food_log")
-        .select("*")
+        .select("id, date, meal_type, item_name, grams, protein_g, fat_g, carbs_g, source, menu_item_id")
         .eq("user_id", user.id)
         .eq("date", today)
         .order("created_at", { ascending: true }),

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -39,7 +39,7 @@ export type FavoriteEntryPayload = {
   favorite_group_id: string;
   menu_item_id: string;
   display_order: number;
-  menu_item: MenuItem;
+  menu_item?: MenuItem;
 };
 
 /** ユーザー別お気に入りグループ（店名など任意のラベル） */


### PR DESCRIPTION
## Summary
- `/today` 初期ロードの Supabase クエリを `select('*')` から必要列指定へ変更し、初期 RSC/HTML ペイロードを削減
- お気に入り取得の `favorite_entries(menu_items(*))` を廃止し、`menu_items` の重複ペイロードを除去
- `FavoriteEntryPayload` を `menu_item` 任意にし、`useRestaurantState` 側で未同梱時でも安全に解決できるよう調整
- `CHANGELOG.md` に `1.38.6` を追加し、`package.json` を `1.38.6` に更新

## Test plan
- [x] `npm run lint -- src/app/today/page.tsx src/app/today/actions/favorites.ts src/app/today/_hooks/useRestaurantState.ts src/types/database.ts`
- [x] `npm test`
- [ ] 本番/プレビューで `/today` の Network 計測（Responseサイズ / Content Download / LCP）を Before/After 比較

Made with [Cursor](https://cursor.com)