### PR TITLE
docs: Issueラベル運用ルールを明文化する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Changed
 
+- **ドキュメント / 開発運用**: `CONTRIBUTING.md` と `docs/release/README.md` に Issue ラベル運用の最小ルール（`platform` / `type` / `priority` の必須系統、`epic:*` / `track:*` の推奨運用）を追加した（[#274](https://github.com/kzkski/ketolog/issues/274)）。
 - **ドキュメント / リリース運用**: ステージング環境（Supabase + Vercel Preview + OAuth Redirect）の手順を `docs/release/staging-setup.md` に追加し、`docs/release/README.md`・`beta-checklist.md`・`operations-and-costs.md`・`quality-and-ci.md`・`ROADMAP.md`・`README.md` と GitHub Issue [#250](https://github.com/kzkski/ketolog/issues/250)〜[#253](https://github.com/kzkski/ketolog/issues/253)・[#255](https://github.com/kzkski/ketolog/issues/255) を整合させた。
 - **ドキュメント**: `ROADMAP.md` を公開向けのマイルストーン構成（v1/v2/v3）へ再編し、市場調査は公開サマリー中心に整理した。詳細な戦略レポートは公開リポジトリ管理の対象外にした。
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,20 @@ git branch -d feat/your-feature-name
 - PR は対応する Issue を `closes #<番号>` で参照する
 - Issue がない緊急バグ修正は PR 作成時に説明を記載する
 
+### Issue ラベル運用（管理しやすさのための最小ルール）
+
+- 新規 Issue 作成時は、原則として **`platform` / `type` / `priority`** の3系統を付ける
+- 親子構造で進めるテーマ（例: ネイティブ化 PoC）は、親・子ともに同じ `epic:*` を付ける
+- PR 作成時は、対応 Issue と同じラベル群を最低1系統以上引き継ぐ
+
+| 系統 | 必須度 | 例 |
+|---|---|---|
+| `epic:*` | 親子Issueで推奨 | `epic:native-poc` |
+| `platform:*` | 必須 | `platform:web` / `platform:mobile` / `platform:shared` |
+| `type:*` | 必須 | `type:feature` / `type:fix` / `type:perf` / `type:docs` / `type:ops` |
+| `priority:*` | 必須 | `priority:p0` / `priority:p1` / `priority:p2` |
+| `track:*` | リリース運用で推奨 | `track:v2-1` / `track:v2-2` / `track:v3` |
+
 ---
 
 ## マージ運用（ブランチ保護）

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -43,6 +43,22 @@
 - `Owner`: 任意（未定なら `TBD`）
 - `DoD`: 完了判定を1-3行で定義
 
+### Issue ラベル（v2/v3 運用向け）
+
+リリース系の実務 Issue は、最低でも次を付与する。
+
+- `platform:*`（`platform:web` / `platform:mobile` / `platform:shared`）
+- `type:*`（`type:feature` / `type:fix` / `type:perf` / `type:docs` / `type:ops`）
+- `priority:*`（`priority:p0` / `priority:p1` / `priority:p2`）
+
+トラック運用時は `track:*` を追加する。
+
+- v2-1: `track:v2-1`
+- v2-2: `track:v2-2`
+- v3: `track:v3`
+
+親子Issueで管理するテーマ（例: ネイティブ化実証）は `epic:*` を親子で共通付与する。
+
 ## 関連（戦略・市場）
 
 - [docs/research/README.md](../research/README.md) … 市場調査の公開サマリー（参考）。公開ゲート本体ではない。


### PR DESCRIPTION
## Summary
- `CONTRIBUTING.md` に Issue ラベル運用の最小ルール（必須3系統 + 推奨ラベル）を追加
- `docs/release/README.md` に v2/v3 リリース運用向けラベル方針を追加
- ルールの参照先を開発者向け/リリース運用向けで統一

Closes #274

## Test plan
- [x] ドキュメント差分のみであることを確認
- [x] 追記内容が `CONTRIBUTING.md` と `docs/release/README.md` の双方で整合していることを確認

Made with [Cursor](https://cursor.com)