### PR TITLE
feat: お気に入り初期表示をクライアント遅延取得に変更

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.40.0] - 2026-04-20
+
+### Changed
+
+- **Today / 初期ロード最適化**: `/today` の初期サーバー取得からお気に入り取得を外し、初回描画後にクライアントで自動遅延取得する方式へ変更した。初期表示（お気に入りタブ）では「お気に入りを読み込んでいます...」を表示し、失敗時は再試行できるようにした（[#261](https://github.com/kzkski/ketolog/issues/261)）。
+
 ## [1.39.0] - 2026-04-20
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1400,6 +1400,9 @@ export default function TodayClient({
     selectedRestaurantMenuLoading,
     selectedRestaurantMenuError,
     retryLoadSelectedRestaurantMenu,
+    favoriteGroupsLoading,
+    favoriteGroupsError,
+    retryLoadFavoriteGroups,
   } = useRestaurantState({
     initialRestaurants,
     initialMenuItems,
@@ -2004,6 +2007,9 @@ export default function TodayClient({
           isSelectedRestaurantMenuLoading={selectedRestaurantMenuLoading}
           selectedRestaurantMenuError={selectedRestaurantMenuError}
           onRetryLoadSelectedRestaurantMenu={() => void retryLoadSelectedRestaurantMenu()}
+          favoriteGroupsLoading={favoriteGroupsLoading}
+          favoriteGroupsError={favoriteGroupsError}
+          onRetryLoadFavoriteGroups={() => void retryLoadFavoriteGroups()}
         />
 
         {/* カート: sm+ は従来どおりインライン展開。未満は折りたたみバー＋展開時オーバーレイ（メニュー領域を確保） */}

--- a/src/app/today/_components/FavoritesPanel.tsx
+++ b/src/app/today/_components/FavoritesPanel.tsx
@@ -1,7 +1,38 @@
 "use client";
 
 /** お気に入りタブで、集約されたメニューがまだないときの案内。 */
-export function FavoritesPanel() {
+export function FavoritesPanel({
+  loading,
+  error,
+  onRetry,
+}: {
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  if (loading) {
+    return (
+      <p className="text-center text-gray-500 text-base sm:text-sm py-8 px-4">
+        お気に入りを読み込んでいます...
+      </p>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="px-4 py-8 text-center">
+        <p className="text-sm text-amber-300">{error}</p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="mt-3 rounded-md border border-amber-300/50 px-2.5 py-1 text-xs text-amber-100 hover:bg-amber-500/20"
+        >
+          再試行
+        </button>
+      </div>
+    );
+  }
+
   return (
     <p className="text-center text-gray-500 text-base sm:text-sm py-8 px-4">
       お気に入りはまだありません。各メニューの☆をタップすると、ここに集約されます。

--- a/src/app/today/_components/MenuItemList.tsx
+++ b/src/app/today/_components/MenuItemList.tsx
@@ -40,6 +40,9 @@ export type MenuItemListProps = {
   isSelectedRestaurantMenuLoading: boolean;
   selectedRestaurantMenuError: string | null;
   onRetryLoadSelectedRestaurantMenu: () => void;
+  favoriteGroupsLoading: boolean;
+  favoriteGroupsError: string | null;
+  onRetryLoadFavoriteGroups: () => void;
 };
 
 export function MenuItemList({
@@ -72,6 +75,9 @@ export function MenuItemList({
   isSelectedRestaurantMenuLoading,
   selectedRestaurantMenuError,
   onRetryLoadSelectedRestaurantMenu,
+  favoriteGroupsLoading,
+  favoriteGroupsError,
+  onRetryLoadFavoriteGroups,
 }: MenuItemListProps) {
   const isNormalRestaurantTab =
     Boolean(selectedRestaurantIdResolved) &&
@@ -242,7 +248,13 @@ export function MenuItemList({
             )}
 
           {menuGroups.every((g) => g.items.length === 0) &&
-            selectedRestaurantIdResolved === FAVORITES_TAB_ID && <FavoritesPanel />}
+            selectedRestaurantIdResolved === FAVORITES_TAB_ID && (
+              <FavoritesPanel
+                loading={favoriteGroupsLoading}
+                error={favoriteGroupsError}
+                onRetry={onRetryLoadFavoriteGroups}
+              />
+            )}
           {menuGroups.every((g) => g.items.length === 0) &&
             selectedRestaurantIdResolved &&
             selectedRestaurantIdResolved !== FAVORITES_TAB_ID &&

--- a/src/app/today/_hooks/useRestaurantState.ts
+++ b/src/app/today/_hooks/useRestaurantState.ts
@@ -13,6 +13,7 @@ import { isSnapshotRestaurant } from "@/lib/snapshot-restaurant";
 import { sortMenuItemsForListOrder } from "@/lib/menu-item-sort";
 import {
   addMenuItemToFavorites,
+  fetchFavoriteGroupsPayload,
   removeMenuItemFromFavorites,
 } from "../actions/favorites";
 import { fetchMenuItemsForRestaurant } from "../actions/menu-item";
@@ -28,15 +29,6 @@ export const FAVORITES_TAB_ID = "__ketolog_favorites__";
 
 /** 文科省標準成分表検索パネル（仮想タブ） */
 export const MEXT_COMPOSITION_TAB_ID = "__ketolog_mext_std__";
-
-function firstTabRestaurantId(restaurants: Restaurant[]): string {
-  const visible = restaurants.filter((r) => !isSnapshotRestaurant(r));
-  return visible[0]?.id ?? "";
-}
-
-function hasFavoriteEntries(groups: FavoriteGroupPayload[]): boolean {
-  return groups.some((g) => g.entries.length > 0);
-}
 
 /** タブ並びの先頭から、お気に入りメニューが1件でもある店を探す */
 function firstRestaurantIdWithFavoriteMenu(
@@ -93,17 +85,17 @@ export function useRestaurantState({
   const [loadingRestaurantIds, setLoadingRestaurantIds] = useState<Record<string, boolean>>({});
   const [favoriteGroups, setFavoriteGroups] =
     useState<FavoriteGroupPayload[]>(initialFavoriteGroups);
+  const [favoriteGroupsLoading, setFavoriteGroupsLoading] = useState<boolean>(true);
+  const [favoriteGroupsLoaded, setFavoriteGroupsLoaded] = useState<boolean>(false);
+  const [favoriteGroupsError, setFavoriteGroupsError] = useState<string | null>(null);
+  const favoriteGroupsLoadingRef = useRef(false);
   const [, setMenuLoadTick] = useState(0);
   const [menuLoadErrorByRestaurantId, setMenuLoadErrorByRestaurantId] = useState<Record<string, string>>({});
   /** お気に入りトグルごとの世代。古い非同期結果で state を上書きしない。 */
   const favoriteToggleGenRef = useRef<Map<string, number>>(new Map());
   /** 同一 menu_item_id のサーバー更新を直列化（前段の失敗で後段を止めない）。 */
   const favoriteToggleChainRef = useRef<Map<string, Promise<void>>>(new Map());
-  const [selectedRestaurantId, setSelectedRestaurantId] = useState(() =>
-    hasFavoriteEntries(initialFavoriteGroups)
-      ? FAVORITES_TAB_ID
-      : firstTabRestaurantId(initialRestaurants)
-  );
+  const [selectedRestaurantId, setSelectedRestaurantId] = useState<string>(FAVORITES_TAB_ID);
   const [compositionTargetRestaurantId, setCompositionTargetRestaurantId] =
     useState("");
   const lastRealRestaurantTabIdRef = useRef<string>("");
@@ -289,6 +281,39 @@ export function useRestaurantState({
     });
     setMenuLoadTick((n) => n + 1);
   }, []);
+
+  const loadFavoriteGroups = useCallback(async ({ force }: { force: boolean }) => {
+    if (favoriteGroupsLoadingRef.current) return;
+    if (!force && favoriteGroupsLoaded) return;
+    favoriteGroupsLoadingRef.current = true;
+    setFavoriteGroupsLoading(true);
+    setFavoriteGroupsError(null);
+
+    const result = await fetchFavoriteGroupsPayload();
+
+    favoriteGroupsLoadingRef.current = false;
+    if (result.error) {
+      setFavoriteGroupsLoading(false);
+      setFavoriteGroupsError(result.error);
+      return;
+    }
+
+    setFavoriteGroups(result.data);
+    setFavoriteGroupsLoaded(true);
+    setFavoriteGroupsLoading(false);
+    setFavoriteGroupsError(null);
+  }, [favoriteGroupsLoaded]);
+
+  const retryLoadFavoriteGroups = useCallback(async () => {
+    await loadFavoriteGroups({ force: true });
+  }, [loadFavoriteGroups]);
+
+  useEffect(() => {
+    const tid = window.setTimeout(() => {
+      void loadFavoriteGroups({ force: false });
+    }, 0);
+    return () => window.clearTimeout(tid);
+  }, [loadFavoriteGroups]);
 
   const retryLoadSelectedRestaurantMenu = useCallback(async () => {
     if (
@@ -616,6 +641,9 @@ export function useRestaurantState({
     selectedRestaurantMenuLoading,
     selectedRestaurantMenuError,
     retryLoadSelectedRestaurantMenu,
+    favoriteGroupsLoading,
+    favoriteGroupsError,
+    retryLoadFavoriteGroups,
     restaurantNameById,
     favoriteMenuItemIds,
     openRestaurantTabMenu,

--- a/src/app/today/actions/favorites.ts
+++ b/src/app/today/actions/favorites.ts
@@ -5,12 +5,28 @@ import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import type {
   FavoriteEntryPayload,
   FavoriteGroupPayload,
+  MenuItem,
 } from "@/types/database";
+
+const FAVORITE_MENU_ITEM_SELECT_WITH_STANDARD_FOOD_CODE =
+  "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, standard_food_code, created_at";
+const FAVORITE_MENU_ITEM_SELECT_LEGACY =
+  "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, created_at";
+
+function isMissingColumnError(error: { message?: string } | null | undefined): boolean {
+  if (!error?.message) return false;
+  const msg = error.message.toLowerCase();
+  return msg.includes("column") && msg.includes("does not exist");
+}
 
 async function fetchFavoriteGroupsPayloadInternal(
   supabase: Awaited<ReturnType<typeof createClient>>,
-  userId: string
+  userId: string,
+  includeStandardFoodCode: boolean
 ): Promise<{ data: FavoriteGroupPayload[]; error: string | null }> {
+  const nestedMenuItemSelect = includeStandardFoodCode
+    ? FAVORITE_MENU_ITEM_SELECT_WITH_STANDARD_FOOD_CODE
+    : FAVORITE_MENU_ITEM_SELECT_LEGACY;
   const { data: rows, error } = await supabase
     .from("favorite_groups")
     .select(
@@ -22,7 +38,10 @@ async function fetchFavoriteGroupsPayloadInternal(
         id,
         favorite_group_id,
         menu_item_id,
-        display_order
+        display_order,
+        menu_item:menu_items (
+          ${nestedMenuItemSelect}
+        )
       )
     `
     )
@@ -35,12 +54,19 @@ async function fetchFavoriteGroupsPayloadInternal(
     const rawEntries =
       (g.favorite_entries as Array<Record<string, unknown>> | null) ?? [];
     const entries: FavoriteEntryPayload[] = rawEntries
-      .map((e) => ({
-        id: e.id as string,
-        favorite_group_id: e.favorite_group_id as string,
-        menu_item_id: e.menu_item_id as string,
-        display_order: e.display_order as number,
-      }))
+      .map((e) => {
+        const rawMenuItem = e.menu_item as Record<string, unknown> | null | undefined;
+        return {
+          id: e.id as string,
+          favorite_group_id: e.favorite_group_id as string,
+          menu_item_id: e.menu_item_id as string,
+          display_order: e.display_order as number,
+          menu_item:
+            rawMenuItem && typeof rawMenuItem.id === "string"
+              ? (rawMenuItem as unknown as MenuItem)
+              : undefined,
+        };
+      })
       .sort((a, b) => a.display_order - b.display_order);
     return {
       id: g.id as string,
@@ -59,7 +85,9 @@ export async function fetchFavoriteGroupsPayload(): Promise<{
 }> {
   const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { data: [], error: "認証が必要です" };
-  return fetchFavoriteGroupsPayloadInternal(supabase, user.id);
+  const primary = await fetchFavoriteGroupsPayloadInternal(supabase, user.id, true);
+  if (!isMissingColumnError(primary.error ? { message: primary.error } : null)) return primary;
+  return fetchFavoriteGroupsPayloadInternal(supabase, user.id, false);
 }
 
 async function getOrCreateFavoriteGroupByName(
@@ -170,7 +198,7 @@ export async function addMenuItemToFavorites(
   );
   if (addErr.error) return { data: null, error: addErr.error };
 
-  const payload = await fetchFavoriteGroupsPayloadInternal(supabase, user.id);
+  const payload = await fetchFavoriteGroupsPayload();
   return { data: payload.data, error: payload.error };
 }
 
@@ -183,6 +211,6 @@ export async function removeMenuItemFromFavorites(
   const { error } = await supabase.from("favorite_entries").delete().eq("menu_item_id", menuItemId);
   if (error) return { data: null, error: error.message };
 
-  const payload = await fetchFavoriteGroupsPayloadInternal(supabase, user.id);
+  const payload = await fetchFavoriteGroupsPayload();
   return { data: payload.data, error: payload.error };
 }

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -3,7 +3,6 @@ import { getMealTypeForTimeZone } from "@/lib/meal-timezone";
 import { redirect } from "next/navigation";
 import TodayClient from "./TodayClient";
 import { getOrCreateSnapshotRestaurant } from "./actions/restaurant";
-import { fetchFavoriteGroupsPayload } from "./actions/favorites";
 import { fetchMenuItemsForRestaurant } from "./actions/menu-item";
 import type { FoodLogEntry, MenuItem, Restaurant, UserSettings, TodayConsumed } from "@/types/database";
 import { normalizeUserSettings } from "@/lib/diet-phase";
@@ -38,7 +37,7 @@ export default async function TodayPage() {
 
   const today = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
 
-  const [settingsRes, restaurantsRes, foodLogRes, favoritePayload, snapshotRestaurant] =
+  const [settingsRes, restaurantsRes, foodLogRes, snapshotRestaurant] =
     await Promise.all([
       supabase
         .from("user_settings")
@@ -52,7 +51,6 @@ export default async function TodayPage() {
         .eq("user_id", user.id)
         .eq("date", today)
         .order("created_at", { ascending: true }),
-      fetchFavoriteGroupsPayload(),
       getOrCreateSnapshotRestaurant(),
     ]);
 
@@ -77,12 +75,11 @@ export default async function TodayPage() {
   });
 
   const initialMealType = getMealTypeForTimeZone(new Date(), "Asia/Tokyo");
-  const initialFavoriteGroups = favoritePayload.error ? [] : favoritePayload.data;
-  const hasFavoriteEntries = initialFavoriteGroups.some((group) => group.entries.length > 0);
+  const initialFavoriteGroups: [] = [];
   const snapshotRestaurantId = snapshotRestaurant.data?.id ?? "";
   const firstVisibleRestaurantId =
     restaurants.find((restaurant) => restaurant.id !== snapshotRestaurantId)?.id ?? "";
-  const initialMenuRestaurantId = hasFavoriteEntries ? "" : firstVisibleRestaurantId;
+  const initialMenuRestaurantId = firstVisibleRestaurantId;
   const initialMenuItemsRes = initialMenuRestaurantId
     ? await fetchMenuItemsForRestaurant(initialMenuRestaurantId)
     : { data: [] as MenuItem[], error: null };

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -4,7 +4,14 @@ import { redirect } from "next/navigation";
 import TodayClient from "./TodayClient";
 import { getOrCreateSnapshotRestaurant } from "./actions/restaurant";
 import { fetchMenuItemsForRestaurant } from "./actions/menu-item";
-import type { FoodLogEntry, MenuItem, Restaurant, UserSettings, TodayConsumed } from "@/types/database";
+import type {
+  FavoriteGroupPayload,
+  FoodLogEntry,
+  MenuItem,
+  Restaurant,
+  UserSettings,
+  TodayConsumed,
+} from "@/types/database";
 import { normalizeUserSettings } from "@/lib/diet-phase";
 import { sumPfc, type PfcGrams } from "@/lib/pfc";
 import { loadPresets } from "@/lib/presets-server";
@@ -75,7 +82,7 @@ export default async function TodayPage() {
   });
 
   const initialMealType = getMealTypeForTimeZone(new Date(), "Asia/Tokyo");
-  const initialFavoriteGroups: [] = [];
+  const initialFavoriteGroups: FavoriteGroupPayload[] = [];
   const snapshotRestaurantId = snapshotRestaurant.data?.id ?? "";
   const firstVisibleRestaurantId =
     restaurants.find((restaurant) => restaurant.id !== snapshotRestaurantId)?.id ?? "";


### PR DESCRIPTION
## Summary
- `/today` の初期SSR取得からお気に入りクエリを除外し、初期表示を軽量化
- 初回描画後にお気に入りを自動遅延取得するよう `useRestaurantState` に loading/error/retry の状態管理を追加
- お気に入りタブに「読み込み中」表示と、取得失敗時の再試行UIを追加

closes #261

## Test plan
- [x] `npm run lint`
- [x] `npm test`
- [ ] `/today` 初期表示でお気に入りが「読み込み中」表示になることを確認
- [ ] 遅延取得後にお気に入り一覧へ自動反映されることを確認
- [ ] 取得失敗時にエラー表示と再試行ボタンが機能することを確認


Made with [Cursor](https://cursor.com)