### PR TITLE
fix: todayメニュー取得の本番互換フォールバックを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.38.7] - 2026-04-20
+
+### Fixed
+
+- **Today / 本番互換性**: `/today` の初期取得クエリで、古いスキーマに `display_order` / `standard_food_code` が存在しない場合のフォールバックを追加した。列限定のまま互換運用できるようにし、本番でメニュー一覧が空になる回帰を防止した。
+
 ## [1.38.6] - 2026-04-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.38.6",
+  "version": "1.38.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -11,6 +11,55 @@ import { loadPresets } from "@/lib/presets-server";
 
 export type { PresetMeta } from "@/lib/presets-server";
 
+function isMissingColumnError(error: { message?: string } | null | undefined): boolean {
+  if (!error?.message) return false;
+  const msg = error.message.toLowerCase();
+  return msg.includes("column") && msg.includes("does not exist");
+}
+
+async function fetchRestaurantsForToday(
+  supabase: Awaited<ReturnType<typeof getSupabaseAuthForRequest>>["supabase"],
+  userId: string
+) {
+  const primary = await supabase
+    .from("restaurants")
+    .select("id, name, category, order_count, display_order")
+    .eq("user_id", userId);
+  if (!isMissingColumnError(primary.error)) return primary;
+
+  // Older schema fallback: display_order is unavailable.
+  return supabase.from("restaurants").select("id, name, category, order_count").eq("user_id", userId);
+}
+
+async function fetchMenuItemsForToday(
+  supabase: Awaited<ReturnType<typeof getSupabaseAuthForRequest>>["supabase"],
+  userId: string
+) {
+  const primary = await supabase
+    .from("menu_items")
+    .select(
+      "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, standard_food_code, created_at"
+    )
+    .eq("user_id", userId)
+    .order("rank")
+    .order("name")
+    .order("created_at", { ascending: true })
+    .order("id");
+  if (!isMissingColumnError(primary.error)) return primary;
+
+  // Older schema fallback: standard_food_code is unavailable.
+  return supabase
+    .from("menu_items")
+    .select(
+      "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, created_at"
+    )
+    .eq("user_id", userId)
+    .order("rank")
+    .order("name")
+    .order("created_at", { ascending: true })
+    .order("id");
+}
+
 export default async function TodayPage() {
   const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) redirect("/login");
@@ -24,20 +73,8 @@ export default async function TodayPage() {
         .select("diet_phase, phase_profiles")
         .eq("user_id", user.id)
         .maybeSingle(),
-      supabase
-        .from("restaurants")
-        .select("id, name, category, order_count, display_order")
-        .eq("user_id", user.id),
-      supabase
-        .from("menu_items")
-        .select(
-          "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, standard_food_code, created_at"
-        )
-        .eq("user_id", user.id)
-        .order("rank")
-        .order("name")
-        .order("created_at", { ascending: true })
-        .order("id"),
+      fetchRestaurantsForToday(supabase, user.id),
+      fetchMenuItemsForToday(supabase, user.id),
       supabase
         .from("food_log")
         .select("id, date, meal_type, item_name, grams, protein_g, fat_g, carbs_g, source, menu_item_id")


### PR DESCRIPTION
## Summary
- `/today` の初期クエリで、`restaurants.display_order` が無い環境向けフォールバックを追加
- `/today` の初期クエリで、`menu_items.standard_food_code` が無い環境向けフォールバックを追加
- 列限定による軽量化は維持しつつ、スキーマ差異で `menuItems` が空になる回帰を回避
- `CHANGELOG.md` に `1.38.7` を追加し、`package.json` を `1.38.7` に更新

## Test plan
- [x] `npm run lint -- src/app/today/page.tsx`
- [x] `npm test`
- [ ] 本番で `/today` を再確認し、登録済みメニューが表示されること

Made with [Cursor](https://cursor.com)