### PR TITLE
feat(mobile): メニューから食事追加の最小導線

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.47.0] - 2026-04-23
+
+### Added
+
+- **Mobile / Today**: 「メニュー」から Web で登録した店舗・メニューを選び、品目名・標準分量・100g あたり PFC を反映した状態で食事を追加できるようにした。保存時は Web と同様に `menu_item_id` と店舗 UUID を `source` に付与する（[#269](https://github.com/kzkski/ketolog/issues/269)）。
+
+### Fixed
+
+- **Mobile / メニュー選択**: `restaurants.display_order` 列が無いデータベースでも店舗一覧が取得できるよう、取得列と並び替えを見直した（[#269](https://github.com/kzkski/ketolog/issues/269)）。
+
 ## [1.46.0] - 2026-04-23
 
 ### Changed

--- a/apps/mobile/components/FoodLogEntryModal.tsx
+++ b/apps/mobile/components/FoodLogEntryModal.tsx
@@ -15,6 +15,8 @@ import type { SupabaseClient } from "@supabase/supabase-js";
 import { pfcGramsFromNullablePer100 } from "@ketolog/domain/pfc";
 import type { MealType } from "@ketolog/types";
 
+import type { MenuPrefill } from "../lib/menu-prefill";
+
 const MEALS: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
 
 const MEAL_LABEL: Record<MealType, string> = {
@@ -51,6 +53,11 @@ function parseNum(s: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
+function per100FieldString(n: number | null): string {
+  if (n == null || !Number.isFinite(n)) return "";
+  return String(n);
+}
+
 type Props = {
   visible: boolean;
   mode: "add" | "edit";
@@ -58,6 +65,8 @@ type Props = {
   userId: string;
   date: string;
   entry: FoodLogRow | null;
+  /** メニューから開いたときのプリフィル。手入力のときは null。 */
+  menuPrefill: MenuPrefill | null;
   onClose: () => void;
   onSaved: () => Promise<void>;
   onToast: (message: string) => void;
@@ -70,6 +79,7 @@ export function FoodLogEntryModal({
   userId,
   date,
   entry,
+  menuPrefill,
   onClose,
   onSaved,
   onToast,
@@ -104,9 +114,18 @@ export function FoodLogEntryModal({
       setItemName(entry.item_name);
       setGramsStr(String(entry.grams));
     } else if (mode === "add") {
-      resetAddForm();
+      if (menuPrefill) {
+        setMeal("lunch");
+        setItemName(menuPrefill.itemName);
+        setGramsStr(String(menuPrefill.defaultGrams));
+        setP100(per100FieldString(menuPrefill.proteinPer100));
+        setF100(per100FieldString(menuPrefill.fatPer100));
+        setC100(per100FieldString(menuPrefill.carbsPer100));
+      } else {
+        resetAddForm();
+      }
     }
-  }, [visible, mode, entry, resetAddForm]);
+  }, [visible, mode, entry, menuPrefill, resetAddForm]);
 
   const runSaveAdd = useCallback(async () => {
     const name = itemName.trim();
@@ -134,8 +153,8 @@ export function FoodLogEntryModal({
       protein_g: v.p,
       fat_g: v.f,
       carbs_g: v.c,
-      source: "manual",
-      menu_item_id: null,
+      source: menuPrefill?.restaurantId ?? "manual",
+      menu_item_id: menuPrefill?.menuItemId ?? null,
     });
     setBusy(false);
     if (error) {
@@ -156,6 +175,7 @@ export function FoodLogEntryModal({
     userId,
     date,
     meal,
+    menuPrefill,
     onClose,
     onSaved,
     onToast,
@@ -232,7 +252,11 @@ export function FoodLogEntryModal({
         <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
         <View style={styles.card}>
           <Text style={styles.title}>
-            {mode === "add" ? "食事を追加（手入力）" : "記録を編集"}
+            {mode === "add"
+              ? menuPrefill
+                ? "食事を追加（メニュー）"
+                : "食事を追加（手入力）"
+              : "記録を編集"}
           </Text>
           <ScrollView
             keyboardShouldPersistTaps="handled"
@@ -255,8 +279,13 @@ export function FoodLogEntryModal({
                   placeholder="例: ささみソテー"
                   placeholderTextColor={COLORS.textMuted}
                   style={styles.input}
-                  editable={!busy}
+                  editable={!busy && !menuPrefill}
                 />
+                {menuPrefill ? (
+                  <Text style={styles.hint}>
+                    メニューから読み込みました。名称の変更は Web 版のメニュー編集で行ってください。
+                  </Text>
+                ) : null}
               </View>
             )}
 

--- a/apps/mobile/components/MenuPickModal.tsx
+++ b/apps/mobile/components/MenuPickModal.tsx
@@ -1,0 +1,389 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  Modal,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { MenuPrefill } from "../lib/menu-prefill";
+import { isSnapshotRestaurant, SNAPSHOT_RESTAURANT_NAME } from "../lib/snapshot-restaurant";
+
+const COLORS = {
+  bg: "#111827",
+  text: "#e5e7eb",
+  textMuted: "#9ca3af",
+  border: "#374151",
+  primary: "#10b981",
+};
+
+type RestaurantRow = {
+  id: string;
+  name: string;
+  order_count: number;
+  created_at: string | null;
+};
+
+type MenuItemRow = {
+  id: string;
+  name: string;
+  protein_per_100g: number | null;
+  fat_per_100g: number | null;
+  carbs_per_100g: number | null;
+  default_grams: number | null;
+  rank: number;
+  created_at: string | null;
+};
+
+/** `display_order` 列が無い DB でも動かすため、取得列のみで並べる（利用頻度 → 登録順）。 */
+function sortRestaurants(list: RestaurantRow[]): RestaurantRow[] {
+  return [...list].sort((a, b) => {
+    if (b.order_count !== a.order_count) return b.order_count - a.order_count;
+    const ac = a.created_at ?? "";
+    const bc = b.created_at ?? "";
+    if (ac !== bc) return ac < bc ? -1 : 1;
+    const nameCmp = a.name.localeCompare(b.name, "ja");
+    if (nameCmp !== 0) return nameCmp;
+    return a.id < b.id ? -1 : 1;
+  });
+}
+
+/** Web `compareMenuItemsForListOrder` に揃える */
+function compareMenuItemsForListOrder(a: MenuItemRow, b: MenuItemRow): number {
+  if (a.rank !== b.rank) return a.rank - b.rank;
+  const nameCmp = a.name.localeCompare(b.name, "ja");
+  if (nameCmp !== 0) return nameCmp;
+  const ac = a.created_at ?? "";
+  const bc = b.created_at ?? "";
+  if (ac !== bc) return ac < bc ? -1 : 1;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+type Props = {
+  visible: boolean;
+  supabase: SupabaseClient;
+  userId: string;
+  onClose: () => void;
+  onPick: (prefill: MenuPrefill) => void;
+};
+
+export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Props) {
+  const [step, setStep] = useState<"restaurants" | "menus">("restaurants");
+  const [restaurantId, setRestaurantId] = useState<string | null>(null);
+  const [restaurantName, setRestaurantName] = useState<string>("");
+  const [restaurants, setRestaurants] = useState<RestaurantRow[]>([]);
+  const [menuItems, setMenuItems] = useState<MenuItemRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
+
+  const resetLocal = useCallback(() => {
+    setStep("restaurants");
+    setRestaurantId(null);
+    setRestaurantName("");
+    setRestaurants([]);
+    setMenuItems([]);
+    setError(null);
+    setQuery("");
+  }, []);
+
+  const loadRestaurants = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    const { data, error: err } = await supabase
+      .from("restaurants")
+      .select("id, name, order_count, created_at")
+      .eq("user_id", userId);
+
+    setLoading(false);
+    if (err) {
+      setError(err.message);
+      return;
+    }
+
+    const rows = (data ?? []) as RestaurantRow[];
+    const filtered = sortRestaurants(rows.filter((r) => !isSnapshotRestaurant(r)));
+
+    if (filtered.length === 0) {
+      setRestaurants([]);
+      return;
+    }
+
+    if (filtered.length === 1) {
+      const only = filtered[0]!;
+      setRestaurantId(only.id);
+      setRestaurantName(only.name);
+      setStep("menus");
+      setLoading(true);
+      const mRes = await supabase
+        .from("menu_items")
+        .select(
+          "id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, rank, created_at"
+        )
+        .eq("user_id", userId)
+        .eq("restaurant_id", only.id);
+      setLoading(false);
+      if (mRes.error) {
+        setError(mRes.error.message);
+        return;
+      }
+      const items = ((mRes.data ?? []) as MenuItemRow[]).sort(compareMenuItemsForListOrder);
+      setMenuItems(items);
+      return;
+    }
+
+    setRestaurants(filtered);
+    setStep("restaurants");
+  }, [supabase, userId]);
+
+  const loadMenus = useCallback(
+    async (rid: string, rname: string) => {
+      setLoading(true);
+      setError(null);
+      const { data, error: err } = await supabase
+        .from("menu_items")
+        .select(
+          "id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, rank, created_at"
+        )
+        .eq("user_id", userId)
+        .eq("restaurant_id", rid);
+
+      setLoading(false);
+      if (err) {
+        setError(err.message);
+        return;
+      }
+      setRestaurantId(rid);
+      setRestaurantName(rname);
+      setMenuItems(((data ?? []) as MenuItemRow[]).sort(compareMenuItemsForListOrder));
+      setStep("menus");
+      setQuery("");
+    },
+    [supabase, userId]
+  );
+
+  useEffect(() => {
+    if (!visible) {
+      resetLocal();
+      return;
+    }
+    void loadRestaurants();
+  }, [visible, loadRestaurants, resetLocal]);
+
+  const filteredRestaurants = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return restaurants;
+    return restaurants.filter((r) => r.name.toLowerCase().includes(q));
+  }, [restaurants, query]);
+
+  const filteredMenus = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return menuItems;
+    return menuItems.filter((m) => m.name.toLowerCase().includes(q));
+  }, [menuItems, query]);
+
+  const onSelectRestaurant = useCallback(
+    (r: RestaurantRow) => {
+      void loadMenus(r.id, r.name);
+    },
+    [loadMenus]
+  );
+
+  const onSelectMenu = useCallback(
+    (m: MenuItemRow) => {
+      if (!restaurantId) return;
+      const defG = Number(m.default_grams);
+      const defaultGrams = Number.isFinite(defG) && defG > 0 ? defG : 100;
+      onPick({
+        menuItemId: m.id,
+        restaurantId,
+        itemName: m.name,
+        proteinPer100: m.protein_per_100g != null ? Number(m.protein_per_100g) : null,
+        fatPer100: m.fat_per_100g != null ? Number(m.fat_per_100g) : null,
+        carbsPer100: m.carbs_per_100g != null ? Number(m.carbs_per_100g) : null,
+        defaultGrams,
+      });
+    },
+    [restaurantId, onPick]
+  );
+
+  const goBackToRestaurants = useCallback(() => {
+    setStep("restaurants");
+    setRestaurantId(null);
+    setRestaurantName("");
+    setMenuItems([]);
+    setQuery("");
+    setError(null);
+  }, []);
+
+  const title =
+    step === "restaurants"
+      ? "店舗を選ぶ"
+      : `メニュー（${restaurantName.length > 14 ? `${restaurantName.slice(0, 14)}…` : restaurantName}）`;
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        <View style={styles.card}>
+          <View style={styles.headerRow}>
+            {step === "menus" && restaurants.length > 1 ? (
+              <Pressable onPress={goBackToRestaurants} style={styles.backBtn} hitSlop={8}>
+                <Text style={styles.backBtnText}>‹ 店舗</Text>
+              </Pressable>
+            ) : (
+              <View style={styles.backPlaceholder} />
+            )}
+            <Text style={styles.title} numberOfLines={1}>
+              {title}
+            </Text>
+            <Pressable onPress={onClose} style={styles.closeBtn} hitSlop={8}>
+              <Text style={styles.closeBtnText}>閉じる</Text>
+            </Pressable>
+          </View>
+
+          <TextInput
+            value={query}
+            onChangeText={setQuery}
+            placeholder={step === "restaurants" ? "店名で絞り込み" : "メニュー名で絞り込み"}
+            placeholderTextColor={COLORS.textMuted}
+            style={styles.search}
+            editable={!loading}
+          />
+
+          {loading ? (
+            <View style={styles.center}>
+              <ActivityIndicator color={COLORS.primary} />
+            </View>
+          ) : error ? (
+            <Text style={styles.error}>{error}</Text>
+          ) : step === "restaurants" ? (
+            filteredRestaurants.length === 0 ? (
+              <Text style={styles.hint}>
+                登録済みの店舗がありません（「{SNAPSHOT_RESTAURANT_NAME}」は除く）。Web
+                版で店舗とメニューを登録してからお試しください。
+              </Text>
+            ) : (
+              <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={styles.listPad}>
+                {filteredRestaurants.map((r) => (
+                  <Pressable
+                    key={r.id}
+                    onPress={() => onSelectRestaurant(r)}
+                    style={({ pressed }) => [styles.row, pressed && { opacity: 0.85 }]}
+                  >
+                    <Text style={styles.rowText} numberOfLines={2}>
+                      {r.name}
+                    </Text>
+                    <Text style={styles.chev}>›</Text>
+                  </Pressable>
+                ))}
+              </ScrollView>
+            )
+          ) : filteredMenus.length === 0 ? (
+            <Text style={styles.hint}>
+              {menuItems.length === 0
+                ? "この店舗にメニューがありません。Web 版から追加してください。"
+                : "検索に一致するメニューがありません。"}
+            </Text>
+          ) : (
+            <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={styles.listPad}>
+              {filteredMenus.map((m) => (
+                <Pressable
+                  key={m.id}
+                  onPress={() => onSelectMenu(m)}
+                  style={({ pressed }) => [styles.row, pressed && { opacity: 0.85 }]}
+                >
+                  <View style={styles.menuRowBody}>
+                    <Text style={styles.rowText} numberOfLines={2}>
+                      {m.name}
+                    </Text>
+                    <Text style={styles.menuMeta} numberOfLines={1}>
+                      標準 {m.default_grams != null ? Number(m.default_grams) : 100}g · P/F/C
+                      100g
+                    </Text>
+                  </View>
+                  <Text style={styles.chev}>›</Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          )}
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  card: {
+    maxHeight: "85%",
+    backgroundColor: COLORS.bg,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingTop: 12,
+    paddingHorizontal: 14,
+    paddingBottom: 20,
+    borderTopWidth: 1,
+    borderColor: COLORS.border,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 10,
+    gap: 6,
+  },
+  backBtn: { minWidth: 56, paddingVertical: 4 },
+  backBtnText: { color: "#93c5fd", fontSize: 15, fontWeight: "600" },
+  backPlaceholder: { minWidth: 56 },
+  title: {
+    flex: 1,
+    color: COLORS.text,
+    fontSize: 16,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  closeBtn: { minWidth: 52, paddingVertical: 4 },
+  closeBtnText: { color: COLORS.textMuted, fontSize: 14, textAlign: "right" },
+  search: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: COLORS.text,
+    fontSize: 15,
+    marginBottom: 10,
+  },
+  center: { paddingVertical: 28, alignItems: "center" },
+  error: { color: "#fecaca", fontSize: 13, marginBottom: 8 },
+  hint: {
+    color: COLORS.textMuted,
+    fontSize: 13,
+    lineHeight: 19,
+    paddingVertical: 8,
+  },
+  listPad: { paddingBottom: 24 },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 12,
+    paddingHorizontal: 10,
+    borderRadius: 10,
+    backgroundColor: "#0f172a",
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+  },
+  menuRowBody: { flex: 1, minWidth: 0 },
+  rowText: { color: COLORS.text, fontSize: 15, fontWeight: "500" },
+  menuMeta: { color: COLORS.textMuted, fontSize: 11, marginTop: 4 },
+  chev: { color: COLORS.textMuted, fontSize: 18, marginLeft: 8 },
+});

--- a/apps/mobile/lib/menu-prefill.ts
+++ b/apps/mobile/lib/menu-prefill.ts
@@ -1,0 +1,10 @@
+/** メニュー選択から食事追加フォームへ渡す最小ペイロード */
+export type MenuPrefill = {
+  menuItemId: string;
+  restaurantId: string;
+  itemName: string;
+  proteinPer100: number | null;
+  fatPer100: number | null;
+  carbsPer100: number | null;
+  defaultGrams: number;
+};

--- a/apps/mobile/lib/snapshot-restaurant.ts
+++ b/apps/mobile/lib/snapshot-restaurant.ts
@@ -1,0 +1,6 @@
+/** Web の `src/lib/snapshot-restaurant.ts` と同一。メニュー選択 UI からは除外する。 */
+export const SNAPSHOT_RESTAURANT_NAME = "（スナップショット記録）" as const;
+
+export function isSnapshotRestaurant(r: { name: string }): boolean {
+  return r.name === SNAPSHOT_RESTAURANT_NAME;
+}

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -28,6 +28,8 @@ import {
   FoodLogEntryModal,
   type FoodLogRow,
 } from "../components/FoodLogEntryModal";
+import { MenuPickModal } from "../components/MenuPickModal";
+import type { MenuPrefill } from "../lib/menu-prefill";
 
 type UserSettingsState = {
   diet_phase: DietPhase;
@@ -121,6 +123,8 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
   const [entryModalOpen, setEntryModalOpen] = useState(false);
   const [entryModalMode, setEntryModalMode] = useState<"add" | "edit">("add");
   const [editingEntry, setEditingEntry] = useState<FoodLogRow | null>(null);
+  const [menuPrefill, setMenuPrefill] = useState<MenuPrefill | null>(null);
+  const [menuPickOpen, setMenuPickOpen] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 
   const appVersion = Constants.expoConfig?.version ?? "—";
@@ -191,12 +195,26 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
   }, [supabase, userId]);
 
   const openAddEntry = useCallback(() => {
+    setMenuPrefill(null);
     setEditingEntry(null);
     setEntryModalMode("add");
     setEntryModalOpen(true);
   }, []);
 
+  const openMenuPick = useCallback(() => {
+    setMenuPickOpen(true);
+  }, []);
+
+  const onMenuPicked = useCallback((prefill: MenuPrefill) => {
+    setMenuPrefill(prefill);
+    setEditingEntry(null);
+    setEntryModalMode("add");
+    setMenuPickOpen(false);
+    setEntryModalOpen(true);
+  }, []);
+
   const openEditEntry = useCallback((e: FoodLogRow) => {
+    setMenuPrefill(null);
     setEditingEntry(e);
     setEntryModalMode("edit");
     setEntryModalOpen(true);
@@ -392,21 +410,35 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
           <View style={styles.logSection}>
             <View style={styles.logSectionHeader}>
               <Text style={styles.logSectionTitle}>今日の記録</Text>
-              <Pressable
-                onPress={openAddEntry}
-                style={({ pressed }) => [
-                  styles.addChip,
-                  pressed && { opacity: 0.85 },
-                ]}
-                accessibilityLabel="食事を追加"
-              >
-                <Ionicons name="add" size={18} color="#022c22" />
-                <Text style={styles.addChipText}>追加</Text>
-              </Pressable>
+              <View style={styles.logActions}>
+                <Pressable
+                  onPress={openMenuPick}
+                  style={({ pressed }) => [
+                    styles.menuChip,
+                    pressed && { opacity: 0.85 },
+                  ]}
+                  accessibilityLabel="登録メニューから追加"
+                >
+                  <Ionicons name="restaurant-outline" size={16} color="#e5e7eb" />
+                  <Text style={styles.menuChipText}>メニュー</Text>
+                </Pressable>
+                <Pressable
+                  onPress={openAddEntry}
+                  style={({ pressed }) => [
+                    styles.addChip,
+                    pressed && { opacity: 0.85 },
+                  ]}
+                  accessibilityLabel="食事を手入力で追加"
+                >
+                  <Ionicons name="add" size={18} color="#022c22" />
+                  <Text style={styles.addChipText}>追加</Text>
+                </Pressable>
+              </View>
             </View>
             {logEntries.length === 0 ? (
               <Text style={styles.logEmpty}>
-                まだ記録がありません。「追加」から手入力で登録できます（Web
+                まだ記録がありません。「メニュー」で Web
+                に登録した店のメニューから、「追加」から手入力で登録できます（Web
                 での記録もここに表示されます）。
               </Text>
             ) : (
@@ -459,6 +491,14 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
         </ScrollView>
       </View>
 
+      <MenuPickModal
+        visible={menuPickOpen}
+        supabase={supabase}
+        userId={userId}
+        onClose={() => setMenuPickOpen(false)}
+        onPick={onMenuPicked}
+      />
+
       <FoodLogEntryModal
         visible={entryModalOpen}
         mode={entryModalMode}
@@ -466,9 +506,11 @@ export function TodayScreen({ session, onSignOut }: TodayScreenProps) {
         userId={userId}
         date={jstDate}
         entry={editingEntry}
+        menuPrefill={entryModalMode === "add" ? menuPrefill : null}
         onClose={() => {
           setEntryModalOpen(false);
           setEditingEntry(null);
+          setMenuPrefill(null);
         }}
         onSaved={load}
         onToast={showToast}
@@ -654,11 +696,28 @@ const styles = StyleSheet.create({
     justifyContent: "space-between",
     marginBottom: 10,
   },
+  logActions: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
   logSectionTitle: {
     color: COLORS.text,
     fontSize: 15,
     fontWeight: "600",
   },
+  menuChip: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    backgroundColor: "#1f2937",
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: COLORS.headerBorder,
+  },
+  menuChipText: { color: COLORS.text, fontWeight: "600", fontSize: 13 },
   addChip: {
     flexDirection: "row",
     alignItems: "center",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.46.0",
+  "version": "1.47.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## 概要
[Native PoC] Issue #269: Web で登録した店舗・メニューから選択し、当日の食事記録フォームへ反映する最小導線です。

## 変更内容
- `MenuPickModal`: 店舗一覧・メニュー一覧、店名／メニュー名の絞り込み。店舗が1件（スナップショット店除く）のときは店舗ステップを省略。
- `FoodLogEntryModal`: `menuPrefill` で品目・標準分量・100g あたり PFC をプリフィル。保存時は Web の `saveMealToLog` と同様に `menu_item_id` と `source`（店舗 UUID）を付与。手入力は従来どおり `manual`。
- レガシー DB 向け: `restaurants.display_order` 列が無くても店舗一覧が取得できるよう、取得列とソートを `order_count` / `created_at` ベースに変更。

## リリース
- ルート `package.json` を **1.47.0** に更新（`CHANGELOG.md` に同版見出しを追加）。

closes #269

Made with [Cursor](https://cursor.com)