### PR TITLE
feat: Expo Today で食事ログ CRUD（#268）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.45.0] - 2026-04-23
+
+### Added
+
+- **Mobile / Today**: 当日 `food_log` の一覧表示、手入力での追加（品目・食事区分・分量 g・100g あたり PFC）、分量と食事区分の編集（Web と同様の PFC 比率による再計算）、削除（確認ダイアログ）。失敗時はトーストとモーダル内の再試行。Web で登録した行も同じ一覧に表示される（[#268](https://github.com/kzkski/ketolog/issues/268)）。
+
+### Changed
+
+- **Shared / domain**: `pfcGramsFromNullablePer100` を `packages/domain/src/pfc.ts` に追加し、`src/lib/menu-item-pfc.ts` から再エクスポートするよう整理した（[#268](https://github.com/kzkski/ketolog/issues/268)）。
+
 ## [1.44.0] - 2026-04-23
 
 ### Added

--- a/apps/mobile/components/FoodLogEntryModal.tsx
+++ b/apps/mobile/components/FoodLogEntryModal.tsx
@@ -1,0 +1,494 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { pfcGramsFromNullablePer100 } from "@ketolog/domain/pfc";
+import type { MealType } from "@ketolog/types";
+
+const MEALS: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
+
+const MEAL_LABEL: Record<MealType, string> = {
+  breakfast: "朝食",
+  lunch: "昼食",
+  dinner: "夕食",
+  snack: "間食",
+};
+
+const COLORS = {
+  bg: "#111827",
+  text: "#e5e7eb",
+  textMuted: "#9ca3af",
+  border: "#374151",
+  primary: "#10b981",
+  danger: "#ef4444",
+};
+
+export type FoodLogRow = {
+  id: string;
+  date: string;
+  meal_type: string;
+  item_name: string;
+  grams: number;
+  protein_g: number;
+  fat_g: number;
+  carbs_g: number;
+};
+
+function parseNum(s: string): number | null {
+  const t = s.trim().replace(/,/g, "");
+  if (t === "") return null;
+  const n = Number(t);
+  return Number.isFinite(n) ? n : null;
+}
+
+type Props = {
+  visible: boolean;
+  mode: "add" | "edit";
+  supabase: SupabaseClient;
+  userId: string;
+  date: string;
+  entry: FoodLogRow | null;
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+  onToast: (message: string) => void;
+};
+
+export function FoodLogEntryModal({
+  visible,
+  mode,
+  supabase,
+  userId,
+  date,
+  entry,
+  onClose,
+  onSaved,
+  onToast,
+}: Props) {
+  const [meal, setMeal] = useState<MealType>("lunch");
+  const [itemName, setItemName] = useState("");
+  const [gramsStr, setGramsStr] = useState("");
+  const [p100, setP100] = useState("");
+  const [f100, setF100] = useState("");
+  const [c100, setC100] = useState("");
+  const [formError, setFormError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const resetAddForm = useCallback(() => {
+    setMeal("lunch");
+    setItemName("");
+    setGramsStr("");
+    setP100("");
+    setF100("");
+    setC100("");
+    setFormError(null);
+  }, []);
+
+  useEffect(() => {
+    if (!visible) return;
+    setFormError(null);
+    if (mode === "edit" && entry) {
+      const m = MEALS.includes(entry.meal_type as MealType)
+        ? (entry.meal_type as MealType)
+        : "lunch";
+      setMeal(m);
+      setItemName(entry.item_name);
+      setGramsStr(String(entry.grams));
+    } else if (mode === "add") {
+      resetAddForm();
+    }
+  }, [visible, mode, entry, resetAddForm]);
+
+  const runSaveAdd = useCallback(async () => {
+    const name = itemName.trim();
+    if (!name) {
+      setFormError("品目名を入力してください");
+      return;
+    }
+    const grams = parseNum(gramsStr);
+    if (grams == null || grams <= 0) {
+      setFormError("分量（g）は正の数で入力してください");
+      return;
+    }
+    const pp = parseNum(p100);
+    const fp = parseNum(f100);
+    const cp = parseNum(c100);
+    const v = pfcGramsFromNullablePer100(pp, fp, cp, grams);
+    setBusy(true);
+    setFormError(null);
+    const { error } = await supabase.from("food_log").insert({
+      user_id: userId,
+      date,
+      meal_type: meal,
+      item_name: name,
+      grams,
+      protein_g: v.p,
+      fat_g: v.f,
+      carbs_g: v.c,
+      source: "manual",
+      menu_item_id: null,
+    });
+    setBusy(false);
+    if (error) {
+      setFormError(error.message);
+      onToast(`保存に失敗しました: ${error.message}`);
+      return;
+    }
+    onToast("保存しました");
+    onClose();
+    await onSaved();
+  }, [
+    itemName,
+    gramsStr,
+    p100,
+    f100,
+    c100,
+    supabase,
+    userId,
+    date,
+    meal,
+    onClose,
+    onSaved,
+    onToast,
+  ]);
+
+  const runSaveEdit = useCallback(async () => {
+    if (!entry) return;
+    const grams = parseNum(gramsStr);
+    if (grams == null || grams <= 0) {
+      setFormError("分量（g）は正の数で入力してください");
+      return;
+    }
+    setBusy(true);
+    setFormError(null);
+    const { data: row, error: fetchErr } = await supabase
+      .from("food_log")
+      .select("grams, protein_g, fat_g, carbs_g")
+      .eq("id", entry.id)
+      .eq("user_id", userId)
+      .single();
+
+    if (fetchErr || !row) {
+      setBusy(false);
+      const msg = fetchErr?.message ?? "記録が見つかりません";
+      setFormError(msg);
+      onToast(msg);
+      return;
+    }
+
+    const oldGrams = Number(row.grams) || 1;
+    const pPer100 = ((Number(row.protein_g) || 0) * 100) / oldGrams;
+    const fPer100 = ((Number(row.fat_g) || 0) * 100) / oldGrams;
+    const cPer100 = ((Number(row.carbs_g) || 0) * 100) / oldGrams;
+    const v = pfcGramsFromNullablePer100(pPer100, fPer100, cPer100, grams);
+
+    const { error } = await supabase
+      .from("food_log")
+      .update({
+        grams,
+        meal_type: meal,
+        protein_g: v.p,
+        fat_g: v.f,
+        carbs_g: v.c,
+      })
+      .eq("id", entry.id)
+      .eq("user_id", userId);
+
+    setBusy(false);
+    if (error) {
+      setFormError(error.message);
+      onToast(`更新に失敗しました: ${error.message}`);
+      return;
+    }
+    onToast("更新しました");
+    onClose();
+    await onSaved();
+  }, [entry, gramsStr, meal, supabase, userId, onClose, onSaved, onToast]);
+
+  const onSubmit = useCallback(() => {
+    void (mode === "add" ? runSaveAdd() : runSaveEdit());
+  }, [mode, runSaveAdd, runSaveEdit]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        <View style={styles.card}>
+          <Text style={styles.title}>
+            {mode === "add" ? "食事を追加（手入力）" : "記録を編集"}
+          </Text>
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={styles.scrollPad}
+          >
+            {mode === "edit" ? (
+              <View style={styles.field}>
+                <Text style={styles.label}>品目</Text>
+                <Text style={styles.readonly}>{itemName}</Text>
+                <Text style={styles.hint}>
+                  名称の変更は Web 版から行うか、いったん削除して追加してください。
+                </Text>
+              </View>
+            ) : (
+              <View style={styles.field}>
+                <Text style={styles.label}>品目名</Text>
+                <TextInput
+                  value={itemName}
+                  onChangeText={setItemName}
+                  placeholder="例: ささみソテー"
+                  placeholderTextColor={COLORS.textMuted}
+                  style={styles.input}
+                  editable={!busy}
+                />
+              </View>
+            )}
+
+            <View style={styles.field}>
+              <Text style={styles.label}>食事</Text>
+              <View style={styles.mealRow}>
+                {MEALS.map((m) => (
+                  <Pressable
+                    key={m}
+                    onPress={() => !busy && setMeal(m)}
+                    style={[
+                      styles.mealChip,
+                      meal === m && styles.mealChipOn,
+                      busy && { opacity: 0.5 },
+                    ]}
+                  >
+                    <Text
+                      style={[
+                        styles.mealChipText,
+                        meal === m && styles.mealChipTextOn,
+                      ]}
+                    >
+                      {MEAL_LABEL[m]}
+                    </Text>
+                  </Pressable>
+                ))}
+              </View>
+            </View>
+
+            <View style={styles.field}>
+              <Text style={styles.label}>分量（g）</Text>
+              <TextInput
+                value={gramsStr}
+                onChangeText={setGramsStr}
+                placeholder="200"
+                placeholderTextColor={COLORS.textMuted}
+                keyboardType="decimal-pad"
+                style={styles.input}
+                editable={!busy}
+              />
+            </View>
+
+            {mode === "add" ? (
+              <>
+                <Text style={styles.sectionHint}>
+                  100g あたりの PFC（食品表示などから入力。空欄は 0）
+                </Text>
+                <View style={styles.pfcRow}>
+                  <View style={styles.pfcCol}>
+                    <Text style={styles.label}>P / 100g</Text>
+                    <TextInput
+                      value={p100}
+                      onChangeText={setP100}
+                      keyboardType="decimal-pad"
+                      style={styles.input}
+                      editable={!busy}
+                    />
+                  </View>
+                  <View style={styles.pfcCol}>
+                    <Text style={styles.label}>F / 100g</Text>
+                    <TextInput
+                      value={f100}
+                      onChangeText={setF100}
+                      keyboardType="decimal-pad"
+                      style={styles.input}
+                      editable={!busy}
+                    />
+                  </View>
+                  <View style={styles.pfcCol}>
+                    <Text style={styles.label}>C / 100g</Text>
+                    <TextInput
+                      value={c100}
+                      onChangeText={setC100}
+                      keyboardType="decimal-pad"
+                      style={styles.input}
+                      editable={!busy}
+                    />
+                  </View>
+                </View>
+              </>
+            ) : (
+              <Text style={styles.sectionHint}>
+                分量を変えると、もとの記録の PFC 比率に応じて再計算されます（Web
+                版と同じ）。
+              </Text>
+            )}
+
+            {formError ? <Text style={styles.error}>{formError}</Text> : null}
+
+            <View style={styles.btnRow}>
+              <Pressable
+                onPress={onClose}
+                disabled={busy}
+                style={[styles.btnGhost, busy && { opacity: 0.5 }]}
+              >
+                <Text style={styles.btnGhostText}>キャンセル</Text>
+              </Pressable>
+              <Pressable
+                onPress={onSubmit}
+                disabled={busy}
+                style={[styles.btnPrimary, busy && { opacity: 0.6 }]}
+              >
+                {busy ? (
+                  <ActivityIndicator color="#022c22" />
+                ) : (
+                  <Text style={styles.btnPrimaryText}>
+                    {mode === "add" ? "保存" : "更新"}
+                  </Text>
+                )}
+              </Pressable>
+            </View>
+            {formError ? (
+              <Pressable
+                onPress={onSubmit}
+                disabled={busy}
+                style={styles.retry}
+              >
+                <Text style={styles.retryText}>再試行</Text>
+              </Pressable>
+            ) : null}
+          </ScrollView>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  card: {
+    maxHeight: "88%",
+    backgroundColor: COLORS.bg,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingTop: 16,
+    paddingHorizontal: 16,
+    borderTopWidth: 1,
+    borderColor: COLORS.border,
+  },
+  title: {
+    color: COLORS.text,
+    fontSize: 17,
+    fontWeight: "700",
+    marginBottom: 8,
+  },
+  scrollPad: { paddingBottom: 28 },
+  field: { marginBottom: 14 },
+  label: {
+    color: COLORS.textMuted,
+    fontSize: 12,
+    marginBottom: 6,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: COLORS.text,
+    fontSize: 16,
+  },
+  readonly: {
+    color: COLORS.text,
+    fontSize: 16,
+    paddingVertical: 8,
+  },
+  hint: {
+    color: COLORS.textMuted,
+    fontSize: 11,
+    marginTop: 4,
+    lineHeight: 16,
+  },
+  mealRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  mealChip: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: "#0f172a",
+  },
+  mealChipOn: {
+    borderColor: COLORS.primary,
+    backgroundColor: "rgba(16, 185, 129, 0.15)",
+  },
+  mealChipText: { color: COLORS.textMuted, fontSize: 13 },
+  mealChipTextOn: { color: "#a7f3d0", fontWeight: "600" },
+  sectionHint: {
+    color: COLORS.textMuted,
+    fontSize: 12,
+    lineHeight: 17,
+    marginBottom: 10,
+  },
+  pfcRow: { flexDirection: "row", gap: 8, marginBottom: 8 },
+  pfcCol: { flex: 1 },
+  error: {
+    color: "#fecaca",
+    fontSize: 13,
+    marginBottom: 10,
+  },
+  btnRow: {
+    flexDirection: "row",
+    gap: 10,
+    marginTop: 8,
+  },
+  btnGhost: {
+    flex: 1,
+    alignItems: "center",
+    paddingVertical: 14,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+  },
+  btnGhostText: { color: COLORS.text, fontWeight: "600" },
+  btnPrimary: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 14,
+    borderRadius: 8,
+    backgroundColor: COLORS.primary,
+    minHeight: 48,
+  },
+  btnPrimaryText: { color: "#022c22", fontWeight: "700" },
+  retry: { alignItems: "center", marginTop: 12, padding: 8 },
+  retryText: { color: "#93c5fd", fontSize: 14, fontWeight: "600" },
+});

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import {
   ActivityIndicator,
+  Alert,
   Image,
   Modal,
   Pressable,
@@ -23,6 +24,10 @@ import {
   normalizeUserSettings,
 } from "@ketolog/domain/diet-phase";
 import { getSupabase } from "../lib/supabase";
+import {
+  FoodLogEntryModal,
+  type FoodLogRow,
+} from "../components/FoodLogEntryModal";
 
 type UserSettingsState = {
   diet_phase: DietPhase;
@@ -30,6 +35,13 @@ type UserSettingsState = {
 };
 
 const DIET_PHASES: DietPhase[] = [1, 2, 3];
+
+const MEAL_SHORT: Record<string, string> = {
+  breakfast: "朝",
+  lunch: "昼",
+  dinner: "夕",
+  snack: "間",
+};
 
 const COLORS = {
   bg: "#0a0a0a",
@@ -105,8 +117,23 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
   const [jstDate, setJstDate] = useState(() => toJstDateString());
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [phaseSaving, setPhaseSaving] = useState(false);
+  const [logEntries, setLogEntries] = useState<FoodLogRow[]>([]);
+  const [entryModalOpen, setEntryModalOpen] = useState(false);
+  const [entryModalMode, setEntryModalMode] = useState<"add" | "edit">("add");
+  const [editingEntry, setEditingEntry] = useState<FoodLogRow | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
 
   const appVersion = Constants.expoConfig?.version ?? "—";
+
+  const showToast = useCallback((message: string) => {
+    setToast(message);
+  }, []);
+
+  useEffect(() => {
+    if (!toast) return;
+    const t = setTimeout(() => setToast(null), 2800);
+    return () => clearTimeout(t);
+  }, [toast]);
 
   const load = useCallback(async () => {
     setLoadError(null);
@@ -121,9 +148,12 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
         .maybeSingle(),
       supabase
         .from("food_log")
-        .select("protein_g, fat_g, carbs_g")
+        .select(
+          "id, date, meal_type, item_name, grams, protein_g, fat_g, carbs_g"
+        )
         .eq("user_id", userId)
-        .eq("date", today),
+        .eq("date", today)
+        .order("created_at", { ascending: true }),
     ]);
 
     if (settingsRes.error) {
@@ -137,6 +167,18 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
 
     setSettings(normalizeUserSettings(settingsRes.data));
     const rows = logRes.data ?? [];
+    setLogEntries(
+      rows.map((r) => ({
+        id: String(r.id),
+        date: String(r.date),
+        meal_type: String(r.meal_type),
+        item_name: String(r.item_name),
+        grams: Number(r.grams) || 0,
+        protein_g: Number(r.protein_g) || 0,
+        fat_g: Number(r.fat_g) || 0,
+        carbs_g: Number(r.carbs_g) || 0,
+      }))
+    );
     setConsumed(
       sumPfc(
         ...rows.map((r) => ({
@@ -147,6 +189,51 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
       )
     );
   }, [supabase, userId]);
+
+  const openAddEntry = useCallback(() => {
+    setEditingEntry(null);
+    setEntryModalMode("add");
+    setEntryModalOpen(true);
+  }, []);
+
+  const openEditEntry = useCallback((e: FoodLogRow) => {
+    setEditingEntry(e);
+    setEntryModalMode("edit");
+    setEntryModalOpen(true);
+  }, []);
+
+  const confirmDeleteEntry = useCallback(
+    (e: FoodLogRow) => {
+      Alert.alert(
+        "記録を削除",
+        `「${e.item_name}」を削除しますか？`,
+        [
+          { text: "キャンセル", style: "cancel" },
+          {
+            text: "削除",
+            style: "destructive",
+            onPress: () => {
+              void (async () => {
+                const { error } = await supabase
+                  .from("food_log")
+                  .delete()
+                  .eq("id", e.id)
+                  .eq("user_id", userId);
+                if (error) {
+                  showToast(`削除に失敗: ${error.message}`);
+                  return;
+                }
+                showToast("削除しました");
+                await load();
+              })();
+            },
+          },
+        ],
+        { cancelable: true }
+      );
+    },
+    [supabase, userId, load, showToast]
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -302,15 +389,96 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
             />
           </View>
 
-          <View style={styles.mvpBox}>
-            <Text style={styles.mvpTitle}>MVP 表示中</Text>
-            <Text style={styles.mvpBody}>
-              メニュー・カート・食事記録の追加・編集は、引き続き Web 版（PWA）をご利用ください。アプリは Web
-              で記録した内容と同じ Supabase 上の日次合計（上記 PFC）を表示します。
-            </Text>
+          <View style={styles.logSection}>
+            <View style={styles.logSectionHeader}>
+              <Text style={styles.logSectionTitle}>今日の記録</Text>
+              <Pressable
+                onPress={openAddEntry}
+                style={({ pressed }) => [
+                  styles.addChip,
+                  pressed && { opacity: 0.85 },
+                ]}
+                accessibilityLabel="食事を追加"
+              >
+                <Ionicons name="add" size={18} color="#022c22" />
+                <Text style={styles.addChipText}>追加</Text>
+              </Pressable>
+            </View>
+            {logEntries.length === 0 ? (
+              <Text style={styles.logEmpty}>
+                まだ記録がありません。「追加」から手入力で登録できます（Web
+                での記録もここに表示されます）。
+              </Text>
+            ) : (
+              logEntries.map((e) => (
+                <View key={e.id} style={styles.logRow}>
+                  <Pressable
+                    onPress={() => openEditEntry(e)}
+                    style={({ pressed }) => [
+                      styles.logRowMain,
+                      pressed && { opacity: 0.85 },
+                    ]}
+                  >
+                    <Text style={styles.logMealBadge}>
+                      {MEAL_SHORT[e.meal_type] ?? e.meal_type}
+                    </Text>
+                    <View style={styles.logRowBody}>
+                      <Text style={styles.logItemName} numberOfLines={2}>
+                        {e.item_name}
+                      </Text>
+                      <Text style={styles.logMeta}>
+                        {e.grams}g · P {fmtMacroGrams(e.protein_g)} / F{" "}
+                        {fmtMacroGrams(e.fat_g)} / C {fmtMacroGrams(e.carbs_g)}
+                      </Text>
+                    </View>
+                    <Ionicons
+                      name="chevron-forward"
+                      size={18}
+                      color={COLORS.textMuted}
+                    />
+                  </Pressable>
+                  <Pressable
+                    onPress={() => confirmDeleteEntry(e)}
+                    hitSlop={10}
+                    style={({ pressed }) => [
+                      styles.logDeleteBtn,
+                      pressed && { opacity: 0.7 },
+                    ]}
+                    accessibilityLabel="削除"
+                  >
+                    <Ionicons
+                      name="trash-outline"
+                      size={20}
+                      color="#f87171"
+                    />
+                  </Pressable>
+                </View>
+              ))
+            )}
           </View>
         </ScrollView>
       </View>
+
+      <FoodLogEntryModal
+        visible={entryModalOpen}
+        mode={entryModalMode}
+        supabase={supabase}
+        userId={userId}
+        date={jstDate}
+        entry={editingEntry}
+        onClose={() => {
+          setEntryModalOpen(false);
+          setEditingEntry(null);
+        }}
+        onSaved={load}
+        onToast={showToast}
+      />
+
+      {toast ? (
+        <View style={styles.toast} pointerEvents="none">
+          <Text style={styles.toastText}>{toast}</Text>
+        </View>
+      ) : null}
 
       <Modal
         visible={settingsOpen}
@@ -475,21 +643,94 @@ const styles = StyleSheet.create({
     color: COLORS.text,
     fontVariant: ["tabular-nums"],
   },
-  mvpBox: {
-    margin: 12,
-    padding: 14,
-    borderRadius: 12,
-    backgroundColor: "#0f172a",
+  logSection: {
+    marginHorizontal: 12,
+    marginTop: 8,
+    paddingBottom: 72,
+  },
+  logSectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 10,
+  },
+  logSectionTitle: {
+    color: COLORS.text,
+    fontSize: 15,
+    fontWeight: "600",
+  },
+  addChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    backgroundColor: COLORS.c,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 20,
+  },
+  addChipText: { color: "#022c22", fontWeight: "700", fontSize: 13 },
+  logEmpty: {
+    color: COLORS.textMuted,
+    fontSize: 12,
+    lineHeight: 18,
+    paddingVertical: 8,
+  },
+  logRow: {
+    flexDirection: "row",
+    alignItems: "stretch",
+    backgroundColor: COLORS.sectionBg,
+    borderRadius: 10,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: COLORS.headerBorder,
+    overflow: "hidden",
+  },
+  logRowMain: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingLeft: 10,
+    paddingRight: 4,
+    gap: 8,
+  },
+  logMealBadge: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#a7f3d0",
+    backgroundColor: "rgba(16, 185, 129, 0.2)",
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+    overflow: "hidden",
+  },
+  logRowBody: { flex: 1, minWidth: 0 },
+  logItemName: { color: COLORS.text, fontSize: 14, fontWeight: "500" },
+  logMeta: {
+    color: COLORS.textMuted,
+    fontSize: 11,
+    marginTop: 4,
+    fontVariant: ["tabular-nums"],
+  },
+  logDeleteBtn: {
+    justifyContent: "center",
+    paddingHorizontal: 12,
+    borderLeftWidth: StyleSheet.hairlineWidth,
+    borderLeftColor: COLORS.headerBorder,
+  },
+  toast: {
+    position: "absolute",
+    left: 16,
+    right: 16,
+    bottom: 24,
+    backgroundColor: "#1f2937",
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 10,
     borderWidth: 1,
     borderColor: COLORS.headerBorder,
   },
-  mvpTitle: {
-    color: COLORS.text,
-    fontWeight: "600",
-    fontSize: 14,
-    marginBottom: 8,
-  },
-  mvpBody: { color: COLORS.textMuted, fontSize: 12, lineHeight: 18 },
+  toastText: { color: COLORS.text, fontSize: 13, textAlign: "center" },
   inlineError: {
     color: "#fecaca",
     fontSize: 12,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.43.1",
+  "version": "1.45.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.43.1",
+      "version": "1.45.0",
       "workspaces": [
         "apps/*",
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/src/pfc.ts
+++ b/packages/domain/src/pfc.ts
@@ -20,3 +20,17 @@ export function sumPfc(...parts: PfcGrams[]): PfcGrams {
   }
   return { p, f, c };
 }
+
+/** 100g あたり（nullable は 0 扱い）と分量 g から、その分量の PFC（g）を算出する。 */
+export function pfcGramsFromNullablePer100(
+  proteinPer100: number | null,
+  fatPer100: number | null,
+  carbsPer100: number | null,
+  grams: number
+): PfcGrams {
+  return {
+    p: ((proteinPer100 ?? 0) * grams) / 100,
+    f: ((fatPer100 ?? 0) * grams) / 100,
+    c: ((carbsPer100 ?? 0) * grams) / 100,
+  };
+}

--- a/src/lib/menu-item-pfc.ts
+++ b/src/lib/menu-item-pfc.ts
@@ -1,25 +1,15 @@
 import type { MenuItem } from "@/types/database";
 import type { PfcGrams } from "@ketolog/types";
+import { pfcGramsFromNullablePer100 as pfcFromPer100 } from "@ketolog/domain/pfc";
+
+export { pfcGramsFromNullablePer100 } from "@ketolog/domain/pfc";
 
 /** メニュー行（100g あたり）とグラム数から、その分量の PFC（g）を算出する。 */
 export function pfcGramsFromMenuItem(item: MenuItem, grams: number): PfcGrams {
-  return {
-    p: ((item.protein_per_100g ?? 0) * grams) / 100,
-    f: ((item.fat_per_100g ?? 0) * grams) / 100,
-    c: ((item.carbs_per_100g ?? 0) * grams) / 100,
-  };
-}
-
-/** 100g あたりの nullable 値とグラム数から PFC（g）を算出する（スナップショット行・カート用）。 */
-export function pfcGramsFromNullablePer100(
-  proteinPer100: number | null,
-  fatPer100: number | null,
-  carbsPer100: number | null,
-  grams: number
-): PfcGrams {
-  return {
-    p: ((proteinPer100 ?? 0) * grams) / 100,
-    f: ((fatPer100 ?? 0) * grams) / 100,
-    c: ((carbsPer100 ?? 0) * grams) / 100,
-  };
+  return pfcFromPer100(
+    item.protein_per_100g,
+    item.fat_per_100g,
+    item.carbs_per_100g,
+    grams
+  );
 }


### PR DESCRIPTION
## 概要
Issue #268（ネイティブ PoC）に対応し、Expo の Today から `food_log` の当日一覧・手入力追加・編集（分量・食事区分）・削除を実装した。

## 変更点
- `TodayScreen`: 一覧、トースト、削除確認、`FoodLogEntryModal` 連携
- `FoodLogEntryModal`: 手入力（100g あたり PFC）、編集時は Web の `updateFoodLogEntry` と同様の比率再計算
- `@ketolog/domain/pfc`: `pfcGramsFromNullablePer100` を共通化、`menu-item-pfc` から再エクスポート

## リリース
- バージョン **1.45.0**（`CHANGELOG.md` 反映済み）

closes #268

Made with [Cursor](https://cursor.com)