### PR TITLE
feat: モバイル Today コア（日付・記録・スナップショット source）#289

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,20 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.51.0] - 2026-04-23
+
+### Added
+
+- **Mobile / Today（#287 子）**: JST の日付ナビ（未来日不可）、選択日の `food_log` 取得、手入力時の `source` を Web と同じスナップショット店 UUID に統一（`getOrCreateSnapshotRestaurant` 相当）。過去日表示時は「今日」チップで当日へ戻れるようにした（[#289](https://github.com/kzkski/ketolog/issues/289)）。
+
+### Fixed
+
+- **Mobile / Today**: Hermes / iOS で日付ナビの曜日が「？」になる問題を、`Intl` の曜日表記に依存しない暦計算へ切り替えて解消した（[#289](https://github.com/kzkski/ketolog/issues/289)）。
+
+### Changed
+
+- **Shared / domain**: Today 向けに `formatNavDate` を追加し、モバイルの日付ラベルで利用するようにした（[#289](https://github.com/kzkski/ketolog/issues/289)）。
+
 ## [1.50.0] - 2026-04-23
 
 ### Added

--- a/apps/mobile/components/FoodLogEntryModal.tsx
+++ b/apps/mobile/components/FoodLogEntryModal.tsx
@@ -71,6 +71,8 @@ type Props = {
   supabase: SupabaseClient;
   userId: string;
   date: string;
+  /** 手入力時の `food_log.source`（Web と同じスナップショット店 UUID）。メニュー経路では未使用。 */
+  snapshotRestaurantId: string | null;
   entry: FoodLogRow | null;
   /** メニューから開いたときのプリフィル。手入力のときは null。 */
   menuPrefill: MenuPrefill | null;
@@ -87,6 +89,7 @@ export function FoodLogEntryModal({
   supabase,
   userId,
   date,
+  snapshotRestaurantId,
   entry,
   menuPrefill,
   onClose,
@@ -143,6 +146,17 @@ export function FoodLogEntryModal({
       setFormError("品目名を入力してください");
       return;
     }
+    if (!menuPrefill && !snapshotRestaurantId) {
+      setFormError(
+        "手入力の店舗情報を取得できませんでした。通信を確認してから再度お試しください。"
+      );
+      return;
+    }
+    const sourceId = menuPrefill?.restaurantId ?? snapshotRestaurantId;
+    if (!sourceId) {
+      setFormError("保存できませんでした。しばらくしてから再度お試しください。");
+      return;
+    }
     const grams = parseNum(gramsStr);
     if (grams == null || grams <= 0) {
       setFormError("分量（g）は正の数で入力してください");
@@ -162,7 +176,7 @@ export function FoodLogEntryModal({
       protein_g: v.p,
       fat_g: v.f,
       carbs_g: v.c,
-      source: menuPrefill?.restaurantId ?? "manual",
+      source: sourceId,
       menu_item_id: menuPrefill?.menuItemId ?? null,
       saved_at: new Date().toISOString(),
     };
@@ -224,6 +238,7 @@ export function FoodLogEntryModal({
     onSaved,
     onToast,
     onOutboxChanged,
+    snapshotRestaurantId,
   ]);
 
   const runSaveEdit = useCallback(async () => {

--- a/apps/mobile/lib/get-or-create-snapshot-restaurant.ts
+++ b/apps/mobile/lib/get-or-create-snapshot-restaurant.ts
@@ -1,0 +1,81 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { SNAPSHOT_RESTAURANT_NAME } from "./snapshot-restaurant";
+
+function isUniqueConstraintViolation(
+  err: { code?: string; message?: string } | null | undefined
+): boolean {
+  if (!err) return false;
+  if (err.code === "23505") return true;
+  return typeof err.message === "string" && err.message.includes("duplicate key");
+}
+
+/** Web `getOrCreateSnapshotRestaurant`（`src/app/today/actions/restaurant.ts`）と同じ挙動。 */
+export async function getOrCreateSnapshotRestaurant(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<{ data: { id: string } | null; error: string | null }> {
+  const { data: existingRows, error: selectError } = await supabase
+    .from("restaurants")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("name", SNAPSHOT_RESTAURANT_NAME)
+    .order("created_at", { ascending: true })
+    .limit(1);
+
+  if (selectError) return { data: null, error: selectError.message };
+  const existing = existingRows?.[0];
+  if (existing?.id) return { data: { id: String(existing.id) }, error: null };
+
+  const { data: maxRow } = await supabase
+    .from("restaurants")
+    .select("display_order")
+    .eq("user_id", userId)
+    .order("display_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const displayOrder = (maxRow?.display_order ?? -1) + 1;
+
+  const insertPrimary = await supabase
+    .from("restaurants")
+    .insert({
+      user_id: userId,
+      name: SNAPSHOT_RESTAURANT_NAME,
+      category: "other",
+      display_order: displayOrder,
+    })
+    .select("id")
+    .single();
+
+  let inserted = insertPrimary;
+
+  if (insertPrimary.error && insertPrimary.error.message.includes("display_order")) {
+    inserted = await supabase
+      .from("restaurants")
+      .insert({
+        user_id: userId,
+        name: SNAPSHOT_RESTAURANT_NAME,
+        category: "other",
+      })
+      .select("id")
+      .single();
+  }
+
+  if (inserted.error && isUniqueConstraintViolation(inserted.error)) {
+    const { data: afterConflict, error: retryErr } = await supabase
+      .from("restaurants")
+      .select("id")
+      .eq("user_id", userId)
+      .eq("name", SNAPSHOT_RESTAURANT_NAME)
+      .order("created_at", { ascending: true })
+      .limit(1);
+    if (retryErr) return { data: null, error: retryErr.message };
+    const row = afterConflict?.[0];
+    if (row?.id) return { data: { id: String(row.id) }, error: null };
+  }
+
+  if (inserted.error) return { data: null, error: inserted.error.message };
+  const id = inserted.data?.id;
+  if (!id) return { data: null, error: "スナップショット店舗の作成に失敗しました" };
+  return { data: { id: String(id) }, error: null };
+}

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -16,7 +16,11 @@ import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import Constants from "expo-constants";
 import { sumPfc, type PfcGrams } from "@ketolog/domain/pfc";
-import { toJstDateString } from "@ketolog/domain/date";
+import {
+  addDaysJst,
+  formatNavDate,
+  toJstDateString,
+} from "@ketolog/domain/date";
 import {
   type DietPhase,
   type PhaseProfiles,
@@ -38,6 +42,7 @@ import {
   type FoodLogOutboxDraft,
 } from "../lib/food-log-outbox";
 import { getIsOnline } from "../lib/network";
+import { getOrCreateSnapshotRestaurant } from "../lib/get-or-create-snapshot-restaurant";
 
 type UserSettingsState = {
   diet_phase: DietPhase;
@@ -120,7 +125,11 @@ export function TodayScreen() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [settings, setSettings] = useState<UserSettingsState | null>(null);
   const [consumed, setConsumed] = useState<PfcGrams>({ p: 0, f: 0, c: 0 });
-  const [jstDate, setJstDate] = useState(() => toJstDateString());
+  const [selectedDate, setSelectedDate] = useState(() => toJstDateString());
+  const [snapshotRestaurantId, setSnapshotRestaurantId] = useState<
+    string | null
+  >(null);
+  const [snapshotError, setSnapshotError] = useState<string | null>(null);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [phaseSaving, setPhaseSaving] = useState(false);
   const [logEntries, setLogEntries] = useState<FoodLogRow[]>([]);
@@ -132,8 +141,12 @@ export function TodayScreen() {
   const [toast, setToast] = useState<string | null>(null);
   const [outbox, setOutbox] = useState<FoodLogOutboxDraft[]>([]);
   const [resendingDraftId, setResendingDraftId] = useState<string | null>(null);
+  const [loadingDate, setLoadingDate] = useState(false);
+  const initialLoadDoneForUser = useRef(false);
+  const prevUserIdForDate = useRef<string | null>(null);
 
   const appVersion = Constants.expoConfig?.version ?? "—";
+  const todayJst = toJstDateString();
 
   const refreshOutbox = useCallback(async () => {
     if (!userId) return;
@@ -153,10 +166,8 @@ export function TodayScreen() {
   const load = useCallback(async () => {
     if (!userId) return;
     setLoadError(null);
-    const today = toJstDateString();
-    setJstDate(today);
 
-    const [settingsRes, logRes] = await Promise.all([
+    const [settingsRes, logRes, snapRes] = await Promise.all([
       supabase
         .from("user_settings")
         .select("diet_phase, phase_profiles")
@@ -168,8 +179,9 @@ export function TodayScreen() {
           "id, date, meal_type, item_name, grams, protein_g, fat_g, carbs_g"
         )
         .eq("user_id", userId)
-        .eq("date", today)
+        .eq("date", selectedDate)
         .order("created_at", { ascending: true }),
+      getOrCreateSnapshotRestaurant(supabase, userId),
     ]);
 
     if (settingsRes.error) {
@@ -179,6 +191,13 @@ export function TodayScreen() {
     if (logRes.error) {
       setLoadError(logRes.error.message);
       return;
+    }
+    if (snapRes.error) {
+      setSnapshotError(snapRes.error);
+      setSnapshotRestaurantId(null);
+    } else {
+      setSnapshotError(null);
+      setSnapshotRestaurantId(snapRes.data?.id ?? null);
     }
 
     setSettings(normalizeUserSettings(settingsRes.data));
@@ -204,13 +223,36 @@ export function TodayScreen() {
         }))
       )
     );
-  }, [supabase, userId]);
+  }, [supabase, userId, selectedDate]);
 
   const openAddEntry = useCallback(() => {
+    if (!snapshotRestaurantId) {
+      showToast(
+        snapshotError ??
+          "手入力の準備ができていません。通信を確認してから再度お試しください。"
+      );
+      return;
+    }
     setMenuPrefill(null);
     setEditingEntry(null);
     setEntryModalMode("add");
     setEntryModalOpen(true);
+  }, [showToast, snapshotError, snapshotRestaurantId]);
+
+  const goPrevDate = useCallback(() => {
+    setSelectedDate((d) => addDaysJst(d, -1));
+  }, []);
+
+  const goNextDate = useCallback(() => {
+    setSelectedDate((d) => {
+      const n = addDaysJst(d, 1);
+      if (n > toJstDateString()) return d;
+      return n;
+    });
+  }, []);
+
+  const goToday = useCallback(() => {
+    setSelectedDate(toJstDateString());
   }, []);
 
   const openMenuPick = useCallback(() => {
@@ -266,17 +308,35 @@ export function TodayScreen() {
   );
 
   useEffect(() => {
+    initialLoadDoneForUser.current = false;
+    if (userId && prevUserIdForDate.current !== userId) {
+      queueMicrotask(() => {
+        setSelectedDate(toJstDateString());
+      });
+    }
+    prevUserIdForDate.current = userId || null;
+  }, [userId]);
+
+  useEffect(() => {
     if (!userId) return;
     let cancelled = false;
+    const isFirstForUser = !initialLoadDoneForUser.current;
     (async () => {
-      setLoading(true);
+      if (isFirstForUser) setLoading(true);
+      else setLoadingDate(true);
       await Promise.all([load(), refreshOutbox()]);
-      if (!cancelled) setLoading(false);
+      if (cancelled) return;
+      if (isFirstForUser) {
+        setLoading(false);
+        initialLoadDoneForUser.current = true;
+      } else {
+        setLoadingDate(false);
+      }
     })();
     return () => {
       cancelled = true;
     };
-  }, [load, refreshOutbox, userId]);
+  }, [load, refreshOutbox, userId, selectedDate]);
 
   const onRefresh = useCallback(async () => {
     if (!userId) return;
@@ -402,7 +462,7 @@ export function TodayScreen() {
             </View>
             <View>
               <Text style={styles.brandName}>Ketolog</Text>
-              <Text style={styles.brandSub}>v{appVersion} · 記録（JST {jstDate}）</Text>
+              <Text style={styles.brandSub}>v{appVersion}</Text>
             </View>
           </View>
           <Pressable
@@ -415,6 +475,56 @@ export function TodayScreen() {
           </Pressable>
         </View>
 
+        <View style={styles.dateNav}>
+          <Pressable
+            onPress={goPrevDate}
+            disabled={loadingDate}
+            style={({ pressed }) => [
+              styles.dateNavBtn,
+              (loadingDate || pressed) && { opacity: 0.65 },
+            ]}
+            accessibilityLabel="前の日"
+          >
+            <Ionicons name="chevron-back" size={22} color={COLORS.text} />
+          </Pressable>
+          <View style={styles.dateNavCenter}>
+            {loadingDate ? (
+              <ActivityIndicator size="small" color={COLORS.c} />
+            ) : (
+              <Text style={styles.dateNavLabel} numberOfLines={1}>
+                {formatNavDate(selectedDate, todayJst)}
+              </Text>
+            )}
+          </View>
+          {selectedDate !== todayJst ? (
+            <Pressable
+              onPress={goToday}
+              disabled={loadingDate}
+              style={({ pressed }) => [
+                styles.todayChip,
+                (loadingDate || pressed) && { opacity: 0.75 },
+              ]}
+              accessibilityLabel="今日に戻る"
+              accessibilityRole="button"
+            >
+              <Text style={styles.todayChipText}>今日</Text>
+            </Pressable>
+          ) : null}
+          <Pressable
+            onPress={goNextDate}
+            disabled={selectedDate >= todayJst || loadingDate}
+            style={({ pressed }) => [
+              styles.dateNavBtn,
+              (selectedDate >= todayJst || loadingDate || pressed) && {
+                opacity: 0.35,
+              },
+            ]}
+            accessibilityLabel="次の日"
+          >
+            <Ionicons name="chevron-forward" size={22} color={COLORS.text} />
+          </Pressable>
+        </View>
+
         <ScrollView
           style={styles.scroll}
           contentContainerStyle={styles.scrollContent}
@@ -423,6 +533,12 @@ export function TodayScreen() {
           }
         >
           {loadError ? <Text style={styles.inlineError}>{loadError}</Text> : null}
+          {snapshotError && !snapshotRestaurantId ? (
+            <Text style={styles.inlineWarn}>
+              手入力用の店舗データを読み込めませんでした（{snapshotError}
+              ）。メニューからの追加は利用できます。
+            </Text>
+          ) : null}
 
           <View style={styles.phaseRow}>
             {DIET_PHASES.map((ph) => {
@@ -533,7 +649,9 @@ export function TodayScreen() {
               </View>
             ) : null}
             <View style={styles.logSectionHeader}>
-              <Text style={styles.logSectionTitle}>今日の記録</Text>
+              <Text style={styles.logSectionTitle}>
+                {selectedDate === todayJst ? "今日の記録" : "この日の記録"}
+              </Text>
               <View style={styles.logActions}>
                 <Pressable
                   onPress={openMenuPick}
@@ -563,7 +681,7 @@ export function TodayScreen() {
               <Text style={styles.logEmpty}>
                 まだ記録がありません。「メニュー」で Web
                 に登録した店のメニューから、「追加」から手入力で登録できます（Web
-                での記録もここに表示されます）。
+                での記録もここに表示されます）。過去の日付は上の矢印で切り替えられます。
               </Text>
             ) : (
               logEntries.map((e) => (
@@ -628,7 +746,8 @@ export function TodayScreen() {
         mode={entryModalMode}
         supabase={supabase}
         userId={userId}
-        date={jstDate}
+        date={selectedDate}
+        snapshotRestaurantId={snapshotRestaurantId}
         entry={editingEntry}
         menuPrefill={entryModalMode === "add" ? menuPrefill : null}
         onClose={() => {
@@ -741,6 +860,50 @@ const styles = StyleSheet.create({
     color: COLORS.textMuted,
     fontSize: 11,
     marginTop: 2,
+  },
+  dateNav: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    backgroundColor: COLORS.sectionBg,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: COLORS.headerBorder,
+  },
+  dateNavBtn: {
+    minWidth: 44,
+    minHeight: 40,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dateNavCenter: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 4,
+    minHeight: 40,
+    minWidth: 0,
+  },
+  dateNavLabel: {
+    color: COLORS.text,
+    fontSize: 15,
+    fontWeight: "600",
+    textAlign: "center",
+  },
+  todayChip: {
+    paddingVertical: 6,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.c,
+    backgroundColor: "rgba(16, 185, 129, 0.18)",
+    marginRight: 2,
+  },
+  todayChipText: {
+    color: "#a7f3d0",
+    fontSize: 13,
+    fontWeight: "700",
   },
   iconBtn: {
     minWidth: 40,
@@ -973,6 +1136,13 @@ const styles = StyleSheet.create({
     fontSize: 12,
     marginHorizontal: 12,
     marginTop: 8,
+  },
+  inlineWarn: {
+    color: "#fde68a",
+    fontSize: 12,
+    marginHorizontal: 12,
+    marginTop: 8,
+    lineHeight: 18,
   },
   errorTitle: { color: "#fecaca", fontSize: 16, fontWeight: "600" },
   errorMsg: { color: COLORS.text, marginTop: 8, textAlign: "center" },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.50.0",
+  "version": "1.51.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/src/date.test.ts
+++ b/packages/domain/src/date.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { addDaysJst, eachDate, getTokyoHourMinute, toJstDateString } from "./date";
+import {
+  addDaysJst,
+  eachDate,
+  formatNavDate,
+  getTokyoHourMinute,
+  toJstDateString,
+} from "./date";
 
 describe("addDaysJst", () => {
   it("翌日へ進む", () => {
@@ -36,5 +42,22 @@ describe("toJstDateString", () => {
 describe("getTokyoHourMinute", () => {
   it("東京の時分を返す", () => {
     expect(getTokyoHourMinute(new Date("2024-06-01T10:30:00.000Z"))).toEqual({ hour: 19, minute: 30 });
+  });
+});
+
+describe("formatNavDate", () => {
+  it("今日と一致するとプレフィックスが付く", () => {
+    expect(formatNavDate("2024-06-15", "2024-06-15")).toMatch(/^今日 /);
+  });
+
+  it("別日では今日プレフィックスが付かない", () => {
+    expect(formatNavDate("2024-06-15", "2024-06-16")).not.toMatch(/^今日 /);
+    expect(formatNavDate("2024-06-15", "2024-06-16")).toContain("6/15");
+    expect(formatNavDate("2024-06-15", "2024-06-16")).toContain("（");
+  });
+
+  it("曜日はロケールに依存せず日本語1文字になる", () => {
+    // 2026-04-23 は木曜
+    expect(formatNavDate("2026-04-23", "2026-04-24")).toContain("（木）");
   });
 });

--- a/packages/domain/src/date.ts
+++ b/packages/domain/src/date.ts
@@ -37,3 +37,23 @@ export function eachDate(start: string, end: string): string[] {
   }
   return out;
 }
+
+const NAV_DAY_LABELS = ["日", "月", "火", "水", "木", "金", "土"] as const;
+
+/**
+ * Today 画面の日付ナビ表示。`dateStr` / `todayJst` は `toJstDateString` と同じ `YYYY-MM-DD`。
+ * 暦日は JST の暦として解釈し、曜日は `Intl` のロケール差（Hermes / iOS 等）に依存しない。
+ */
+export function formatNavDate(dateStr: string, todayJst: string): string {
+  const parts = dateStr.split("-").map(Number);
+  const y = parts[0]!;
+  const mo = parts[1]!;
+  const d = parts[2]!;
+  // その暦日の JST 正午 = UTC 同日 03:00（日本は DST なし）。その瞬間の世界共通の曜日 = その日の曜日。
+  const anchor = new Date(Date.UTC(y, mo - 1, d, 3, 0, 0));
+  const wi = anchor.getUTCDay();
+  const wk = NAV_DAY_LABELS[wi] ?? "？";
+
+  const label = `${mo}/${d}（${wk}）`;
+  return dateStr === todayJst ? `今日 ${label}` : label;
+}


### PR DESCRIPTION
## 概要
Issue #289（Today コア）のモバイル実装と、日付ナビの曜日表記・「今日」戻りの UI 修正を含みます。

## 変更
- JST の `selectedDate`、前日／翌日（未来不可）、明示の「今日」チップ
- 手入力 `source` をスナップショット店 UUID に（Web の `getOrCreateSnapshotRestaurant` と同等）
- `@ketolog/domain` の `formatNavDate`（曜日は UTC 暦計算で Hermes でも安定）

closes #289

Made with [Cursor](https://cursor.com)