### PR TITLE
fix: TestFlight で Supabase 未設定になる問題を修正

### DIFF
--- a/.github/workflows/mobile-ios-testflight-release.yml
+++ b/.github/workflows/mobile-ios-testflight-release.yml
@@ -48,5 +48,13 @@ jobs:
       - name: Typecheck mobile app
         run: npm run mobile:typecheck
 
+      - name: Sync required EAS production env vars
+        run: |
+          npx --yes eas-cli env:create --non-interactive --force --environment production --name EXPO_PUBLIC_SUPABASE_PRODUCTION_URL --value "$EXPO_PUBLIC_SUPABASE_PRODUCTION_URL" --visibility sensitive
+          npx --yes eas-cli env:create --non-interactive --force --environment production --name EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY --value "$EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY" --visibility sensitive
+          npx --yes eas-cli env:create --non-interactive --force --environment production --name EXPO_PUBLIC_SUPABASE_URL --value "$EXPO_PUBLIC_SUPABASE_PRODUCTION_URL" --visibility sensitive
+          npx --yes eas-cli env:create --non-interactive --force --environment production --name EXPO_PUBLIC_SUPABASE_ANON_KEY --value "$EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY" --visibility sensitive
+        working-directory: apps/mobile
+
       - name: Build iOS and auto-submit to TestFlight
         run: npm --prefix apps/mobile run eas:build:ios:production -- --non-interactive --auto-submit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.49.1] - 2026-04-23
+
+### Fixed
+
+- **Mobile / Supabase 設定**: TestFlight 実機で `Supabase 未設定` になる問題を修正。接続先解決をデバイス判定依存から外し、`EXPO_PUBLIC_SUPABASE_PRODUCTION_*` 優先 + `EXPO_PUBLIC_SUPABASE_*` フォールバックで安定化した（[#271](https://github.com/kzkski/ketolog/issues/271)）。
+- **CI / iOS 配布自動化**: `Mobile iOS TestFlight Release` 実行時に required な Supabase env を EAS production 環境へ同期してから build するようにし、Actions 経由でも起動設定が欠けないようにした（[#271](https://github.com/kzkski/ketolog/issues/271)）。
+
 ## [1.49.0] - 2026-04-23
 
 ### Added

--- a/apps/mobile/App.tsx
+++ b/apps/mobile/App.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from "react";
 import { StatusBar } from "expo-status-bar";
 import * as SplashScreen from "expo-splash-screen";
-import Constants from "expo-constants";
 import { ActivityIndicator, StyleSheet, Text, View } from "react-native";
 import { useAuthSession } from "./hooks/useAuthSession";
 import { isSupabaseConfigured } from "./lib/supabase";
@@ -10,14 +9,11 @@ import { TodayScreen } from "./screens/TodayScreen";
 import { LoginScreen } from "./screens/LoginScreen";
 
 function MissingSupabaseConfigScreen() {
-  const onDevice = Constants.isDevice === true;
   return (
     <View style={styles.centered}>
       <Text style={styles.errorTitle}>Supabase 未設定</Text>
       <Text style={styles.hint}>
-        {onDevice
-          ? "実機では本番接続用の変数が必要です。`apps/mobile/.env` に次を定義し、**実機向けに再ビルド**（または EAS の env 注入）してください。\n\nEXPO_PUBLIC_SUPABASE_PRODUCTION_URL\nEXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY\n\n互換のため EXPO_PUBLIC_SUPABASE_URL / EXPO_PUBLIC_SUPABASE_ANON_KEY もフォールバックとして利用します。"
-          : "シミュレータではローカル Supabase 用に次を定義し、Expo（Metro）を再起動してください。\n\nEXPO_PUBLIC_SUPABASE_URL\nEXPO_PUBLIC_SUPABASE_ANON_KEY\n\n雛形は `apps/mobile/.env.example` を参照。"}
+        {"接続用の環境変数が不足しています。`apps/mobile/.env` または EAS env に次を設定し、再ビルドしてください。\n\nEXPO_PUBLIC_SUPABASE_PRODUCTION_URL\nEXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY\n\n互換のため次も利用できます。\nEXPO_PUBLIC_SUPABASE_URL\nEXPO_PUBLIC_SUPABASE_ANON_KEY\n\n雛形は `apps/mobile/.env.example` を参照。"}
       </Text>
       <StatusBar style="light" />
     </View>

--- a/apps/mobile/lib/supabase.ts
+++ b/apps/mobile/lib/supabase.ts
@@ -1,34 +1,22 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
-import Constants from "expo-constants";
-
 let client: SupabaseClient | null = null;
 
 /**
- * 実機（物理デバイス）では本番 Supabase、シミュレータ / エミュレータではローカル用の
- * `EXPO_PUBLIC_SUPABASE_*` を使う（`Constants.isDevice` は Expo が提供する判別）。
+ * Prefer production keys first, then fall back to legacy/local keys.
+ * Do not branch on device detection because runtime flags can differ
+ * between Expo Go / dev build / TestFlight.
  */
 function resolveSupabaseEnv(): { url: string; key: string } | null {
-  const onPhysicalDevice = Constants.isDevice === true;
-  if (onPhysicalDevice) {
-    // Prefer dedicated production keys for physical devices, but keep backward
-    // compatibility with EXPO_PUBLIC_SUPABASE_* so TestFlight builds don't break
-    // when only legacy keys are configured on EAS.
-    const productionUrl =
-      process.env.EXPO_PUBLIC_SUPABASE_PRODUCTION_URL?.trim();
-    const productionKey =
-      process.env.EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY?.trim();
-    if (productionUrl && productionKey) {
-      return { url: productionUrl, key: productionKey };
-    }
-    const fallbackUrl = process.env.EXPO_PUBLIC_SUPABASE_URL?.trim();
-    const fallbackKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY?.trim();
-    if (fallbackUrl && fallbackKey) return { url: fallbackUrl, key: fallbackKey };
-    return null;
+  const productionUrl = process.env.EXPO_PUBLIC_SUPABASE_PRODUCTION_URL?.trim();
+  const productionKey =
+    process.env.EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY?.trim();
+  if (productionUrl && productionKey) {
+    return { url: productionUrl, key: productionKey };
   }
-  const url = process.env.EXPO_PUBLIC_SUPABASE_URL?.trim();
-  const key = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY?.trim();
-  if (url && key) return { url, key };
+  const fallbackUrl = process.env.EXPO_PUBLIC_SUPABASE_URL?.trim();
+  const fallbackKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY?.trim();
+  if (fallbackUrl && fallbackKey) return { url: fallbackUrl, key: fallbackKey };
   return null;
 }
 
@@ -39,11 +27,8 @@ export function isSupabaseConfigured(): boolean {
 export function getSupabase(): SupabaseClient {
   const resolved = resolveSupabaseEnv();
   if (!resolved) {
-    const onPhysicalDevice = Constants.isDevice === true;
     throw new Error(
-      onPhysicalDevice
-        ? "実機用の `EXPO_PUBLIC_SUPABASE_PRODUCTION_URL` / `EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY`（またはフォールバックの `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY`）が未設定、または空です。"
-        : "シミュレータ用の `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` が未設定、または空です。"
+      "`EXPO_PUBLIC_SUPABASE_PRODUCTION_URL` / `EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY` または `EXPO_PUBLIC_SUPABASE_URL` / `EXPO_PUBLIC_SUPABASE_ANON_KEY` が未設定、または空です。"
     );
   }
   if (!client) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.49.0",
+      "version": "1.49.1",
       "workspaces": [
         "apps/*",
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## Summary
- TestFlight 実機で `Supabase 未設定` になる問題を修正
- Supabase 接続先解決をデバイス判定依存から外し、`EXPO_PUBLIC_SUPABASE_PRODUCTION_*` 優先 + `EXPO_PUBLIC_SUPABASE_*` フォールバックに変更
- `Mobile iOS TestFlight Release` workflow で、build 前に required な Supabase env を EAS production へ同期する処理を追加

## Test plan
- [x] `npm --prefix apps/mobile run typecheck`
- [ ] GitHub Actions `Mobile iOS TestFlight Release` を再実行し、TestFlight 実機で起動確認

closes #271

Made with [Cursor](https://cursor.com)