### PR TITLE
feat: today初期ロードを店舗単位の段階取得に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.39.0] - 2026-04-20
+
+### Changed
+
+- **Today / 初期ロード最適化**: `/today` で全店舗メニューを初回一括取得せず、初期表示に必要な最小データのみを先に読み込むようにした。店舗タブを開いたタイミングで該当店舗のメニューを遅延取得し、取得中表示・エラー時の再試行導線を追加した（[#257](https://github.com/kzkski/ketolog/issues/257)）。
+
 ## [1.38.7] - 2026-04-20
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.38.7",
+  "version": "1.39.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1313,6 +1313,7 @@ function RestaurantRenameSheet({
 interface Props {
   restaurants: Restaurant[];
   menuItems: MenuItem[];
+  initialLoadedRestaurantIds: string[];
   initialFavoriteGroups: FavoriteGroupPayload[];
   settings: UserSettings;
   todayConsumed: TodayConsumed;
@@ -1326,6 +1327,7 @@ interface Props {
 export default function TodayClient({
   restaurants: initialRestaurants,
   menuItems: initialMenuItems,
+  initialLoadedRestaurantIds,
   initialFavoriteGroups,
   settings,
   todayConsumed,
@@ -1395,10 +1397,14 @@ export default function TodayClient({
     registerManualRestaurant,
     registerImportedRestaurant,
     registerAdditionalMenuItems,
+    selectedRestaurantMenuLoading,
+    selectedRestaurantMenuError,
+    retryLoadSelectedRestaurantMenu,
   } = useRestaurantState({
     initialRestaurants,
     initialMenuItems,
     initialFavoriteGroups,
+    initialLoadedRestaurantIds,
   });
   const [cart, setCart]             = useState<Map<string, CartEntry>>(new Map());
   const [mealType, setMealType]     = useState<MealType>(initialMealType);
@@ -1734,8 +1740,11 @@ export default function TodayClient({
 
   useEffect(() => {
     if (headerCenterIsAppUpdate) return;
-    setAppUpdateDialogOpen(false);
-    setAppUpdateApplying(false);
+    const id = window.setTimeout(() => {
+      setAppUpdateDialogOpen(false);
+      setAppUpdateApplying(false);
+    }, 0);
+    return () => window.clearTimeout(id);
   }, [headerCenterIsAppUpdate]);
 
   return (
@@ -1992,6 +2001,9 @@ export default function TodayClient({
               downloadRestaurantJson(selectedRestaurant, menuItems);
             }
           }}
+          isSelectedRestaurantMenuLoading={selectedRestaurantMenuLoading}
+          selectedRestaurantMenuError={selectedRestaurantMenuError}
+          onRetryLoadSelectedRestaurantMenu={() => void retryLoadSelectedRestaurantMenu()}
         />
 
         {/* カート: sm+ は従来どおりインライン展開。未満は折りたたみバー＋展開時オーバーレイ（メニュー領域を確保） */}

--- a/src/app/today/_components/MenuItemList.tsx
+++ b/src/app/today/_components/MenuItemList.tsx
@@ -37,6 +37,9 @@ export type MenuItemListProps = {
   onOpenImportMenuItems: () => void;
   onDeleteRestaurant: () => void;
   onDownloadRestaurantJson: () => void;
+  isSelectedRestaurantMenuLoading: boolean;
+  selectedRestaurantMenuError: string | null;
+  onRetryLoadSelectedRestaurantMenu: () => void;
 };
 
 export function MenuItemList({
@@ -66,7 +69,15 @@ export function MenuItemList({
   onOpenImportMenuItems,
   onDeleteRestaurant,
   onDownloadRestaurantJson,
+  isSelectedRestaurantMenuLoading,
+  selectedRestaurantMenuError,
+  onRetryLoadSelectedRestaurantMenu,
 }: MenuItemListProps) {
+  const isNormalRestaurantTab =
+    Boolean(selectedRestaurantIdResolved) &&
+    selectedRestaurantIdResolved !== FAVORITES_TAB_ID &&
+    selectedRestaurantIdResolved !== MEXT_COMPOSITION_TAB_ID;
+
   return (
     <div className="flex-1 overflow-y-auto [scrollbar-gutter:stable]">
       {selectedRestaurantIdResolved === MEXT_COMPOSITION_TAB_ID ? (
@@ -79,6 +90,23 @@ export function MenuItemList({
         />
       ) : (
         <>
+          {isNormalRestaurantTab && selectedRestaurantMenuError && (
+            <div className="mx-4 mt-4 rounded-lg border border-amber-500/30 bg-amber-500/10 p-3">
+              <p className="text-xs text-amber-200">{selectedRestaurantMenuError}</p>
+              <button
+                type="button"
+                onClick={onRetryLoadSelectedRestaurantMenu}
+                className="mt-2 rounded-md border border-amber-300/50 px-2.5 py-1 text-xs text-amber-100 hover:bg-amber-500/20"
+              >
+                再試行
+              </button>
+            </div>
+          )}
+          {isNormalRestaurantTab && isSelectedRestaurantMenuLoading && menuGroups.every((g) => g.items.length === 0) && (
+            <p className="text-center text-gray-500 text-base sm:text-sm py-8">
+              メニューを読み込み中...
+            </p>
+          )}
           <MenuGroupCollapseSession
             key={menuGroupCollapseSessionKey}
             selectedRestaurantIdResolved={selectedRestaurantIdResolved}
@@ -217,7 +245,9 @@ export function MenuItemList({
             selectedRestaurantIdResolved === FAVORITES_TAB_ID && <FavoritesPanel />}
           {menuGroups.every((g) => g.items.length === 0) &&
             selectedRestaurantIdResolved &&
-            selectedRestaurantIdResolved !== FAVORITES_TAB_ID && (
+            selectedRestaurantIdResolved !== FAVORITES_TAB_ID &&
+            !isSelectedRestaurantMenuLoading &&
+            !selectedRestaurantMenuError && (
               <p className="text-center text-gray-500 text-base sm:text-sm py-8">
                 メニューがまだありません
               </p>

--- a/src/app/today/_hooks/useRestaurantState.ts
+++ b/src/app/today/_hooks/useRestaurantState.ts
@@ -15,6 +15,7 @@ import {
   addMenuItemToFavorites,
   removeMenuItemFromFavorites,
 } from "../actions/favorites";
+import { fetchMenuItemsForRestaurant } from "../actions/menu-item";
 import {
   deleteRestaurant,
   reorderRestaurants,
@@ -76,17 +77,24 @@ type UseRestaurantStateParams = {
   initialRestaurants: Restaurant[];
   initialMenuItems: MenuItem[];
   initialFavoriteGroups: FavoriteGroupPayload[];
+  initialLoadedRestaurantIds: string[];
 };
 
 export function useRestaurantState({
   initialRestaurants,
   initialMenuItems,
   initialFavoriteGroups,
+  initialLoadedRestaurantIds,
 }: UseRestaurantStateParams) {
   const [restaurants, setRestaurants] = useState<Restaurant[]>(initialRestaurants);
   const [menuItems, setMenuItems] = useState<MenuItem[]>(initialMenuItems);
+  const loadedRestaurantIdsRef = useRef<Set<string>>(new Set(initialLoadedRestaurantIds));
+  const loadingRestaurantIdsRef = useRef<Set<string>>(new Set());
+  const [loadingRestaurantIds, setLoadingRestaurantIds] = useState<Record<string, boolean>>({});
   const [favoriteGroups, setFavoriteGroups] =
     useState<FavoriteGroupPayload[]>(initialFavoriteGroups);
+  const [, setMenuLoadTick] = useState(0);
+  const [menuLoadErrorByRestaurantId, setMenuLoadErrorByRestaurantId] = useState<Record<string, string>>({});
   /** お気に入りトグルごとの世代。古い非同期結果で state を上書きしない。 */
   const favoriteToggleGenRef = useRef<Map<string, number>>(new Map());
   /** 同一 menu_item_id のサーバー更新を直列化（前段の失敗で後段を止めない）。 */
@@ -217,6 +225,18 @@ export function useRestaurantState({
   const selectedRestaurant = restaurants.find(
     (r) => r.id === selectedRestaurantIdResolved
   );
+  const selectedRestaurantMenuLoading = Boolean(
+    selectedRestaurantIdResolved &&
+      selectedRestaurantIdResolved !== FAVORITES_TAB_ID &&
+      selectedRestaurantIdResolved !== MEXT_COMPOSITION_TAB_ID &&
+      loadingRestaurantIds[selectedRestaurantIdResolved]
+  );
+  const selectedRestaurantMenuError =
+    selectedRestaurantIdResolved &&
+    selectedRestaurantIdResolved !== FAVORITES_TAB_ID &&
+    selectedRestaurantIdResolved !== MEXT_COMPOSITION_TAB_ID
+      ? menuLoadErrorByRestaurantId[selectedRestaurantIdResolved] ?? null
+      : null;
 
   const tabRestaurantIds = useMemo(
     () => tabRestaurants.map((r) => r.id),
@@ -228,6 +248,73 @@ export function useRestaurantState({
     for (const r of restaurants) m.set(r.id, r.name);
     return m;
   }, [restaurants]);
+
+  const ensureRestaurantMenuLoaded = useCallback(async (restaurantId: string) => {
+    if (!restaurantId) return;
+    if (loadingRestaurantIdsRef.current.has(restaurantId)) return;
+    if (loadedRestaurantIdsRef.current.has(restaurantId)) return;
+
+    loadingRestaurantIdsRef.current.add(restaurantId);
+    setLoadingRestaurantIds((prev) => ({ ...prev, [restaurantId]: true }));
+    setMenuLoadErrorByRestaurantId((prev) => {
+      if (!prev[restaurantId]) return prev;
+      const next = { ...prev };
+      delete next[restaurantId];
+      return next;
+    });
+    setMenuLoadTick((n) => n + 1);
+
+    const result = await fetchMenuItemsForRestaurant(restaurantId);
+    loadingRestaurantIdsRef.current.delete(restaurantId);
+    setLoadingRestaurantIds((prev) => {
+      if (!prev[restaurantId]) return prev;
+      const next = { ...prev };
+      delete next[restaurantId];
+      return next;
+    });
+
+    if (result.error) {
+      setMenuLoadErrorByRestaurantId((prev) => ({
+        ...prev,
+        [restaurantId]: result.error ?? "メニューの取得に失敗しました",
+      }));
+      setMenuLoadTick((n) => n + 1);
+      return;
+    }
+
+    loadedRestaurantIdsRef.current.add(restaurantId);
+    setMenuItems((prev) => {
+      const others = prev.filter((item) => item.restaurant_id !== restaurantId);
+      return sortMenuItemsForListOrder([...others, ...(result.data ?? [])]);
+    });
+    setMenuLoadTick((n) => n + 1);
+  }, []);
+
+  const retryLoadSelectedRestaurantMenu = useCallback(async () => {
+    if (
+      !selectedRestaurantIdResolved ||
+      selectedRestaurantIdResolved === FAVORITES_TAB_ID ||
+      selectedRestaurantIdResolved === MEXT_COMPOSITION_TAB_ID
+    ) {
+      return;
+    }
+    loadedRestaurantIdsRef.current.delete(selectedRestaurantIdResolved);
+    await ensureRestaurantMenuLoaded(selectedRestaurantIdResolved);
+  }, [ensureRestaurantMenuLoaded, selectedRestaurantIdResolved]);
+
+  useEffect(() => {
+    if (
+      !selectedRestaurantIdResolved ||
+      selectedRestaurantIdResolved === FAVORITES_TAB_ID ||
+      selectedRestaurantIdResolved === MEXT_COMPOSITION_TAB_ID
+    ) {
+      return;
+    }
+    const tid = window.setTimeout(() => {
+      void ensureRestaurantMenuLoaded(selectedRestaurantIdResolved);
+    }, 0);
+    return () => window.clearTimeout(tid);
+  }, [selectedRestaurantIdResolved, ensureRestaurantMenuLoaded]);
 
   const favoriteMenuItemIds = useMemo(() => {
     const s = new Set<string>();
@@ -405,6 +492,7 @@ export function useRestaurantState({
   const menuGroupCollapseSessionKey = `${selectedRestaurantIdResolved}\0${collapsibleMenuSectionKeys.join("\0")}`;
 
   const applyMenuItemSaved = useCallback((saved: MenuItem) => {
+    loadedRestaurantIdsRef.current.add(saved.restaurant_id);
     setMenuItems((prev) => {
       const idx = prev.findIndex((m) => m.id === saved.id);
       const next =
@@ -443,6 +531,20 @@ export function useRestaurantState({
       return;
     }
     const rid = selectedRestaurant.id;
+    loadedRestaurantIdsRef.current.delete(rid);
+    loadingRestaurantIdsRef.current.delete(rid);
+    setLoadingRestaurantIds((prev) => {
+      if (!prev[rid]) return prev;
+      const next = { ...prev };
+      delete next[rid];
+      return next;
+    });
+    setMenuLoadErrorByRestaurantId((prev) => {
+      if (!prev[rid]) return prev;
+      const next = { ...prev };
+      delete next[rid];
+      return next;
+    });
     const next = restaurants.filter((r) => r.id !== rid);
     setRestaurants(next);
     setMenuItems((prev) => prev.filter((m) => m.restaurant_id !== rid));
@@ -470,6 +572,7 @@ export function useRestaurantState({
   }, []);
 
   const registerImportedRestaurant = useCallback((restaurant: Restaurant, items: MenuItem[]) => {
+    loadedRestaurantIdsRef.current.add(restaurant.id);
     setRestaurants((prev) => sortRestaurants([...prev, restaurant]));
     setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
     setSelectedRestaurantId(restaurant.id);
@@ -477,6 +580,9 @@ export function useRestaurantState({
   }, []);
 
   const registerAdditionalMenuItems = useCallback((items: MenuItem[]) => {
+    for (const item of items) {
+      loadedRestaurantIdsRef.current.add(item.restaurant_id);
+    }
     setMenuItems((prev) => sortMenuItemsForListOrder([...prev, ...items]));
     setShowImportMenuItems(false);
   }, []);
@@ -507,6 +613,9 @@ export function useRestaurantState({
     resolvedCompositionTargetId,
     menuAddRestaurantId,
     selectedRestaurant,
+    selectedRestaurantMenuLoading,
+    selectedRestaurantMenuError,
+    retryLoadSelectedRestaurantMenu,
     restaurantNameById,
     favoriteMenuItemIds,
     openRestaurantTabMenu,

--- a/src/app/today/actions/menu-item.ts
+++ b/src/app/today/actions/menu-item.ts
@@ -16,6 +16,10 @@ const OFF_USER_AGENT =
   process.env.OFF_USER_AGENT ??
   `Ketolog/${process.env.NEXT_PUBLIC_APP_VERSION ?? "dev"} (${OFF_DEFAULT_CONTACT})`;
 const SHARED_PRODUCT_TTL_MS = 1000 * 60 * 60 * 24 * 180; // 180日
+const MENU_ITEM_SELECT_WITH_STANDARD_FOOD_CODE =
+  "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, standard_food_code, created_at";
+const MENU_ITEM_SELECT_LEGACY =
+  "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, created_at";
 
 function normalizeBarcode(raw: string): string {
   return raw.replace(/[^\d]/g, "").trim();
@@ -38,11 +42,56 @@ function parseServingSizeGrams(servingSize: string | undefined): number | null {
   return Number.isFinite(grams) && grams > 0 ? grams : null;
 }
 
+function isMissingColumnError(error: { message?: string } | null | undefined): boolean {
+  if (!error?.message) return false;
+  const msg = error.message.toLowerCase();
+  return msg.includes("column") && msg.includes("does not exist");
+}
+
 export type BarcodeLookupResult = {
   status: "ok" | "not_found" | "error";
   product: SharedProduct | null;
   error: string | null;
 };
+
+export async function fetchMenuItemsForRestaurant(
+  restaurantId: string
+): Promise<{ data: MenuItem[]; error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { data: [], error: "認証が必要です" };
+
+  const primary = await supabase
+    .from("menu_items")
+    .select(MENU_ITEM_SELECT_WITH_STANDARD_FOOD_CODE)
+    .eq("user_id", user.id)
+    .eq("restaurant_id", restaurantId)
+    .order("rank")
+    .order("name")
+    .order("created_at", { ascending: true })
+    .order("id");
+
+  if (!isMissingColumnError(primary.error)) {
+    return {
+      data: (primary.data ?? []) as MenuItem[],
+      error: primary.error?.message ?? null,
+    };
+  }
+
+  const fallback = await supabase
+    .from("menu_items")
+    .select(MENU_ITEM_SELECT_LEGACY)
+    .eq("user_id", user.id)
+    .eq("restaurant_id", restaurantId)
+    .order("rank")
+    .order("name")
+    .order("created_at", { ascending: true })
+    .order("id");
+
+  return {
+    data: (fallback.data ?? []) as MenuItem[],
+    error: fallback.error?.message ?? null,
+  };
+}
 
 async function fetchOffProduct(barcode: string): Promise<SharedProduct | null> {
   const url = `${OFF_API_BASE}/api/v2/product/${barcode}.json?fields=code,product_name,brands,nutriments`;

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from "next/navigation";
 import TodayClient from "./TodayClient";
 import { getOrCreateSnapshotRestaurant } from "./actions/restaurant";
 import { fetchFavoriteGroupsPayload } from "./actions/favorites";
+import { fetchMenuItemsForRestaurant } from "./actions/menu-item";
 import type { FoodLogEntry, MenuItem, Restaurant, UserSettings, TodayConsumed } from "@/types/database";
 import { normalizeUserSettings } from "@/lib/diet-phase";
 import { sumPfc, type PfcGrams } from "@/lib/pfc";
@@ -31,42 +32,13 @@ async function fetchRestaurantsForToday(
   return supabase.from("restaurants").select("id, name, category, order_count").eq("user_id", userId);
 }
 
-async function fetchMenuItemsForToday(
-  supabase: Awaited<ReturnType<typeof getSupabaseAuthForRequest>>["supabase"],
-  userId: string
-) {
-  const primary = await supabase
-    .from("menu_items")
-    .select(
-      "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, standard_food_code, created_at"
-    )
-    .eq("user_id", userId)
-    .order("rank")
-    .order("name")
-    .order("created_at", { ascending: true })
-    .order("id");
-  if (!isMissingColumnError(primary.error)) return primary;
-
-  // Older schema fallback: standard_food_code is unavailable.
-  return supabase
-    .from("menu_items")
-    .select(
-      "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, created_at"
-    )
-    .eq("user_id", userId)
-    .order("rank")
-    .order("name")
-    .order("created_at", { ascending: true })
-    .order("id");
-}
-
 export default async function TodayPage() {
   const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) redirect("/login");
 
   const today = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
 
-  const [settingsRes, restaurantsRes, menuItemsRes, foodLogRes, favoritePayload, snapshotRestaurant] =
+  const [settingsRes, restaurantsRes, foodLogRes, favoritePayload, snapshotRestaurant] =
     await Promise.all([
       supabase
         .from("user_settings")
@@ -74,7 +46,6 @@ export default async function TodayPage() {
         .eq("user_id", user.id)
         .maybeSingle(),
       fetchRestaurantsForToday(supabase, user.id),
-      fetchMenuItemsForToday(supabase, user.id),
       supabase
         .from("food_log")
         .select("id, date, meal_type, item_name, grams, protein_g, fat_g, carbs_g, source, menu_item_id")
@@ -106,8 +77,17 @@ export default async function TodayPage() {
   });
 
   const initialMealType = getMealTypeForTimeZone(new Date(), "Asia/Tokyo");
-
-  const menuItems: MenuItem[] = menuItemsRes.data ?? [];
+  const initialFavoriteGroups = favoritePayload.error ? [] : favoritePayload.data;
+  const hasFavoriteEntries = initialFavoriteGroups.some((group) => group.entries.length > 0);
+  const snapshotRestaurantId = snapshotRestaurant.data?.id ?? "";
+  const firstVisibleRestaurantId =
+    restaurants.find((restaurant) => restaurant.id !== snapshotRestaurantId)?.id ?? "";
+  const initialMenuRestaurantId = hasFavoriteEntries ? "" : firstVisibleRestaurantId;
+  const initialMenuItemsRes = initialMenuRestaurantId
+    ? await fetchMenuItemsForRestaurant(initialMenuRestaurantId)
+    : { data: [] as MenuItem[], error: null };
+  const menuItems: MenuItem[] = initialMenuItemsRes.data ?? [];
+  const initialLoadedRestaurantIds = initialMenuRestaurantId ? [initialMenuRestaurantId] : [];
 
   const logEntries: FoodLogEntry[] = (foodLogRes.data ?? []) as FoodLogEntry[];
   const summed = logEntries.reduce<PfcGrams>(
@@ -126,13 +106,13 @@ export default async function TodayPage() {
   };
 
   const presets = loadPresets();
-  const initialFavoriteGroups = favoritePayload.error ? [] : favoritePayload.data;
 
   return (
     <div className="flex flex-col min-h-dvh h-dvh bg-gray-950 w-full">
       <TodayClient
         restaurants={restaurants}
         menuItems={menuItems}
+        initialLoadedRestaurantIds={initialLoadedRestaurantIds}
         initialFavoriteGroups={initialFavoriteGroups}
         settings={settings}
         todayConsumed={todayConsumed}
@@ -140,7 +120,7 @@ export default async function TodayPage() {
         initialLogEntries={logEntries}
         presets={presets}
         initialMealType={initialMealType}
-        snapshotRestaurantId={snapshotRestaurant.data?.id ?? ""}
+        snapshotRestaurantId={snapshotRestaurantId}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- `/today` の初期ロードを再設計し、初回は選択中タブに必要な最小データのみを取得、店舗メニューはタブ選択時に遅延取得するように変更
- 店舗メニューの遅延取得に `loading / error / retry` UI を追加し、店舗単位キャッシュで同一セッション内の再訪体感を改善
- `CHANGELOG.md` に 1.39.0 の変更点を追加し、`package.json` を 1.39.0 に更新

closes #257

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [ ] `/today` を開き、初期表示で全店舗メニューが一括取得されないことを確認
- [ ] 店舗タブ切替時に対象店舗メニューが遅延表示されることを確認
- [ ] 通信失敗時にエラー表示と「再試行」が機能することを確認


Made with [Cursor](https://cursor.com)