### PR TITLE
feat: Mobile の Supabase をシミュレータと実機で切り替え

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.46.0] - 2026-04-23
+
+### Changed
+
+- **Mobile / Supabase**: `expo-constants` の `Constants.isDevice` に応じて接続先を切り替え。シミュレータ・エミュレータでは `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY`（ローカル想定）、実機では `EXPO_PUBLIC_SUPABASE_PRODUCTION_URL` / `EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY`（本番想定）を使用する。`App.tsx` の未設定案内と `apps/mobile/README.md`・`.env.example` を更新した。
+
 ## [1.45.0] - 2026-04-23
 
 ### Added

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -1,3 +1,9 @@
-# Web の `NEXT_PUBLIC_SUPABASE_*` と同じ Supabase プロジェクトを指す（Anon キーはクライアント用）
-EXPO_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
-EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+# --- シミュレータ / Android エミュレータ（Constants.isDevice === false）---
+# ローカルの Supabase（`supabase start` 等）を指す。Web の `NEXT_PUBLIC_*` と揃えてもよい。
+EXPO_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your-local-anon-key
+
+# --- 実機（物理デバイス。インストールビルドや実機の開発ビルド）---
+# 本番（またはステージング）プロジェクト。未設定のまま実機で起動すると Supabase 未設定になる。
+EXPO_PUBLIC_SUPABASE_PRODUCTION_URL=https://your-production-project.supabase.co
+EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY=your-production-anon-key

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
+import Constants from "expo-constants";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 import { useAuthSession } from "./hooks/useAuthSession";
 import { isSupabaseConfigured } from "./lib/supabase";
@@ -9,14 +10,14 @@ import { TodayScreen } from "./screens/TodayScreen";
 import { LoginScreen } from "./screens/LoginScreen";
 
 function MissingSupabaseConfigScreen() {
+  const onDevice = Constants.isDevice === true;
   return (
     <View style={styles.centered}>
       <Text style={styles.errorTitle}>Supabase 未設定</Text>
       <Text style={styles.hint}>
-        `apps/mobile/.env` に次を定義し、Expo（Metro）を再起動してください。{"\n\n"}
-        EXPO_PUBLIC_SUPABASE_URL{"\n"}
-        EXPO_PUBLIC_SUPABASE_ANON_KEY{"\n\n"}
-        雛形は `apps/mobile/.env.example` をコピーして使えます。
+        {onDevice
+          ? "実機では本番接続用の変数が必要です。`apps/mobile/.env` に次を定義し、**実機向けに再ビルド**（または EAS の env 注入）してください。\n\nEXPO_PUBLIC_SUPABASE_PRODUCTION_URL\nEXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY\n\nシミュレータ用の EXPO_PUBLIC_SUPABASE_URL は実機では使われません。"
+          : "シミュレータではローカル Supabase 用に次を定義し、Expo（Metro）を再起動してください。\n\nEXPO_PUBLIC_SUPABASE_URL\nEXPO_PUBLIC_SUPABASE_ANON_KEY\n\n雛形は `apps/mobile/.env.example` を参照。"}
       </Text>
       <StatusBar style="light" />
     </View>

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -24,8 +24,19 @@ npm install
 
 ### Supabase 認証（Issue #266 / PoC）
 
-1. `apps/mobile/.env.example` を `apps/mobile/.env` にコピーし、`EXPO_PUBLIC_SUPABASE_URL` と `EXPO_PUBLIC_SUPABASE_ANON_KEY` を Web（`NEXT_PUBLIC_SUPABASE_*`）と**同じプロジェクト**の値で埋める。
-2. **Supabase ダッシュボード**（Authentication → URL Configuration）の **Redirect URLs** に、少なくとも次のパターンを含める（Google OAuth・PKCE の戻り先用）。
+**接続先の切り替え**（`apps/mobile/lib/supabase.ts`）: `expo-constants` の **`Constants.isDevice`** で判別する。
+
+| 実行環境 | 使う環境変数 | 想定する DB |
+|---|---|---|
+| **iOS シミュレータ / Android エミュレータ**（`isDevice === false`） | `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` | ローカル Supabase（`supabase start` など） |
+| **実機**（`isDevice === true`、Xcode / EAS でインストールしたビルド含む） | `EXPO_PUBLIC_SUPABASE_PRODUCTION_URL` / `EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY` | 本番（またはステージング）プロジェクト |
+
+実機ビルド時も `.env`（または EAS Secrets などビルド時に埋め込む手段）に **本番用の 2 変数**が入っている必要がある。シミュレータ用の URL だけでは実機では起動しない。
+
+**補足**: **Expo Go を実機で開いた場合**も `Constants.isDevice === true` のため、本番用の 2 変数が使われる（実機からローカル Supabase に繋ぎたい場合は、この判定を変えるかトンネル URL を本番変数側に載せるなど別運用が必要）。
+
+1. `apps/mobile/.env.example` を `apps/mobile/.env` にコピーし、上表に従って **シミュレータ用**と**実機用**の両方を埋める（ローカルと本番で Supabase プロジェクトが違う前提）。
+2. **Supabase ダッシュボード**（Authentication → URL Configuration）の **Redirect URLs** に、少なくとも次のパターンを含める（Google OAuth・PKCE の戻り先用）。**ローカル用と本番用の両プロジェクト**それぞれで、当該環境の `ketolog://` を登録する。
    - カスタムスキーム（`app.config.ts` の `scheme: "ketolog"`）: `ketolog://**` または `ketolog://auth/callback`（必要に応じて両方）
    - **Expo Go 開発時**は、ターミナルに表示される `exp://` 系のリダイレクトが変わるため、エラーに含まれる URL を見ながら **Redirect URLs に都度追加**するか、通し用の `exp://**` が許可できる場合はルールに従って登録する。
 3. 環境変数を変えたら `npx expo start`（Metro）を**再起動**する。

--- a/apps/mobile/lib/supabase.ts
+++ b/apps/mobile/lib/supabase.ts
@@ -1,23 +1,43 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import Constants from "expo-constants";
 
 let client: SupabaseClient | null = null;
 
+/**
+ * 実機（物理デバイス）では本番 Supabase、シミュレータ / エミュレータではローカル用の
+ * `EXPO_PUBLIC_SUPABASE_*` を使う（`Constants.isDevice` は Expo が提供する判別）。
+ */
+function resolveSupabaseEnv(): { url: string; key: string } | null {
+  const onPhysicalDevice = Constants.isDevice === true;
+  if (onPhysicalDevice) {
+    const url = process.env.EXPO_PUBLIC_SUPABASE_PRODUCTION_URL?.trim();
+    const key = process.env.EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY?.trim();
+    if (url && key) return { url, key };
+    return null;
+  }
+  const url = process.env.EXPO_PUBLIC_SUPABASE_URL?.trim();
+  const key = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY?.trim();
+  if (url && key) return { url, key };
+  return null;
+}
+
 export function isSupabaseConfigured(): boolean {
-  const url = process.env.EXPO_PUBLIC_SUPABASE_URL;
-  const key = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
-  return Boolean(url?.trim() && key?.trim());
+  return resolveSupabaseEnv() != null;
 }
 
 export function getSupabase(): SupabaseClient {
-  if (!isSupabaseConfigured()) {
+  const resolved = resolveSupabaseEnv();
+  if (!resolved) {
+    const onPhysicalDevice = Constants.isDevice === true;
     throw new Error(
-      "Supabase 用の `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` が未設定、または空です。",
+      onPhysicalDevice
+        ? "実機用の `EXPO_PUBLIC_SUPABASE_PRODUCTION_URL` / `EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY` が未設定、または空です。"
+        : "シミュレータ用の `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` が未設定、または空です。"
     );
   }
   if (!client) {
-    const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL as string;
-    const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY as string;
+    const { url: supabaseUrl, key: supabaseAnonKey } = resolved;
     client = createClient(supabaseUrl, supabaseAnonKey, {
       auth: {
         storage: AsyncStorage,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.45.0",
+      "version": "1.46.0",
       "workspaces": [
         "apps/*",
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## 概要
`Constants.isDevice` に応じて、シミュレータではローカル用 `EXPO_PUBLIC_SUPABASE_URL`、実機では本番用 `EXPO_PUBLIC_SUPABASE_PRODUCTION_URL` を参照する。

## 変更ファイル
- `apps/mobile/lib/supabase.ts` — 接続先解決ロジック
- `apps/mobile/App.tsx` — 未設定時の案内
- `apps/mobile/.env.example` / `README.md`

## リリース
- **1.46.0**（`CHANGELOG.md` 反映済み）

Made with [Cursor](https://cursor.com)