### PR TITLE
feat(mobile): Today のメニュー・店舗まわりを Web に揃える

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,23 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.52.0] - 2026-04-23
+
+### Added
+
+- **Mobile / Today**: Web のメニュー項目ドロワー相当の `MenuItemEditorModal`（メニュー追加・編集・削除、栄養素の表示単位、登録先・今すぐ記録・カート・メニューに登録）。
+- **Mobile / Today**: 店舗タブ行末尾の「＋」で `AddRestaurantModal` から店舗を追加し、追加直後にその店タブへ切り替え（Web `RestaurantPanel` と同様の配置）。
+- **Mobile / Today**: メニュー一覧下の破線「＋ メニューを追加」（Web `MenuItemList` と同様）。
+- **Mobile / Today**: カートの未登録行用 `snapshotDraft` と、記録時の `menu_item_id: null` 付与。
+
+### Changed
+
+- **Mobile / Today**: 記録パネルの「手入力」からも `MenuItemEditorModal` を開き、Web の食事区分横「＋」と同じ導線に統一した。
+- **Mobile / Today**: メニュー行の編集は品名・PFC ブロックのタップのみ（Web `MenuItemRow` と同等）。専用「編集」ボタンを廃止した。
+- **Mobile / Today**: 記録ヘッダーは「手入力」のみに整理した。
+- **Mobile / Today**: 食事ログの追加（プリフィル）・記録の編集は `FoodLogEntryModal`、メニュー CRUD は `MenuItemEditorModal` に分離した。
+- **Mobile / MenuPickModal**: お気に入りタブ・星トグル・店舗並び（`display_order`）を Today 周りと揃えた。
+
 ## [1.51.0] - 2026-04-23
 
 ### Added

--- a/apps/mobile/components/AddRestaurantModal.tsx
+++ b/apps/mobile/components/AddRestaurantModal.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+import { addRestaurantMobile } from "../lib/add-restaurant-mobile";
+
+const COLORS = {
+  bg: "#111827",
+  text: "#e5e7eb",
+  textMuted: "#9ca3af",
+  border: "#374151",
+  primary: "#10b981",
+};
+
+type Props = {
+  visible: boolean;
+  supabase: SupabaseClient;
+  userId: string;
+  onClose: () => void;
+  onAdded: (restaurant: { id: string; name: string }) => void;
+  onToast: (message: string) => void;
+};
+
+export function AddRestaurantModal({
+  visible,
+  supabase,
+  userId,
+  onClose,
+  onAdded,
+  onToast,
+}: Props) {
+  const [name, setName] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleClose = useCallback(() => {
+    if (busy) return;
+    setName("");
+    setError(null);
+    onClose();
+  }, [busy, onClose]);
+
+  const handleSave = useCallback(async () => {
+    setBusy(true);
+    setError(null);
+    const r = await addRestaurantMobile(supabase, userId, name, "external");
+    setBusy(false);
+    if (r.error || !r.data) {
+      setError(r.error ?? "追加に失敗しました");
+      onToast(r.error ?? "追加に失敗しました");
+      return;
+    }
+    onAdded(r.data);
+    setName("");
+    onClose();
+    onToast("お店を追加しました");
+  }, [name, supabase, userId, onAdded, onClose, onToast]);
+
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={handleClose}>
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <Pressable style={StyleSheet.absoluteFill} onPress={handleClose} />
+        <View style={styles.card}>
+          <View style={styles.headerRow}>
+            <Text style={styles.title}>お店を追加</Text>
+            <Pressable onPress={handleClose} disabled={busy} hitSlop={8}>
+              <Text style={styles.cancel}>キャンセル</Text>
+            </Pressable>
+          </View>
+          <Text style={styles.label}>店名</Text>
+          <TextInput
+            value={name}
+            onChangeText={setName}
+            placeholder="例: サイゼリヤ"
+            placeholderTextColor={COLORS.textMuted}
+            style={styles.input}
+            editable={!busy}
+            maxLength={100}
+            autoFocus
+          />
+          {error ? <Text style={styles.error}>{error}</Text> : null}
+          <Pressable
+            onPress={() => void handleSave()}
+            disabled={busy}
+            style={[styles.saveBtn, busy && { opacity: 0.55 }]}
+          >
+            {busy ? (
+              <ActivityIndicator color="#022c22" />
+            ) : (
+              <Text style={styles.saveBtnText}>追加する</Text>
+            )}
+          </Pressable>
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  card: {
+    backgroundColor: COLORS.bg,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    padding: 16,
+    borderTopWidth: 1,
+    borderColor: COLORS.border,
+  },
+  headerRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 14,
+  },
+  title: { color: COLORS.text, fontSize: 17, fontWeight: "700" },
+  cancel: { color: COLORS.textMuted, fontSize: 14 },
+  label: { color: COLORS.textMuted, fontSize: 12, marginBottom: 6 },
+  input: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 12,
+    color: COLORS.text,
+    fontSize: 16,
+    marginBottom: 12,
+  },
+  error: { color: "#fecaca", fontSize: 13, marginBottom: 10 },
+  saveBtn: {
+    alignItems: "center",
+    paddingVertical: 14,
+    borderRadius: 10,
+    backgroundColor: COLORS.primary,
+  },
+  saveBtnText: { color: "#022c22", fontWeight: "700", fontSize: 16 },
+});

--- a/apps/mobile/components/FoodLogEntryModal.tsx
+++ b/apps/mobile/components/FoodLogEntryModal.tsx
@@ -71,7 +71,7 @@ type Props = {
   supabase: SupabaseClient;
   userId: string;
   date: string;
-  /** 手入力時の `food_log.source`（Web と同じスナップショット店 UUID）。メニュー経路では未使用。 */
+  /** 手入力時の `food_log.source`（スナップショット店 UUID）。メニュー経路では未使用。 */
   snapshotRestaurantId: string | null;
   entry: FoodLogRow | null;
   /** メニューから開いたときのプリフィル。手入力のときは null。 */
@@ -140,7 +140,7 @@ export function FoodLogEntryModal({
     }
   }, [visible, mode, entry, menuPrefill, resetAddForm]);
 
-  const runSaveAdd = useCallback(async () => {
+  const runSaveLogOnly = useCallback(async () => {
     const name = itemName.trim();
     if (!name) {
       setFormError("品目名を入力してください");
@@ -294,9 +294,13 @@ export function FoodLogEntryModal({
     await onSaved();
   }, [entry, gramsStr, meal, supabase, userId, onClose, onSaved, onToast]);
 
-  const onSubmit = useCallback(() => {
-    void (mode === "add" ? runSaveAdd() : runSaveEdit());
-  }, [mode, runSaveAdd, runSaveEdit]);
+  const onSubmitLogOnly = useCallback(() => {
+    void runSaveLogOnly();
+  }, [runSaveLogOnly]);
+
+  const onSubmitEdit = useCallback(() => {
+    void runSaveEdit();
+  }, [runSaveEdit]);
 
   return (
     <Modal
@@ -327,7 +331,7 @@ export function FoodLogEntryModal({
                 <Text style={styles.label}>品目</Text>
                 <Text style={styles.readonly}>{itemName}</Text>
                 <Text style={styles.hint}>
-                  名称の変更は Web 版から行うか、いったん削除して追加してください。
+                  名称の変更はメニュー編集から行うか、いったん削除して追加してください。
                 </Text>
               </View>
             ) : (
@@ -343,7 +347,7 @@ export function FoodLogEntryModal({
                 />
                 {menuPrefill ? (
                   <Text style={styles.hint}>
-                    メニューから読み込みました。名称の変更は Web 版のメニュー編集で行ってください。
+                    メニューから読み込みました。名称の変更はメニュー編集で行ってください。
                   </Text>
                 ) : null}
               </View>
@@ -428,8 +432,7 @@ export function FoodLogEntryModal({
               </>
             ) : (
               <Text style={styles.sectionHint}>
-                分量を変えると、もとの記録の PFC 比率に応じて再計算されます（Web
-                版と同じ）。
+                分量を変えると、もとの記録の PFC 比率に応じて再計算されます。
               </Text>
             )}
 
@@ -444,7 +447,7 @@ export function FoodLogEntryModal({
                 <Text style={styles.btnGhostText}>キャンセル</Text>
               </Pressable>
               <Pressable
-                onPress={onSubmit}
+                onPress={mode === "add" ? onSubmitLogOnly : onSubmitEdit}
                 disabled={busy}
                 style={[styles.btnPrimary, busy && { opacity: 0.6 }]}
               >
@@ -459,7 +462,7 @@ export function FoodLogEntryModal({
             </View>
             {formError ? (
               <Pressable
-                onPress={onSubmit}
+                onPress={mode === "edit" ? onSubmitEdit : onSubmitLogOnly}
                 disabled={busy}
                 style={styles.retry}
               >

--- a/apps/mobile/components/MenuItemEditorModal.tsx
+++ b/apps/mobile/components/MenuItemEditorModal.tsx
@@ -1,0 +1,1117 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { pfcGramsFromNullablePer100 } from "@ketolog/domain/pfc";
+import type { MealType } from "@ketolog/types";
+
+import { fetchDistinctMenuGroupNames } from "../lib/fetch-distinct-menu-group-names";
+import { fetchRestaurantsExcludingSnapshot } from "../lib/fetch-restaurants-excluding-snapshot";
+import {
+  buildFoodLogInsertPayload,
+  enqueueFoodLogDraft,
+  newClientRowId,
+  type FoodLogOutboxDraft,
+} from "../lib/food-log-outbox";
+import { getIsOnline, isTransientNetworkError } from "../lib/network";
+import { resolveMenuItemGroupOrder } from "../lib/resolve-menu-item-group-order";
+
+const MEALS: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
+const MEAL_LABEL: Record<MealType, string> = {
+  breakfast: "朝食",
+  lunch: "昼食",
+  dinner: "夕食",
+  snack: "間食",
+};
+
+const RANK_OPTIONS: { value: number; label: string }[] = [
+  { value: 1, label: "◎ 最優先" },
+  { value: 2, label: "○ 通常" },
+  { value: 3, label: "△ 控えめ" },
+  { value: 4, label: "✕ 避ける" },
+];
+
+const MEMO_MIN_ROWS = 3;
+
+type NutrientMode = "per100g" | "perServing";
+
+const COLORS = {
+  bg: "#111827",
+  text: "#e5e7eb",
+  textMuted: "#9ca3af",
+  border: "#374151",
+  primary: "#10b981",
+  danger: "#ef4444",
+};
+
+function to100g(val: string, gramsStr: string): string {
+  const v = parseFloat(val);
+  const g = parseFloat(gramsStr);
+  if (Number.isNaN(v) || Number.isNaN(g) || g === 0) return val;
+  return String(parseFloat(((v * 100) / g).toFixed(2)));
+}
+
+function toServing(val: string, gramsStr: string): string {
+  const v = parseFloat(val);
+  const g = parseFloat(gramsStr);
+  if (Number.isNaN(v) || Number.isNaN(g)) return val;
+  return String(parseFloat(((v * g) / 100).toFixed(2)));
+}
+
+export type MenuItemEditorState =
+  | { kind: "add"; registerRestaurantIdHint?: string | null }
+  | { kind: "edit"; menuItemId: string };
+
+type MenuRow = {
+  id: string;
+  restaurant_id: string;
+  name: string;
+  protein_per_100g: number | null;
+  fat_per_100g: number | null;
+  carbs_per_100g: number | null;
+  default_grams: number;
+  rank: number;
+  notes: string | null;
+  group_name: string | null;
+  shared_barcode: string | null;
+  standard_food_code: string | null;
+};
+
+type Props = {
+  visible: boolean;
+  state: MenuItemEditorState | null;
+  supabase: SupabaseClient;
+  userId: string;
+  date: string;
+  mealTypeForLog: MealType;
+  snapshotRestaurantId: string | null;
+  onClose: () => void;
+  onSaved: () => Promise<void>;
+  onToast: (message: string) => void;
+  onAddSnapshotDraftToCart: (draft: {
+    name: string;
+    protein_per_100g: number | null;
+    fat_per_100g: number | null;
+    carbs_per_100g: number | null;
+    grams: number;
+  }) => void;
+  onOutboxChanged?: () => void | Promise<void>;
+};
+
+export function MenuItemEditorModal({
+  visible,
+  state,
+  supabase,
+  userId,
+  date,
+  mealTypeForLog,
+  snapshotRestaurantId,
+  onClose,
+  onSaved,
+  onToast,
+  onAddSnapshotDraftToCart,
+  onOutboxChanged,
+}: Props) {
+  const isEdit = state?.kind === "edit";
+
+  const [name, setName] = useState("");
+  const [protein, setProtein] = useState("");
+  const [fat, setFat] = useState("");
+  const [carbs, setCarbs] = useState("");
+  const [grams, setGrams] = useState("100");
+  const [rank, setRank] = useState(2);
+  const [groupName, setGroupName] = useState("");
+  const [notes, setNotes] = useState("");
+  const [nutrientMode, setNutrientMode] = useState<NutrientMode>("perServing");
+  const [rawP, setRawP] = useState<string | null>(null);
+  const [rawF, setRawF] = useState<string | null>(null);
+  const [rawC, setRawC] = useState<string | null>(null);
+
+  const [logMeal, setLogMeal] = useState<MealType>("lunch");
+
+  const [registerRestaurants, setRegisterRestaurants] = useState<{ id: string; name: string }[]>(
+    []
+  );
+  const [registerRestaurantId, setRegisterRestaurantId] = useState<string | null>(null);
+  const [registerRestaurantsLoading, setRegisterRestaurantsLoading] = useState(false);
+  const [existingGroupNames, setExistingGroupNames] = useState<string[]>([]);
+  const [groupSuggestOpen, setGroupSuggestOpen] = useState(false);
+
+  const [loadedEdit, setLoadedEdit] = useState<MenuRow | null>(null);
+  const [editLoading, setEditLoading] = useState(false);
+
+  const [formError, setFormError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  const gramsNum = parseFloat(grams);
+  const modeLabel =
+    nutrientMode === "per100g"
+      ? "100gあたり"
+      : `1回分あたり（${Number.isNaN(gramsNum) ? "?" : gramsNum}g）`;
+
+  const displayP = nutrientMode === "per100g" ? protein : toServing(protein, grams);
+  const displayF = nutrientMode === "per100g" ? fat : toServing(fat, grams);
+  const displayC = nutrientMode === "per100g" ? carbs : toServing(carbs, grams);
+
+  const handleNutrientModeChange = useCallback((m: NutrientMode) => {
+    setRawP(null);
+    setRawF(null);
+    setRawC(null);
+    setNutrientMode(m);
+  }, []);
+
+  const commitNutrientFromText = useCallback(
+    (field: "p" | "f" | "c", rawText: string) => {
+      const trimmed = rawText.trim();
+      const stored = nutrientMode === "per100g" ? trimmed : to100g(trimmed, grams);
+      if (field === "p") {
+        setProtein(stored);
+        setRawP(null);
+      }
+      if (field === "f") {
+        setFat(stored);
+        setRawF(null);
+      }
+      if (field === "c") {
+        setCarbs(stored);
+        setRawC(null);
+      }
+    },
+    [nutrientMode, grams]
+  );
+
+  const resetAddForm = useCallback(() => {
+    setName("");
+    setProtein("");
+    setFat("");
+    setCarbs("");
+    setGrams("100");
+    setRank(2);
+    setGroupName("");
+    setNotes("");
+    setNutrientMode("perServing");
+    setRawP(null);
+    setRawF(null);
+    setRawC(null);
+    setLogMeal(mealTypeForLog);
+    setLoadedEdit(null);
+    setFormError(null);
+    setConfirmDelete(false);
+  }, [mealTypeForLog]);
+
+  useEffect(() => {
+    if (!visible || !state) return;
+    setFormError(null);
+    setConfirmDelete(false);
+    if (state.kind === "add") {
+      resetAddForm();
+    }
+  }, [visible, state, resetAddForm]);
+
+  useEffect(() => {
+    if (!visible || !state || state.kind !== "add") return;
+    let cancelled = false;
+    (async () => {
+      setRegisterRestaurantsLoading(true);
+      const r = await fetchRestaurantsExcludingSnapshot(supabase, userId);
+      if (cancelled) return;
+      setRegisterRestaurantsLoading(false);
+      if (r.error) {
+        setRegisterRestaurants([]);
+        setRegisterRestaurantId(null);
+        return;
+      }
+      setRegisterRestaurants(r.restaurants);
+      const hint = state.registerRestaurantIdHint;
+      setRegisterRestaurantId((prev) => {
+        if (hint && r.restaurants.some((x) => x.id === hint)) return hint;
+        if (prev && r.restaurants.some((x) => x.id === prev)) return prev;
+        return r.restaurants[0]?.id ?? null;
+      });
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, state, supabase, userId]);
+
+  useEffect(() => {
+    if (!visible || !state || state.kind !== "add" || !registerRestaurantId) {
+      if (!visible || !state || state.kind !== "add") setExistingGroupNames([]);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const r = await fetchDistinctMenuGroupNames(supabase, userId, registerRestaurantId);
+      if (!cancelled && !r.error) setExistingGroupNames(r.names);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, state, registerRestaurantId, supabase, userId]);
+
+  useEffect(() => {
+    if (!visible || !state || state.kind !== "edit") {
+      setLoadedEdit(null);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      setEditLoading(true);
+      const { data, error } = await supabase
+        .from("menu_items")
+        .select(
+          "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, rank, notes, group_name, shared_barcode, standard_food_code"
+        )
+        .eq("id", state.menuItemId)
+        .eq("user_id", userId)
+        .maybeSingle();
+      if (cancelled) return;
+      setEditLoading(false);
+      if (error || !data) {
+        setFormError(error?.message ?? "メニューを読み込めませんでした");
+        setLoadedEdit(null);
+        return;
+      }
+      const row = data as MenuRow;
+      setLoadedEdit(row);
+      setName(row.name);
+      setProtein(row.protein_per_100g != null ? String(row.protein_per_100g) : "");
+      setFat(row.fat_per_100g != null ? String(row.fat_per_100g) : "");
+      setCarbs(row.carbs_per_100g != null ? String(row.carbs_per_100g) : "");
+      setGrams(String(row.default_grams ?? 100));
+      setRank(row.rank ?? 2);
+      setGroupName(row.group_name ?? "");
+      setNotes(row.notes ?? "");
+      setNutrientMode("perServing");
+      setRawP(null);
+      setRawF(null);
+      setRawC(null);
+      setLogMeal(mealTypeForLog);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [visible, state, supabase, userId, mealTypeForLog]);
+
+  const buildMenuPayload = useCallback(() => {
+    const gramsNum = parseFloat(grams) || 100;
+    const n = (s: string) => {
+      if (s.trim() === "") return null;
+      const v = parseFloat(s);
+      return Number.isFinite(v) ? v : null;
+    };
+    return {
+      name: name.trim(),
+      protein_per_100g: n(protein),
+      fat_per_100g: n(fat),
+      carbs_per_100g: n(carbs),
+      default_grams: gramsNum,
+      rank,
+      notes: notes.trim() || null,
+      group_name: groupName.trim() || null,
+      shared_barcode: loadedEdit?.shared_barcode ?? null,
+      standard_food_code: loadedEdit?.standard_food_code ?? null,
+    };
+  }, [name, protein, fat, carbs, grams, rank, notes, groupName, loadedEdit]);
+
+  const registerTargetRestaurantName = useMemo(
+    () => registerRestaurants.find((r) => r.id === registerRestaurantId)?.name ?? "",
+    [registerRestaurants, registerRestaurantId]
+  );
+
+  const canRegisterMenu =
+    !isEdit &&
+    !registerRestaurantsLoading &&
+    registerRestaurants.length > 0 &&
+    registerRestaurantId != null;
+
+  const applyMenuUpdate = useCallback(
+    async (id: string, payload: ReturnType<typeof buildMenuPayload>) => {
+      const { data: current, error: fetchErr } = await supabase
+        .from("menu_items")
+        .select("restaurant_id, group_name")
+        .eq("id", id)
+        .eq("user_id", userId)
+        .maybeSingle();
+
+      if (fetchErr || !current) {
+        return { error: fetchErr?.message ?? "メニューが見つかりません" as string };
+      }
+
+      const prevGroupName =
+        current.group_name == null ? null : String(current.group_name).trim() || null;
+      const nextGroupName = payload.group_name?.trim() || null;
+      const updateBody: Record<string, unknown> = {
+        name: payload.name,
+        protein_per_100g: payload.protein_per_100g,
+        fat_per_100g: payload.fat_per_100g,
+        carbs_per_100g: payload.carbs_per_100g,
+        default_grams: payload.default_grams,
+        rank: payload.rank,
+        notes: payload.notes,
+        group_name: nextGroupName,
+        shared_barcode: payload.shared_barcode,
+        standard_food_code: payload.standard_food_code,
+      };
+
+      if (prevGroupName !== nextGroupName) {
+        updateBody.group_order = await resolveMenuItemGroupOrder(
+          supabase,
+          userId,
+          current.restaurant_id as string,
+          nextGroupName
+        );
+      }
+
+      const { error } = await supabase.from("menu_items").update(updateBody).eq("id", id).eq(
+        "user_id",
+        userId
+      );
+      return { error: error?.message ?? null };
+    },
+    [supabase, userId]
+  );
+
+  const handleSaveMenu = useCallback(async () => {
+    if (!name.trim()) {
+      setFormError("名前を入力してください");
+      return;
+    }
+    if (!state) return;
+    const data = buildMenuPayload();
+
+    setBusy(true);
+    setFormError(null);
+    const online = await getIsOnline();
+    if (!online) {
+      setBusy(false);
+      setFormError("オフラインのときはメニューを保存できません。");
+      return;
+    }
+
+    if (state.kind === "edit") {
+      const { error } = await applyMenuUpdate(state.menuItemId, data);
+      setBusy(false);
+      if (error) {
+        setFormError(error);
+        onToast(`保存に失敗しました: ${error}`);
+        return;
+      }
+      onToast("保存しました");
+      onClose();
+      await onSaved();
+      return;
+    }
+
+    if (!registerRestaurantId) {
+      setBusy(false);
+      setFormError(
+        registerRestaurants.length === 0
+          ? "メニューに載せるお店がありません。店舗を追加してください。"
+          : "メニュー登録先のお店を選んでください。"
+      );
+      return;
+    }
+
+    const groupNameTrim = data.group_name?.trim() || null;
+    const groupOrder = await resolveMenuItemGroupOrder(
+      supabase,
+      userId,
+      registerRestaurantId,
+      groupNameTrim
+    );
+
+    const { error } = await supabase.from("menu_items").insert({
+      user_id: userId,
+      restaurant_id: registerRestaurantId,
+      name: data.name,
+      protein_per_100g: data.protein_per_100g,
+      fat_per_100g: data.fat_per_100g,
+      carbs_per_100g: data.carbs_per_100g,
+      default_grams: data.default_grams,
+      rank: data.rank,
+      notes: data.notes,
+      group_name: groupNameTrim,
+      group_order: groupOrder,
+      shared_barcode: null,
+      standard_food_code: null,
+    });
+
+    setBusy(false);
+    if (error) {
+      setFormError(error.message);
+      onToast(`メニュー登録に失敗しました: ${error.message}`);
+      return;
+    }
+    onToast("メニューに登録しました");
+    onClose();
+    await onSaved();
+  }, [
+    name,
+    buildMenuPayload,
+    state,
+    applyMenuUpdate,
+    onClose,
+    onSaved,
+    onToast,
+    registerRestaurantId,
+    registerRestaurants.length,
+    supabase,
+    userId,
+  ]);
+
+  const buildSnapshotLogDraft = useCallback((): FoodLogOutboxDraft | null => {
+    if (!snapshotRestaurantId) return null;
+    if (!name.trim()) return null;
+    const gramsNum = parseFloat(grams) || 100;
+    const p100 = protein === "" ? null : parseFloat(protein);
+    const f100 = fat === "" ? null : parseFloat(fat);
+    const c100 = carbs === "" ? null : parseFloat(carbs);
+    const v = pfcGramsFromNullablePer100(
+      p100 !== null && Number.isFinite(p100) ? p100 : null,
+      f100 !== null && Number.isFinite(f100) ? f100 : null,
+      c100 !== null && Number.isFinite(c100) ? c100 : null,
+      gramsNum
+    );
+    return {
+      id: newClientRowId(),
+      date,
+      meal_type: logMeal,
+      item_name: name.trim(),
+      grams: gramsNum,
+      protein_g: v.p,
+      fat_g: v.f,
+      carbs_g: v.c,
+      source: snapshotRestaurantId,
+      menu_item_id: null,
+      saved_at: new Date().toISOString(),
+    };
+  }, [snapshotRestaurantId, name, grams, protein, fat, carbs, date, logMeal]);
+
+  const handleLogOnly = useCallback(async () => {
+    const draft = buildSnapshotLogDraft();
+    if (!draft) {
+      setFormError("記録用の店舗情報を読み込めていません。");
+      return;
+    }
+    setBusy(true);
+    setFormError(null);
+    const online = await getIsOnline();
+    if (!online) {
+      await enqueueFoodLogDraft(userId, draft);
+      setBusy(false);
+      onToast("オフラインのため端末に保存しました。通信が戻ったら一覧から再送してください。");
+      onClose();
+      await onOutboxChanged?.();
+      return;
+    }
+    const { error } = await supabase
+      .from("food_log")
+      .insert(buildFoodLogInsertPayload(userId, draft));
+    setBusy(false);
+    if (error) {
+      if (error.code === "23505") {
+        onToast("保存しました");
+        onClose();
+        await onSaved();
+        return;
+      }
+      if (isTransientNetworkError(error)) {
+        await enqueueFoodLogDraft(userId, draft);
+        onToast("通信に失敗しました。端末に下書きを残しました。");
+        onClose();
+        await onOutboxChanged?.();
+        return;
+      }
+      setFormError(error.message);
+      onToast(`保存に失敗しました: ${error.message}`);
+      return;
+    }
+    onToast("保存しました");
+    onClose();
+    await onSaved();
+  }, [
+    buildSnapshotLogDraft,
+    supabase,
+    userId,
+    onClose,
+    onSaved,
+    onToast,
+    onOutboxChanged,
+  ]);
+
+  const handleAddToCart = useCallback(() => {
+    if (!name.trim()) {
+      setFormError("名前を入力してください");
+      return;
+    }
+    if (!snapshotRestaurantId) {
+      setFormError("カートに載せる準備ができていません。");
+      return;
+    }
+    const gramsNum = parseFloat(grams) || 100;
+    onAddSnapshotDraftToCart({
+      name: name.trim(),
+      protein_per_100g: protein === "" ? null : parseFloat(protein),
+      fat_per_100g: fat === "" ? null : parseFloat(fat),
+      carbs_per_100g: carbs === "" ? null : parseFloat(carbs),
+      grams: gramsNum,
+    });
+    onToast("カートに入れました");
+    onClose();
+  }, [name, grams, protein, fat, carbs, snapshotRestaurantId, onAddSnapshotDraftToCart, onToast, onClose]);
+
+  const handleDelete = useCallback(async () => {
+    if (!state || state.kind !== "edit") return;
+    setDeleting(true);
+    setFormError(null);
+    const { error } = await supabase
+      .from("menu_items")
+      .delete()
+      .eq("id", state.menuItemId)
+      .eq("user_id", userId);
+    setDeleting(false);
+    if (error) {
+      setFormError(error.message);
+      onToast(`削除に失敗しました: ${error.message}`);
+      return;
+    }
+    onToast("削除しました");
+    onClose();
+    await onSaved();
+  }, [state, supabase, userId, onClose, onSaved, onToast]);
+
+  const titleText = useMemo(() => {
+    if (!state) return "";
+    if (state.kind === "edit") return "メニュー編集";
+    return registerTargetRestaurantName
+      ? `${registerTargetRestaurantName}へメニューを追加`
+      : "メニューを追加";
+  }, [state, registerTargetRestaurantName]);
+
+  if (!state) return null;
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <KeyboardAvoidingView
+        style={styles.overlay}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+      >
+        <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        <View style={styles.card}>
+          <View style={styles.headerRow}>
+            <Text style={styles.title} numberOfLines={2}>
+              {titleText}
+            </Text>
+            <Pressable onPress={onClose} disabled={busy} hitSlop={8}>
+              <Text style={styles.headerCancel}>キャンセル</Text>
+            </Pressable>
+          </View>
+
+          {isEdit && editLoading ? (
+            <ActivityIndicator color={COLORS.primary} style={{ marginVertical: 24 }} />
+          ) : (
+            <ScrollView
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={styles.scrollPad}
+            >
+              <View style={styles.field}>
+                <Text style={styles.label}>名前</Text>
+                <TextInput
+                  value={name}
+                  onChangeText={setName}
+                  placeholder="名前"
+                  placeholderTextColor={COLORS.textMuted}
+                  style={styles.input}
+                  editable={!busy}
+                />
+              </View>
+
+              <View style={styles.field}>
+                <Text style={styles.label}>1回の量（g）</Text>
+                <TextInput
+                  value={grams}
+                  onChangeText={setGrams}
+                  keyboardType="decimal-pad"
+                  style={[styles.input, styles.gramsInput]}
+                  editable={!busy}
+                />
+              </View>
+
+              <View style={styles.field}>
+                <View style={styles.nutrientHeaderRow}>
+                  <Text style={styles.label}>栄養素</Text>
+                  <View style={styles.modeSwitch}>
+                    {(["per100g", "perServing"] as NutrientMode[]).map((m) => {
+                      const on = nutrientMode === m;
+                      return (
+                        <Pressable
+                          key={m}
+                          onPress={() => !busy && handleNutrientModeChange(m)}
+                          style={[styles.modeChip, on && styles.modeChipOn]}
+                        >
+                          <Text style={[styles.modeChipText, on && styles.modeChipTextOn]}>
+                            {m === "per100g" ? "100gあたり" : `1回分（${Number.isNaN(gramsNum) ? "?" : gramsNum}g）`}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                </View>
+                <View style={styles.pfcGrid}>
+                  {(
+                    [
+                      { label: "P タンパク質", raw: rawP, display: displayP, setRaw: setRawP, field: "p" as const },
+                      { label: "F 脂質", raw: rawF, display: displayF, setRaw: setRawF, field: "f" as const },
+                      { label: "C 糖質", raw: rawC, display: displayC, setRaw: setRawC, field: "c" as const },
+                    ] as const
+                  ).map(({ label, raw, display, setRaw, field }) => (
+                    <View key={field} style={styles.pfcCell}>
+                      <Text style={styles.pfcCellLabel}>{label}</Text>
+                      <TextInput
+                        value={raw ?? display}
+                        onChangeText={(t) => setRaw(t)}
+                        onEndEditing={(e) =>
+                          commitNutrientFromText(field, e.nativeEvent.text)
+                        }
+                        placeholder="—"
+                        placeholderTextColor={COLORS.textMuted}
+                        keyboardType="decimal-pad"
+                        style={styles.pfcInput}
+                        editable={!busy}
+                      />
+                    </View>
+                  ))}
+                </View>
+                <Text style={styles.modeHint}>入力単位: {modeLabel}</Text>
+              </View>
+
+              <View style={styles.field}>
+                <Text style={styles.label}>ランク</Text>
+                <View style={styles.rankGrid}>
+                  {RANK_OPTIONS.map((opt) => {
+                    const on = rank === opt.value;
+                    return (
+                      <View key={opt.value} style={styles.rankCell}>
+                        <Pressable
+                          onPress={() => !busy && setRank(opt.value)}
+                          style={[styles.rankBtn, on && styles.rankBtnOn]}
+                          disabled={busy}
+                        >
+                          <Text style={[styles.rankBtnText, on && styles.rankBtnTextOn]}>
+                            {opt.label}
+                          </Text>
+                        </Pressable>
+                      </View>
+                    );
+                  })}
+                </View>
+              </View>
+
+              <View style={styles.field}>
+                <Text style={styles.label}>グループ名（任意）</Text>
+                <View style={styles.groupRow}>
+                  <TextInput
+                    value={groupName}
+                    onChangeText={(t) => {
+                      setGroupName(t);
+                      if (!groupSuggestOpen) setGroupSuggestOpen(true);
+                    }}
+                    placeholder="例: ホルモン系"
+                    placeholderTextColor={COLORS.textMuted}
+                    style={[styles.input, styles.groupInput]}
+                    editable={!busy}
+                  />
+                  {existingGroupNames.length > 0 ? (
+                    <Pressable
+                      onPress={() => setGroupSuggestOpen((v) => !v)}
+                      style={styles.candidateBtn}
+                    >
+                      <Text style={styles.candidateBtnText}>候補</Text>
+                    </Pressable>
+                  ) : null}
+                </View>
+                {existingGroupNames.length > 0 && groupSuggestOpen ? (
+                  <View style={styles.suggestBox}>
+                    {existingGroupNames.map((g) => (
+                      <Pressable
+                        key={g}
+                        onPress={() => {
+                          setGroupName(g);
+                          setGroupSuggestOpen(false);
+                        }}
+                        style={styles.suggestRow}
+                      >
+                        <Text style={styles.suggestRowText}>{g}</Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                ) : null}
+              </View>
+
+              <View style={styles.field}>
+                <Text style={styles.label}>メモ（任意）</Text>
+                <TextInput
+                  value={notes}
+                  onChangeText={setNotes}
+                  placeholder="例: 1切れ約15g"
+                  placeholderTextColor={COLORS.textMuted}
+                  style={[styles.input, styles.textarea]}
+                  multiline
+                  numberOfLines={MEMO_MIN_ROWS}
+                  editable={!busy}
+                />
+              </View>
+
+              {!isEdit ? (
+                <View style={styles.field}>
+                  <Text style={styles.label}>食事（記録で使用）</Text>
+                  <View style={styles.mealRow}>
+                    {MEALS.map((m) => (
+                      <Pressable
+                        key={m}
+                        onPress={() => !busy && setLogMeal(m)}
+                        style={[styles.mealChip, logMeal === m && styles.mealChipOn]}
+                      >
+                        <Text
+                          style={[styles.mealChipText, logMeal === m && styles.mealChipTextOn]}
+                        >
+                          {MEAL_LABEL[m]}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                </View>
+              ) : null}
+
+              {formError ? <Text style={styles.error}>{formError}</Text> : null}
+
+              {isEdit ? (
+                <>
+                  <Pressable
+                    onPress={() => void handleSaveMenu()}
+                    disabled={busy}
+                    style={[styles.btnPrimaryWide, busy && { opacity: 0.55 }]}
+                  >
+                    {busy ? (
+                      <ActivityIndicator color="#022c22" />
+                    ) : (
+                      <Text style={styles.btnPrimaryText}>保存する</Text>
+                    )}
+                  </Pressable>
+
+                  <View style={styles.deleteSection}>
+                    {confirmDelete ? (
+                      <View style={styles.deleteConfirmRow}>
+                        <Pressable
+                          onPress={() => setConfirmDelete(false)}
+                          style={[styles.btnGhostWide, { flex: 1 }]}
+                        >
+                          <Text style={styles.btnGhostText}>キャンセル</Text>
+                        </Pressable>
+                        <Pressable
+                          onPress={() => void handleDelete()}
+                          disabled={deleting}
+                          style={[styles.btnDangerWide, { flex: 1 }, deleting && { opacity: 0.5 }]}
+                        >
+                          <Text style={styles.btnDangerText}>
+                            {deleting ? "削除中…" : "削除する"}
+                          </Text>
+                        </Pressable>
+                      </View>
+                    ) : (
+                      <Pressable onPress={() => setConfirmDelete(true)} style={styles.deleteLink}>
+                        <Text style={styles.deleteLinkText}>このメニューを削除</Text>
+                      </Pressable>
+                    )}
+                  </View>
+                </>
+              ) : (
+                <>
+                  <View style={styles.registerBox}>
+                    <Text style={styles.label}>メニュー登録先</Text>
+                    {registerRestaurantsLoading ? (
+                      <ActivityIndicator color={COLORS.primary} style={{ marginVertical: 12 }} />
+                    ) : registerRestaurants.length === 0 ? (
+                      <Text style={styles.hint}>お店がありません。店舗を追加してください。</Text>
+                    ) : (
+                      <ScrollView
+                        horizontal
+                        showsHorizontalScrollIndicator={false}
+                        keyboardShouldPersistTaps="handled"
+                        contentContainerStyle={styles.registerChipScroll}
+                      >
+                        {registerRestaurants.map((r) => {
+                          const on = r.id === registerRestaurantId;
+                          return (
+                            <Pressable
+                              key={r.id}
+                              onPress={() => !busy && setRegisterRestaurantId(r.id)}
+                              style={[styles.registerChip, on && styles.registerChipOn]}
+                            >
+                              <Text
+                                style={[styles.registerChipText, on && styles.registerChipTextOn]}
+                                numberOfLines={1}
+                              >
+                                {r.name}
+                              </Text>
+                            </Pressable>
+                          );
+                        })}
+                      </ScrollView>
+                    )}
+                  </View>
+
+                  <Pressable
+                    onPress={() => void handleSaveMenu()}
+                    disabled={busy || !canRegisterMenu}
+                    style={[styles.btnPrimaryWide, (busy || !canRegisterMenu) && { opacity: 0.55 }]}
+                  >
+                    {busy ? (
+                      <ActivityIndicator color="#022c22" />
+                    ) : (
+                      <Text style={styles.btnPrimaryText}>メニューに登録</Text>
+                    )}
+                  </Pressable>
+                  {!canRegisterMenu && !registerRestaurantsLoading ? (
+                    <Text style={styles.hint}>
+                      メニュー登録先のお店がないため、メニューへの登録はできません。
+                    </Text>
+                  ) : null}
+
+                  <View style={styles.cartRow}>
+                    <Pressable
+                      onPress={handleAddToCart}
+                      disabled={busy || !snapshotRestaurantId}
+                      style={[styles.btnSecondaryHalf, (!snapshotRestaurantId || busy) && { opacity: 0.5 }]}
+                    >
+                      <Text style={styles.btnSecondaryText}>カートへ</Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => void handleLogOnly()}
+                      disabled={busy || !snapshotRestaurantId}
+                      style={[styles.btnSecondaryHalf, (!snapshotRestaurantId || busy) && { opacity: 0.5 }]}
+                    >
+                      <Text style={styles.btnSecondaryText}>今すぐ記録</Text>
+                    </Pressable>
+                  </View>
+                </>
+              )}
+            </ScrollView>
+          )}
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    justifyContent: "flex-end",
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  card: {
+    maxHeight: "92%",
+    backgroundColor: COLORS.bg,
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingTop: 12,
+    paddingHorizontal: 16,
+    borderTopWidth: 1,
+    borderColor: COLORS.border,
+  },
+  headerRow: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+    marginBottom: 10,
+  },
+  title: {
+    flex: 1,
+    color: COLORS.text,
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  headerCancel: {
+    color: COLORS.textMuted,
+    fontSize: 14,
+    paddingTop: 2,
+  },
+  scrollPad: { paddingBottom: 32 },
+  field: { marginBottom: 14 },
+  label: {
+    color: COLORS.textMuted,
+    fontSize: 12,
+    marginBottom: 6,
+  },
+  hint: {
+    color: COLORS.textMuted,
+    fontSize: 11,
+    marginTop: 4,
+    lineHeight: 16,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    color: COLORS.text,
+    fontSize: 16,
+  },
+  gramsInput: { maxWidth: 120 },
+  nutrientHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: 8,
+    gap: 8,
+  },
+  modeSwitch: { flexDirection: "row", borderRadius: 8, overflow: "hidden", borderWidth: 1, borderColor: COLORS.border },
+  modeChip: { paddingVertical: 6, paddingHorizontal: 10, backgroundColor: "#0f172a" },
+  modeChipOn: { backgroundColor: COLORS.primary },
+  modeChipText: { color: COLORS.textMuted, fontSize: 11 },
+  modeChipTextOn: { color: "#fff", fontWeight: "600" },
+  pfcGrid: { flexDirection: "row", gap: 8 },
+  pfcCell: { flex: 1 },
+  pfcCellLabel: { color: COLORS.textMuted, fontSize: 11, marginBottom: 4 },
+  pfcInput: {
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 8,
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+    color: COLORS.text,
+    fontSize: 15,
+    textAlign: "center",
+  },
+  modeHint: { color: COLORS.textMuted, fontSize: 11, marginTop: 6 },
+  rankGrid: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  rankCell: { width: "48%" },
+  rankBtn: {
+    paddingVertical: 10,
+    paddingHorizontal: 10,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: "#0f172a",
+  },
+  rankBtnOn: { borderColor: COLORS.primary, backgroundColor: "rgba(16, 185, 129, 0.2)" },
+  rankBtnText: { color: COLORS.textMuted, fontSize: 13, fontWeight: "500" },
+  rankBtnTextOn: { color: "#fff", fontWeight: "600" },
+  groupRow: { flexDirection: "row", alignItems: "center", gap: 8 },
+  groupInput: { flex: 1 },
+  candidateBtn: {
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: "#0f172a",
+  },
+  candidateBtnText: { color: COLORS.text, fontSize: 12 },
+  suggestBox: {
+    marginTop: 8,
+    maxHeight: 176,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 8,
+    backgroundColor: "#0f172a",
+  },
+  suggestRow: { paddingHorizontal: 12, paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: COLORS.border },
+  suggestRowText: { color: COLORS.text, fontSize: 14 },
+  textarea: { minHeight: 88, textAlignVertical: "top" },
+  mealRow: { flexDirection: "row", flexWrap: "wrap", gap: 8 },
+  mealChip: {
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: "#0f172a",
+  },
+  mealChipOn: { borderColor: COLORS.primary, backgroundColor: "rgba(16, 185, 129, 0.15)" },
+  mealChipText: { color: COLORS.textMuted, fontSize: 13 },
+  mealChipTextOn: { color: "#a7f3d0", fontWeight: "600" },
+  error: { color: "#fecaca", fontSize: 13, marginBottom: 10 },
+  registerBox: {
+    marginBottom: 12,
+    padding: 10,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: "rgba(15, 23, 42, 0.5)",
+  },
+  registerChipScroll: { flexDirection: "row", gap: 8, paddingVertical: 4 },
+  registerChip: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: "#0f172a",
+    maxWidth: 200,
+  },
+  registerChipOn: { borderColor: COLORS.primary, backgroundColor: "rgba(16, 185, 129, 0.15)" },
+  registerChipText: { color: COLORS.textMuted, fontSize: 13 },
+  registerChipTextOn: { color: "#a7f3d0", fontWeight: "600" },
+  btnPrimaryWide: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 14,
+    borderRadius: 10,
+    backgroundColor: COLORS.primary,
+    minHeight: 48,
+    marginBottom: 10,
+  },
+  btnPrimaryText: { color: "#022c22", fontWeight: "700", fontSize: 16 },
+  cartRow: { flexDirection: "row", gap: 8, marginTop: 4 },
+  btnSecondaryHalf: {
+    flex: 1,
+    alignItems: "center",
+    paddingVertical: 12,
+    borderRadius: 10,
+    backgroundColor: "#0f172a",
+    borderWidth: 1,
+    borderColor: COLORS.border,
+  },
+  btnSecondaryText: { color: COLORS.text, fontSize: 13, fontWeight: "600" },
+  deleteSection: { marginTop: 16, paddingTop: 12, borderTopWidth: 1, borderTopColor: COLORS.border },
+  deleteConfirmRow: { flexDirection: "row", gap: 8 },
+  btnGhostWide: {
+    alignItems: "center",
+    paddingVertical: 12,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+  },
+  btnGhostText: { color: COLORS.text, fontWeight: "600" },
+  btnDangerWide: {
+    alignItems: "center",
+    paddingVertical: 12,
+    borderRadius: 8,
+    backgroundColor: COLORS.danger,
+  },
+  btnDangerText: { color: "#fff", fontWeight: "700" },
+  deleteLink: { paddingVertical: 10 },
+  deleteLinkText: { color: "#f87171", fontSize: 14, textAlign: "center" },
+});

--- a/apps/mobile/components/MenuPickModal.tsx
+++ b/apps/mobile/components/MenuPickModal.tsx
@@ -10,6 +10,15 @@ import {
   View,
 } from "react-native";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  addMenuItemToFavoritesMobile,
+  removeMenuItemFromFavoritesMobile,
+} from "../lib/favorite-mutations";
+import type { FavoriteEntryPayload, FavoriteGroupPayload } from "../lib/fetch-favorite-groups-payload";
+import {
+  fetchFavoriteGroupsPayload,
+  fetchFavoritedMenuItemIds,
+} from "../lib/fetch-favorite-groups-payload";
 import type { MenuPrefill } from "../lib/menu-prefill";
 import { isSnapshotRestaurant, SNAPSHOT_RESTAURANT_NAME } from "../lib/snapshot-restaurant";
 
@@ -19,12 +28,16 @@ const COLORS = {
   textMuted: "#9ca3af",
   border: "#374151",
   primary: "#10b981",
+  starOn: "#fbbf24",
 };
+
+type BrowseTab = "shops" | "favorites";
 
 type RestaurantRow = {
   id: string;
   name: string;
   order_count: number;
+  display_order?: number | null;
   created_at: string | null;
 };
 
@@ -39,9 +52,12 @@ type MenuItemRow = {
   created_at: string | null;
 };
 
-/** `display_order` 列が無い DB でも動かすため、取得列のみで並べる（利用頻度 → 登録順）。 */
+/** Web `sortRestaurants`（`useRestaurantState`）に揃える */
 function sortRestaurants(list: RestaurantRow[]): RestaurantRow[] {
   return [...list].sort((a, b) => {
+    const ao = a.display_order ?? 0;
+    const bo = b.display_order ?? 0;
+    if (ao !== bo) return ao - bo;
     if (b.order_count !== a.order_count) return b.order_count - a.order_count;
     const ac = a.created_at ?? "";
     const bc = b.created_at ?? "";
@@ -72,6 +88,7 @@ type Props = {
 };
 
 export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Props) {
+  const [browseTab, setBrowseTab] = useState<BrowseTab>("shops");
   const [step, setStep] = useState<"restaurants" | "menus">("restaurants");
   const [restaurantId, setRestaurantId] = useState<string | null>(null);
   const [restaurantName, setRestaurantName] = useState<string>("");
@@ -80,8 +97,14 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
+  const [favoritedMenuItemIds, setFavoritedMenuItemIds] = useState<Set<string>>(new Set());
+  const [favoriteGroups, setFavoriteGroups] = useState<FavoriteGroupPayload[]>([]);
+  const [favoritesLoading, setFavoritesLoading] = useState(false);
+  const [favoritesError, setFavoritesError] = useState<string | null>(null);
+  const [favoriteToggleBusyId, setFavoriteToggleBusyId] = useState<string | null>(null);
 
   const resetLocal = useCallback(() => {
+    setBrowseTab("shops");
     setStep("restaurants");
     setRestaurantId(null);
     setRestaurantName("");
@@ -89,19 +112,43 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
     setMenuItems([]);
     setError(null);
     setQuery("");
+    setFavoriteGroups([]);
+    setFavoritesError(null);
+    setFavoritedMenuItemIds(new Set());
+    setFavoriteToggleBusyId(null);
   }, []);
+
+  const refreshFavoritedIds = useCallback(async () => {
+    const r = await fetchFavoritedMenuItemIds(supabase, userId);
+    if (!r.error) setFavoritedMenuItemIds(r.data);
+  }, [supabase, userId]);
+
+  const loadFavoriteGroups = useCallback(async () => {
+    setFavoritesLoading(true);
+    setFavoritesError(null);
+    const r = await fetchFavoriteGroupsPayload(supabase, userId);
+    setFavoritesLoading(false);
+    if (r.error) {
+      setFavoritesError(r.error);
+      setFavoriteGroups([]);
+      return;
+    }
+    setFavoriteGroups(r.data);
+    await refreshFavoritedIds();
+  }, [supabase, userId, refreshFavoritedIds]);
 
   const loadRestaurants = useCallback(async () => {
     setLoading(true);
     setError(null);
     const { data, error: err } = await supabase
       .from("restaurants")
-      .select("id, name, order_count, created_at")
+      .select("id, name, order_count, display_order, created_at")
       .eq("user_id", userId);
 
-    setLoading(false);
     if (err) {
+      setLoading(false);
       setError(err.message);
+      await refreshFavoritedIds();
       return;
     }
 
@@ -110,6 +157,8 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
 
     if (filtered.length === 0) {
       setRestaurants([]);
+      setLoading(false);
+      await refreshFavoritedIds();
       return;
     }
 
@@ -118,7 +167,6 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
       setRestaurantId(only.id);
       setRestaurantName(only.name);
       setStep("menus");
-      setLoading(true);
       const mRes = await supabase
         .from("menu_items")
         .select(
@@ -129,16 +177,20 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
       setLoading(false);
       if (mRes.error) {
         setError(mRes.error.message);
+        await refreshFavoritedIds();
         return;
       }
       const items = ((mRes.data ?? []) as MenuItemRow[]).sort(compareMenuItemsForListOrder);
       setMenuItems(items);
+      await refreshFavoritedIds();
       return;
     }
 
     setRestaurants(filtered);
     setStep("restaurants");
-  }, [supabase, userId]);
+    setLoading(false);
+    await refreshFavoritedIds();
+  }, [supabase, userId, refreshFavoritedIds]);
 
   const loadMenus = useCallback(
     async (rid: string, rname: string) => {
@@ -155,6 +207,7 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
       setLoading(false);
       if (err) {
         setError(err.message);
+        await refreshFavoritedIds();
         return;
       }
       setRestaurantId(rid);
@@ -162,8 +215,9 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
       setMenuItems(((data ?? []) as MenuItemRow[]).sort(compareMenuItemsForListOrder));
       setStep("menus");
       setQuery("");
+      await refreshFavoritedIds();
     },
-    [supabase, userId]
+    [supabase, userId, refreshFavoritedIds]
   );
 
   useEffect(() => {
@@ -173,6 +227,11 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
     }
     void loadRestaurants();
   }, [visible, loadRestaurants, resetLocal]);
+
+  useEffect(() => {
+    if (!visible || browseTab !== "favorites") return;
+    void loadFavoriteGroups();
+  }, [visible, browseTab, loadFavoriteGroups]);
 
   const filteredRestaurants = useMemo(() => {
     const q = query.trim().toLowerCase();
@@ -186,6 +245,37 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
     return menuItems.filter((m) => m.name.toLowerCase().includes(q));
   }, [menuItems, query]);
 
+  const filteredFavoriteRows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const out: { groupName: string; entry: FavoriteEntryPayload }[] = [];
+    for (const g of favoriteGroups) {
+      for (const e of g.entries) {
+        const mi = e.menu_item;
+        if (!mi) continue;
+        if (q && !mi.name.toLowerCase().includes(q)) continue;
+        out.push({ groupName: g.name, entry: e });
+      }
+    }
+    return out;
+  }, [favoriteGroups, query]);
+
+  const pickFromMenuItemRow = useCallback(
+    (m: MenuItemRow, rid: string) => {
+      const defG = Number(m.default_grams);
+      const defaultGrams = Number.isFinite(defG) && defG > 0 ? defG : 100;
+      onPick({
+        menuItemId: m.id,
+        restaurantId: rid,
+        itemName: m.name,
+        proteinPer100: m.protein_per_100g != null ? Number(m.protein_per_100g) : null,
+        fatPer100: m.fat_per_100g != null ? Number(m.fat_per_100g) : null,
+        carbsPer100: m.carbs_per_100g != null ? Number(m.carbs_per_100g) : null,
+        defaultGrams,
+      });
+    },
+    [onPick]
+  );
+
   const onSelectRestaurant = useCallback(
     (r: RestaurantRow) => {
       void loadMenus(r.id, r.name);
@@ -196,19 +286,52 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
   const onSelectMenu = useCallback(
     (m: MenuItemRow) => {
       if (!restaurantId) return;
-      const defG = Number(m.default_grams);
-      const defaultGrams = Number.isFinite(defG) && defG > 0 ? defG : 100;
-      onPick({
-        menuItemId: m.id,
-        restaurantId,
-        itemName: m.name,
-        proteinPer100: m.protein_per_100g != null ? Number(m.protein_per_100g) : null,
-        fatPer100: m.fat_per_100g != null ? Number(m.fat_per_100g) : null,
-        carbsPer100: m.carbs_per_100g != null ? Number(m.carbs_per_100g) : null,
-        defaultGrams,
-      });
+      pickFromMenuItemRow(m, restaurantId);
     },
-    [restaurantId, onPick]
+    [restaurantId, pickFromMenuItemRow]
+  );
+
+  const onSelectFavoriteEntry = useCallback(
+    (e: FavoriteEntryPayload) => {
+      const mi = e.menu_item;
+      if (!mi) return;
+      pickFromMenuItemRow(mi as MenuItemRow, mi.restaurant_id);
+    },
+    [pickFromMenuItemRow]
+  );
+
+  const toggleFavoriteForMenu = useCallback(
+    async (m: MenuItemRow) => {
+      setError(null);
+      setFavoriteToggleBusyId(m.id);
+      try {
+        if (favoritedMenuItemIds.has(m.id)) {
+          const r = await removeMenuItemFromFavoritesMobile(supabase, m.id);
+          if (r.error) {
+            setError(r.error);
+            return;
+          }
+        } else {
+          const r = await addMenuItemToFavoritesMobile(supabase, userId, m.id);
+          if (r.error) {
+            setError(r.error);
+            return;
+          }
+        }
+        await refreshFavoritedIds();
+        if (browseTab === "favorites") await loadFavoriteGroups();
+      } finally {
+        setFavoriteToggleBusyId(null);
+      }
+    },
+    [
+      supabase,
+      userId,
+      favoritedMenuItemIds,
+      refreshFavoritedIds,
+      browseTab,
+      loadFavoriteGroups,
+    ]
   );
 
   const goBackToRestaurants = useCallback(() => {
@@ -220,10 +343,25 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
     setError(null);
   }, []);
 
+  const switchBrowseTab = useCallback(
+    (t: BrowseTab) => {
+      setBrowseTab(t);
+      setQuery("");
+      setError(null);
+    },
+    []
+  );
+
   const title =
-    step === "restaurants"
-      ? "店舗を選ぶ"
-      : `メニュー（${restaurantName.length > 14 ? `${restaurantName.slice(0, 14)}…` : restaurantName}）`;
+    browseTab === "favorites"
+      ? "お気に入り"
+      : step === "restaurants"
+        ? "店舗を選ぶ"
+        : `メニュー（${restaurantName.length > 14 ? `${restaurantName.slice(0, 14)}…` : restaurantName}）`;
+
+  const showShopsContent = browseTab === "shops";
+  const shopsBodyLoading = showShopsContent && loading;
+  const favoritesBodyLoading = browseTab === "favorites" && favoritesLoading;
 
   return (
     <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
@@ -231,7 +369,7 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
         <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
         <View style={styles.card}>
           <View style={styles.headerRow}>
-            {step === "menus" && restaurants.length > 1 ? (
+            {showShopsContent && step === "menus" && restaurants.length > 1 ? (
               <Pressable onPress={goBackToRestaurants} style={styles.backBtn} hitSlop={8}>
                 <Text style={styles.backBtnText}>‹ 店舗</Text>
               </Pressable>
@@ -246,21 +384,91 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
             </Pressable>
           </View>
 
+          <View style={styles.tabRow}>
+            <Pressable
+              onPress={() => switchBrowseTab("shops")}
+              style={({ pressed }) => [
+                styles.tabBtn,
+                browseTab === "shops" ? styles.tabBtnOn : styles.tabBtnOff,
+                pressed && { opacity: 0.88 },
+              ]}
+            >
+              <Text style={browseTab === "shops" ? styles.tabBtnTextOn : styles.tabBtnTextOff}>
+                店舗から
+              </Text>
+            </Pressable>
+            <Pressable
+              onPress={() => switchBrowseTab("favorites")}
+              style={({ pressed }) => [
+                styles.tabBtn,
+                browseTab === "favorites" ? styles.tabBtnOn : styles.tabBtnOff,
+                pressed && { opacity: 0.88 },
+              ]}
+            >
+              <Text style={browseTab === "favorites" ? styles.tabBtnTextOn : styles.tabBtnTextOff}>
+                お気に入り
+              </Text>
+            </Pressable>
+          </View>
+
           <TextInput
             value={query}
             onChangeText={setQuery}
-            placeholder={step === "restaurants" ? "店名で絞り込み" : "メニュー名で絞り込み"}
+            placeholder={
+              browseTab === "favorites"
+                ? "メニュー名で絞り込み"
+                : step === "restaurants"
+                  ? "店名で絞り込み"
+                  : "メニュー名で絞り込み"
+            }
             placeholderTextColor={COLORS.textMuted}
             style={styles.search}
-            editable={!loading}
+            editable={!shopsBodyLoading && !favoritesBodyLoading}
           />
 
-          {loading ? (
+          {shopsBodyLoading || favoritesBodyLoading ? (
             <View style={styles.center}>
               <ActivityIndicator color={COLORS.primary} />
             </View>
           ) : error ? (
             <Text style={styles.error}>{error}</Text>
+          ) : browseTab === "favorites" ? (
+            favoritesError ? (
+              <Text style={styles.error}>{favoritesError}</Text>
+            ) : filteredFavoriteRows.length === 0 ? (
+              <Text style={styles.hint}>
+                お気に入りはまだありません。Web 版の Today でメニューの ☆
+                を押すとここに集約されます。店舗タブのメニュー一覧でも ☆ で追加できます。
+              </Text>
+            ) : (
+              <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={styles.listPad}>
+                {filteredFavoriteRows.map(({ groupName, entry }) => {
+                  const mi = entry.menu_item;
+                  if (!mi) return null;
+                  return (
+                    <Pressable
+                      key={entry.id}
+                      onPress={() => onSelectFavoriteEntry(entry)}
+                      style={({ pressed }) => [styles.row, pressed && { opacity: 0.85 }]}
+                    >
+                      <View style={styles.menuRowBody}>
+                        <Text style={styles.favGroupHint} numberOfLines={1}>
+                          {groupName}
+                        </Text>
+                        <Text style={styles.rowText} numberOfLines={2}>
+                          {mi.name}
+                        </Text>
+                        <Text style={styles.menuMeta} numberOfLines={1}>
+                          標準 {mi.default_grams != null ? Number(mi.default_grams) : 100}g · P/F/C
+                          100g
+                        </Text>
+                      </View>
+                      <Text style={styles.chev}>›</Text>
+                    </Pressable>
+                  );
+                })}
+              </ScrollView>
+            )
           ) : step === "restaurants" ? (
             filteredRestaurants.length === 0 ? (
               <Text style={styles.hint}>
@@ -292,22 +500,46 @@ export function MenuPickModal({ visible, supabase, userId, onClose, onPick }: Pr
           ) : (
             <ScrollView keyboardShouldPersistTaps="handled" contentContainerStyle={styles.listPad}>
               {filteredMenus.map((m) => (
-                <Pressable
-                  key={m.id}
-                  onPress={() => onSelectMenu(m)}
-                  style={({ pressed }) => [styles.row, pressed && { opacity: 0.85 }]}
-                >
-                  <View style={styles.menuRowBody}>
-                    <Text style={styles.rowText} numberOfLines={2}>
-                      {m.name}
-                    </Text>
-                    <Text style={styles.menuMeta} numberOfLines={1}>
-                      標準 {m.default_grams != null ? Number(m.default_grams) : 100}g · P/F/C
-                      100g
-                    </Text>
-                  </View>
-                  <Text style={styles.chev}>›</Text>
-                </Pressable>
+                <View key={m.id} style={styles.row}>
+                  <Pressable
+                    onPress={() => onSelectMenu(m)}
+                    style={({ pressed }) => [styles.menuRowPress, pressed && { opacity: 0.85 }]}
+                  >
+                    <View style={styles.menuRowBody}>
+                      <Text style={styles.rowText} numberOfLines={2}>
+                        {m.name}
+                      </Text>
+                      <Text style={styles.menuMeta} numberOfLines={1}>
+                        標準 {m.default_grams != null ? Number(m.default_grams) : 100}g · P/F/C
+                        100g
+                      </Text>
+                    </View>
+                    <Text style={styles.chev}>›</Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => {
+                      void toggleFavoriteForMenu(m);
+                    }}
+                    disabled={favoriteToggleBusyId !== null}
+                    hitSlop={10}
+                    style={({ pressed }) => [
+                      styles.starBtn,
+                      pressed && { opacity: 0.75 },
+                      favoriteToggleBusyId !== null && { opacity: 0.45 },
+                    ]}
+                    accessibilityLabel={
+                      favoritedMenuItemIds.has(m.id) ? "お気に入りを解除" : "お気に入りに追加"
+                    }
+                  >
+                    {favoriteToggleBusyId === m.id ? (
+                      <ActivityIndicator size="small" color={COLORS.starOn} />
+                    ) : (
+                      <Text style={styles.starGlyph}>
+                        {favoritedMenuItemIds.has(m.id) ? "★" : "☆"}
+                      </Text>
+                    )}
+                  </Pressable>
+                </View>
               ))}
             </ScrollView>
           )}
@@ -340,6 +572,29 @@ const styles = StyleSheet.create({
     marginBottom: 10,
     gap: 6,
   },
+  tabRow: {
+    flexDirection: "row",
+    gap: 8,
+    marginBottom: 10,
+  },
+  tabBtn: {
+    flex: 1,
+    paddingVertical: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  tabBtnOn: {
+    borderColor: COLORS.primary,
+    backgroundColor: "rgba(16, 185, 129, 0.2)",
+  },
+  tabBtnOff: {
+    borderColor: COLORS.border,
+    backgroundColor: "#0f172a",
+  },
+  tabBtnTextOn: { color: "#a7f3d0", fontSize: 14, fontWeight: "700" },
+  tabBtnTextOff: { color: COLORS.textMuted, fontSize: 14, fontWeight: "600" },
   backBtn: { minWidth: 56, paddingVertical: 4 },
   backBtnText: { color: "#93c5fd", fontSize: 15, fontWeight: "600" },
   backPlaceholder: { minWidth: 56 },
@@ -374,16 +629,39 @@ const styles = StyleSheet.create({
   row: {
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 12,
-    paddingHorizontal: 10,
+    paddingVertical: 4,
+    paddingLeft: 10,
+    paddingRight: 4,
     borderRadius: 10,
     backgroundColor: "#0f172a",
     marginBottom: 8,
     borderWidth: 1,
     borderColor: COLORS.border,
   },
+  menuRowPress: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingRight: 4,
+    minWidth: 0,
+  },
   menuRowBody: { flex: 1, minWidth: 0 },
   rowText: { color: COLORS.text, fontSize: 15, fontWeight: "500" },
+  favGroupHint: {
+    color: COLORS.textMuted,
+    fontSize: 10,
+    marginBottom: 2,
+    fontWeight: "600",
+  },
   menuMeta: { color: COLORS.textMuted, fontSize: 11, marginTop: 4 },
-  chev: { color: COLORS.textMuted, fontSize: 18, marginLeft: 8 },
+  chev: { color: COLORS.textMuted, fontSize: 18, marginLeft: 4 },
+  starBtn: {
+    paddingHorizontal: 12,
+    paddingVertical: 10,
+    justifyContent: "center",
+    alignItems: "center",
+    minWidth: 44,
+  },
+  starGlyph: { fontSize: 20, color: COLORS.starOn },
 });

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -1,0 +1,356 @@
+import { useEffect, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import type { MealType } from "@ketolog/types";
+import { pfcGramsFromNullablePer100, type PfcGrams } from "@ketolog/domain/pfc";
+
+export type CartLineState = {
+  menuItemId: string;
+  restaurantId: string;
+  name: string;
+  gramsPerServing: number;
+  count: number;
+  protein_per_100g: number | null;
+  fat_per_100g: number | null;
+  carbs_per_100g: number | null;
+  /** メニュー未登録の下書き行。記録時は `menu_item_id` を null にする */
+  snapshotDraft?: boolean;
+};
+
+export const CART_MEAL_ORDER: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
+
+export const CART_MEAL_LABEL: Record<MealType, string> = {
+  breakfast: "朝食",
+  lunch: "昼食",
+  dinner: "夕食",
+  snack: "間食",
+};
+
+/** Web `MEAL_CART_SEGMENT_ACTIVE` に相当 */
+export const CART_MEAL_CHIP_ACTIVE: Record<MealType, { border: string; bg: string; text: string }> = {
+  breakfast: { border: "#fb7185", bg: "rgba(244, 63, 94, 0.22)", text: "#fecdd3" },
+  lunch: { border: "#22d3ee", bg: "rgba(34, 211, 238, 0.18)", text: "#cffafe" },
+  dinner: { border: "#a78bfa", bg: "rgba(167, 139, 250, 0.2)", text: "#ede9fe" },
+  snack: { border: "#2dd4bf", bg: "rgba(45, 212, 191, 0.18)", text: "#ccfbf1" },
+};
+
+function fmtMacroGrams(n: number) {
+  return n < 10 ? n.toFixed(1) : String(Math.round(n));
+}
+
+function CartGramsEditor({
+  grams,
+  disabled,
+  onCommit,
+}: {
+  grams: number;
+  disabled: boolean;
+  onCommit: (n: number) => void;
+}) {
+  const [local, setLocal] = useState(String(grams));
+  useEffect(() => {
+    setLocal(String(grams));
+  }, [grams]);
+  return (
+    <TextInput
+      value={local}
+      onChangeText={setLocal}
+      onBlur={() => {
+        const n = Number.parseFloat(local.replace(/,/g, ""));
+        if (Number.isFinite(n) && n > 0) {
+          onCommit(n);
+        } else {
+          setLocal(String(grams));
+        }
+      }}
+      keyboardType="decimal-pad"
+      editable={!disabled}
+      style={styles.gramsInput}
+    />
+  );
+}
+
+type Props = {
+  lines: CartLineState[];
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  cartPfc: PfcGrams;
+  mealType: MealType;
+  onMealType: (m: MealType) => void;
+  saving: boolean;
+  onSave: () => void;
+  onRemoveLine: (menuItemId: string) => void;
+  onUpdateGramsPerServing: (menuItemId: string, grams: number) => void;
+};
+
+export function TodayCartDock({
+  lines,
+  expanded,
+  onToggleExpanded,
+  cartPfc,
+  mealType,
+  onMealType,
+  saving,
+  onSave,
+  onRemoveLine,
+  onUpdateGramsPerServing,
+}: Props) {
+  if (lines.length === 0) return null;
+
+  const nItems = lines.reduce((s, l) => s + l.count, 0);
+  const shell = CART_MEAL_CHIP_ACTIVE[mealType];
+
+  return (
+    <View
+      style={[
+        styles.shell,
+        { borderTopColor: shell.border, backgroundColor: "rgba(15, 23, 42, 0.98)" },
+      ]}
+      accessibilityLabel="カート"
+    >
+      <Pressable
+        onPress={onToggleExpanded}
+        style={({ pressed }) => [styles.headerBar, pressed && { opacity: 0.88 }]}
+      >
+        <View style={styles.headerMain}>
+          <Text style={styles.headerTitle}>カート（{nItems}）</Text>
+          <Text style={styles.headerSub}>
+            {CART_MEAL_LABEL[mealType]}に記録 · P{fmtMacroGrams(cartPfc.p)} F{fmtMacroGrams(cartPfc.f)}{" "}
+            C{fmtMacroGrams(cartPfc.c)}
+          </Text>
+        </View>
+        <Text style={styles.chev}>{expanded ? "▼" : "▲"}</Text>
+      </Pressable>
+
+      {expanded ? (
+        <View style={styles.expanded}>
+          <Text style={styles.mealLabel}>記録する食事</Text>
+          <View style={styles.mealRow}>
+            {CART_MEAL_ORDER.map((m) => {
+              const on = mealType === m;
+              const a = CART_MEAL_CHIP_ACTIVE[m];
+              return (
+                <Pressable
+                  key={m}
+                  onPress={() => !saving && onMealType(m)}
+                  style={[
+                    styles.mealChip,
+                    on && { borderColor: a.border, backgroundColor: a.bg },
+                    !on && styles.mealChipOff,
+                    saving && { opacity: 0.45 },
+                  ]}
+                >
+                  <Text style={[styles.mealChipText, on && { color: a.text }, !on && styles.mealChipTextOff]}>
+                    {CART_MEAL_LABEL[m]}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+
+          <ScrollView style={styles.lineScroll} keyboardShouldPersistTaps="handled" nestedScrollEnabled>
+            {lines.map((line) => {
+              const totalGrams = line.gramsPerServing * line.count;
+              const v = pfcGramsFromNullablePer100(
+                line.protein_per_100g,
+                line.fat_per_100g,
+                line.carbs_per_100g,
+                totalGrams
+              );
+              return (
+                <View key={line.menuItemId} style={styles.lineRow}>
+                  <View style={styles.lineBody}>
+                    <Text style={styles.lineName} numberOfLines={2}>
+                      {line.name}
+                      <Text style={styles.countGrams}>
+                        {" "}
+                        ×{line.count}（{totalGrams}g）
+                      </Text>
+                    </Text>
+                    <Text style={styles.linePfc}>
+                      P{fmtMacroGrams(v.p)} F{fmtMacroGrams(v.f)} C{fmtMacroGrams(v.c)}
+                    </Text>
+                  </View>
+                  <View style={styles.gramsCol}>
+                    <Text style={styles.gramsLabel}>1回</Text>
+                    <CartGramsEditor
+                      grams={line.gramsPerServing}
+                      disabled={saving}
+                      onCommit={(n) => onUpdateGramsPerServing(line.menuItemId, n)}
+                    />
+                  </View>
+                  <Pressable
+                    onPress={() => onRemoveLine(line.menuItemId)}
+                    disabled={saving}
+                    hitSlop={8}
+                    style={({ pressed }) => [styles.removeBtn, pressed && { opacity: 0.75 }]}
+                    accessibilityLabel="カートから外す"
+                  >
+                    <Text style={styles.removeBtnText}>×</Text>
+                  </Pressable>
+                </View>
+              );
+            })}
+          </ScrollView>
+
+          <View style={styles.footerRow}>
+            <Text style={styles.totalPfc} numberOfLines={2}>
+              合計 P<Text style={styles.totalNum}>{fmtMacroGrams(cartPfc.p)}</Text> F
+              <Text style={styles.totalNum}>{fmtMacroGrams(cartPfc.f)}</Text> C
+              <Text style={styles.totalNum}>{fmtMacroGrams(cartPfc.c)}</Text>g
+            </Text>
+            <Pressable
+              onPress={onSave}
+              disabled={saving}
+              style={({ pressed }) => [styles.saveBtn, saving && { opacity: 0.5 }, pressed && !saving && { opacity: 0.92 }]}
+            >
+              {saving ? (
+                <ActivityIndicator color="#fff" />
+              ) : (
+                <Text style={styles.saveBtnText}>記録する</Text>
+              )}
+            </Pressable>
+          </View>
+        </View>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  shell: {
+    borderTopWidth: 2,
+    paddingBottom: 10,
+    paddingTop: 4,
+  },
+  headerBar: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    minHeight: 48,
+  },
+  headerMain: { flex: 1, minWidth: 0, paddingRight: 8 },
+  headerTitle: {
+    color: "#f9fafb",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  headerSub: {
+    color: "#9ca3af",
+    fontSize: 11,
+    marginTop: 3,
+    lineHeight: 15,
+  },
+  chev: { color: "#6b7280", fontSize: 14, paddingLeft: 4 },
+  expanded: {
+    paddingHorizontal: 12,
+    paddingBottom: 8,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "#1f2937",
+  },
+  mealLabel: {
+    color: "#6b7280",
+    fontSize: 10,
+    fontWeight: "600",
+    marginTop: 8,
+    marginBottom: 6,
+  },
+  mealRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+    marginBottom: 10,
+  },
+  mealChip: {
+    flex: 1,
+    minWidth: 0,
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    borderRadius: 10,
+    borderWidth: 2,
+    alignItems: "center",
+  },
+  mealChipOff: {
+    borderColor: "rgba(55, 65, 81, 0.9)",
+    backgroundColor: "rgba(31, 41, 55, 0.7)",
+  },
+  mealChipText: { fontSize: 11, fontWeight: "700" },
+  mealChipTextOff: { color: "#6b7280" },
+  lineScroll: { maxHeight: 200, marginBottom: 8 },
+  lineRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 4,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(31, 41, 55, 0.8)",
+    gap: 8,
+  },
+  lineBody: { flex: 1, minWidth: 0 },
+  lineName: { color: "#e5e7eb", fontSize: 14, fontWeight: "500" },
+  countGrams: { color: "#6b7280", fontSize: 12, fontWeight: "400" },
+  linePfc: {
+    color: "#9ca3af",
+    fontSize: 11,
+    marginTop: 4,
+    fontVariant: ["tabular-nums"],
+  },
+  gramsCol: { alignItems: "center", width: 52 },
+  gramsLabel: { color: "#6b7280", fontSize: 9, marginBottom: 2 },
+  gramsInput: {
+    width: 50,
+    textAlign: "center",
+    color: "#fff",
+    fontSize: 13,
+    fontWeight: "600",
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#10b981",
+    backgroundColor: "#111827",
+  },
+  removeBtn: {
+    width: 40,
+    height: 40,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 10,
+  },
+  removeBtnText: { color: "#9ca3af", fontSize: 22, fontWeight: "400" },
+  footerRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 12,
+    paddingTop: 10,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: "#1f2937",
+  },
+  totalPfc: {
+    flex: 1,
+    color: "#d1d5db",
+    fontSize: 14,
+    minWidth: 0,
+  },
+  totalNum: { color: "#fff", fontWeight: "700" },
+  saveBtn: {
+    backgroundColor: "#059669",
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+    borderRadius: 10,
+    minWidth: 108,
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: 44,
+  },
+  saveBtnText: { color: "#fff", fontSize: 15, fontWeight: "700" },
+});

--- a/apps/mobile/components/TodayMenuPanel.tsx
+++ b/apps/mobile/components/TodayMenuPanel.tsx
@@ -1,0 +1,862 @@
+import { Fragment, useCallback, useEffect, useMemo, useState } from "react";
+import { pfcGramsFromNullablePer100 } from "@ketolog/domain/pfc";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from "react-native";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  addMenuItemToFavoritesMobile,
+  removeMenuItemFromFavoritesMobile,
+} from "../lib/favorite-mutations";
+import type {
+  FavoriteGroupPayload,
+  FavoriteMenuItemPayload,
+} from "../lib/fetch-favorite-groups-payload";
+import {
+  fetchFavoriteGroupsPayload,
+  fetchFavoritedMenuItemIds,
+} from "../lib/fetch-favorite-groups-payload";
+import { isSnapshotRestaurant } from "../lib/snapshot-restaurant";
+import {
+  MENU_GROUP_FAVORITES_SCOPE,
+  collapsedMenuGroupsFromExpandedKeys,
+  readMenuGroupExpandedKeysNative,
+  writeMenuGroupExpandedKeysNative,
+} from "../lib/menu-group-expanded-storage-native";
+import {
+  menuRowMacroHighlights,
+  type MacroHighlightTargets,
+} from "../lib/menu-row-macro-highlights";
+
+type BrowseTab = "favorites" | "shops";
+
+/** Web `MenuGroup` に相当 */
+type MenuGroup = {
+  sectionKey: string;
+  groupName: string | null;
+  groupOrder: number;
+  items: FavoriteMenuItemPayload[];
+};
+
+function normalizeMenuGroupKey(raw: string | null | undefined): string | null {
+  if (raw == null) return null;
+  const t = String(raw).trim();
+  return t === "" ? null : t;
+}
+
+type RestaurantRow = {
+  id: string;
+  name: string;
+  order_count: number;
+  display_order?: number | null;
+  created_at: string | null;
+};
+
+type MenuItemRow = FavoriteMenuItemPayload;
+
+function sortRestaurants(list: RestaurantRow[]): RestaurantRow[] {
+  return [...list].sort((a, b) => {
+    const ao = a.display_order ?? 0;
+    const bo = b.display_order ?? 0;
+    if (ao !== bo) return ao - bo;
+    if (b.order_count !== a.order_count) return b.order_count - a.order_count;
+    return a.name.localeCompare(b.name, "ja");
+  });
+}
+
+function buildShopMenuGroups(items: FavoriteMenuItemPayload[]): MenuGroup[] {
+  const sorted = sortMenusForListOrder([...items]);
+  const groupMap = new Map<string | null, MenuGroup>();
+  for (const item of sorted) {
+    const key = normalizeMenuGroupKey(item.group_name);
+    if (!groupMap.has(key)) {
+      groupMap.set(key, {
+        sectionKey: key === null ? "ungrouped" : `g:${key}`,
+        groupName: key,
+        groupOrder: Number(item.group_order) || 0,
+        items: [],
+      });
+    }
+    groupMap.get(key)!.items.push(item);
+  }
+  return [...groupMap.values()].sort((a, b) => {
+    if (a.groupName === null) return -1;
+    if (b.groupName === null) return 1;
+    const o = a.groupOrder - b.groupOrder;
+    if (o !== 0) return o;
+    return (a.groupName as string).localeCompare(b.groupName as string, "ja");
+  });
+}
+
+function buildFavoriteMenuGroups(
+  groups: FavoriteGroupPayload[],
+  query: string
+): MenuGroup[] {
+  const q = query.trim().toLowerCase();
+  return groups
+    .slice()
+    .sort((a, b) => a.display_order - b.display_order)
+    .map((g) => {
+      const items: FavoriteMenuItemPayload[] = [];
+      for (const e of [...g.entries].sort((x, y) => x.display_order - y.display_order)) {
+        const mi = e.menu_item;
+        if (!mi) continue;
+        if (q && !mi.name.toLowerCase().includes(q)) continue;
+        items.push(mi);
+      }
+      return {
+        sectionKey: `favg:${g.id}`,
+        groupName: g.name,
+        groupOrder: g.display_order,
+        items,
+      };
+    })
+    .filter((x) => x.items.length > 0);
+}
+
+type Props = {
+  supabase: SupabaseClient;
+  userId: string;
+  /** 引き下げ更新などでデータを取り直す */
+  reloadNonce?: number;
+  onAddToCart: (item: FavoriteMenuItemPayload, gramsPerServing: number) => void;
+  onEditMenuItem?: (item: FavoriteMenuItemPayload) => void;
+  /** 店舗タブ行の「＋」（Web `RestaurantPanel` のお店追加） */
+  onOpenRestaurantAdd?: () => void;
+  /** 一覧下の「＋ メニューを追加」（Web `MenuItemList`）。いま選んでいる店を登録先ヒントにする */
+  onOpenMenuEditorAdd?: (registerRestaurantIdHint: string | null) => void;
+  /** 店舗追加直後にこの店タブへ切り替える */
+  selectRestaurantIdAfterAdd?: string | null;
+  onSelectRestaurantIdAfterAddConsumed?: () => void;
+  /** メニュー行の P/F 強調（Web `MenuItemRow` の `pfcTargets`） */
+  macroTargets: MacroHighlightTargets;
+};
+
+/** Web `compareMenuItemsForListOrder` / `sortMenuItemsForListOrder` と同順 */
+function compareMenuItemsForListOrder(a: MenuItemRow, b: MenuItemRow): number {
+  if (a.rank !== b.rank) return a.rank - b.rank;
+  const nameCmp = a.name.localeCompare(b.name, "ja");
+  if (nameCmp !== 0) return nameCmp;
+  const ac = a.created_at ?? "";
+  const bc = b.created_at ?? "";
+  if (ac !== bc) return ac < bc ? -1 : 1;
+  return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+}
+
+function sortMenusForListOrder(list: MenuItemRow[]): MenuItemRow[] {
+  return [...list].sort(compareMenuItemsForListOrder);
+}
+
+const RANK_CELL: Record<number, { icon: string; color: string }> = {
+  1: { icon: "◎", color: "#34d399" },
+  2: { icon: "○", color: "#6b7280" },
+  3: { icon: "△", color: "#fbbf24" },
+  4: { icon: "✕", color: "#f87171" },
+};
+
+function fmtPfc(n: number) {
+  return n < 10 ? n.toFixed(1) : String(Math.round(n));
+}
+
+function MenuLineRow({
+  item,
+  starred,
+  onToggleStar,
+  onAdd,
+  onEdit,
+  macroTargets,
+}: {
+  item: MenuItemRow;
+  starred: boolean;
+  onToggleStar: () => void;
+  onAdd: (grams: number) => void;
+  onEdit?: () => void;
+  macroTargets: MacroHighlightTargets;
+}) {
+  const defaultG = item.default_grams && item.default_grams > 0 ? Number(item.default_grams) : 100;
+  const [grams, setGrams] = useState(defaultG);
+  const [editing, setEditing] = useState(false);
+  const [gramsStr, setGramsStr] = useState(String(defaultG));
+
+  useEffect(() => {
+    const d = item.default_grams && item.default_grams > 0 ? Number(item.default_grams) : 100;
+    setGrams(d);
+    setGramsStr(String(d));
+    setEditing(false);
+  }, [item.id, item.default_grams]);
+
+  const serving = pfcGramsFromNullablePer100(
+    item.protein_per_100g != null ? Number(item.protein_per_100g) : null,
+    item.fat_per_100g != null ? Number(item.fat_per_100g) : null,
+    item.carbs_per_100g != null ? Number(item.carbs_per_100g) : null,
+    grams
+  );
+  const rankCell = RANK_CELL[item.rank] ?? RANK_CELL[2]!;
+  const { highlightP, highlightF } =
+    item.protein_per_100g != null
+      ? menuRowMacroHighlights(
+          { p: serving.p, f: serving.f },
+          {
+            protein_per_100g: item.protein_per_100g != null ? Number(item.protein_per_100g) : null,
+            fat_per_100g: item.fat_per_100g != null ? Number(item.fat_per_100g) : null,
+          },
+          macroTargets
+        )
+      : { highlightP: false, highlightF: false };
+
+  return (
+    <View style={styles.row}>
+      <Pressable onPress={onToggleStar} style={styles.starBtn} hitSlop={6}>
+        <Text style={[styles.star, starred && styles.starOn]}>{starred ? "★" : "☆"}</Text>
+      </Pressable>
+      <View style={styles.rankCol}>
+        <Text style={[styles.rankText, { color: rankCell.color }]}>{rankCell.icon}</Text>
+      </View>
+      {onEdit ? (
+        <Pressable
+          onPress={onEdit}
+          style={({ pressed }) => [styles.rowBody, pressed && { opacity: 0.85 }]}
+          accessibilityRole="button"
+          accessibilityLabel={`${item.name}を編集`}
+        >
+          <Text style={styles.rowTitle} numberOfLines={2}>
+            {item.name}
+          </Text>
+          <Text style={styles.rowPfc}>
+            {item.protein_per_100g != null ? (
+              <>
+                <Text style={highlightP ? styles.pfcPHi : styles.pfcMuted}>P{fmtPfc(serving.p)}</Text>
+                <Text style={styles.pfcMuted}> </Text>
+                <Text style={highlightF ? styles.pfcFHi : styles.pfcMuted}>F{fmtPfc(serving.f)}</Text>
+                <Text style={styles.pfcMuted}> </Text>
+                <Text style={styles.pfcMuted}>C{fmtPfc(serving.c)}</Text>
+              </>
+            ) : (
+              <Text style={styles.rowPfcUnset}>PFC未設定 — タップして編集</Text>
+            )}
+          </Text>
+        </Pressable>
+      ) : (
+        <View style={styles.rowBody}>
+          <Text style={styles.rowTitle} numberOfLines={2}>
+            {item.name}
+          </Text>
+          <Text style={styles.rowPfc}>
+            {item.protein_per_100g != null ? (
+              <>
+                <Text style={highlightP ? styles.pfcPHi : styles.pfcMuted}>P{fmtPfc(serving.p)}</Text>
+                <Text style={styles.pfcMuted}> </Text>
+                <Text style={highlightF ? styles.pfcFHi : styles.pfcMuted}>F{fmtPfc(serving.f)}</Text>
+                <Text style={styles.pfcMuted}> </Text>
+                <Text style={styles.pfcMuted}>C{fmtPfc(serving.c)}</Text>
+              </>
+            ) : (
+              <Text style={styles.rowPfcUnset}>PFC未設定</Text>
+            )}
+          </Text>
+        </View>
+      )}
+      {editing ? (
+        <TextInput
+          value={gramsStr}
+          onChangeText={setGramsStr}
+          onBlur={() => {
+            const n = Number.parseFloat(gramsStr.replace(/,/g, ""));
+            if (Number.isFinite(n) && n > 0) {
+              setGrams(n);
+              setGramsStr(String(n));
+            } else {
+              setGramsStr(String(grams));
+            }
+            setEditing(false);
+          }}
+          keyboardType="decimal-pad"
+          style={styles.gramsInput}
+          autoFocus
+        />
+      ) : (
+        <Pressable onPress={() => setEditing(true)} style={styles.gramsTap}>
+          <Text style={styles.gramsTapText}>{grams}g</Text>
+        </Pressable>
+      )}
+      <Pressable onPress={() => onAdd(grams)} style={styles.plusBtn}>
+        <Text style={styles.plusBtnText}>+</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export function TodayMenuPanel({
+  supabase,
+  userId,
+  reloadNonce = 0,
+  onAddToCart,
+  onEditMenuItem,
+  onOpenRestaurantAdd,
+  onOpenMenuEditorAdd,
+  selectRestaurantIdAfterAdd,
+  onSelectRestaurantIdAfterAddConsumed,
+  macroTargets,
+}: Props) {
+  const [tab, setTab] = useState<BrowseTab>("favorites");
+  const [restaurants, setRestaurants] = useState<RestaurantRow[]>([]);
+  const [selectedRestaurantId, setSelectedRestaurantId] = useState<string | null>(null);
+  const [menuItems, setMenuItems] = useState<MenuItemRow[]>([]);
+  const [favoriteGroups, setFavoriteGroups] = useState<FavoriteGroupPayload[]>([]);
+  const [favoritedMenuItemIds, setFavoritedMenuItemIds] = useState<Set<string>>(new Set());
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refreshFavoritedIds = useCallback(async () => {
+    const r = await fetchFavoritedMenuItemIds(supabase, userId);
+    if (!r.error) setFavoritedMenuItemIds(r.data);
+  }, [supabase, userId]);
+
+  const loadFavorites = useCallback(async () => {
+    const r = await fetchFavoriteGroupsPayload(supabase, userId);
+    if (r.error) {
+      setError(r.error);
+      setFavoriteGroups([]);
+      return;
+    }
+    setFavoriteGroups(r.data);
+  }, [supabase, userId]);
+
+  const loadRestaurants = useCallback(async () => {
+    let data: unknown[] | null = null;
+    const primary = await supabase
+      .from("restaurants")
+      .select("id, name, order_count, display_order, created_at")
+      .eq("user_id", userId);
+    if (primary.error) {
+      const missingDisplayOrder =
+        primary.error.message.toLowerCase().includes("display_order") &&
+        primary.error.message.toLowerCase().includes("does not exist");
+      if (!missingDisplayOrder) {
+        setError(primary.error.message);
+        setRestaurants([]);
+        return;
+      }
+      const fallback = await supabase
+        .from("restaurants")
+        .select("id, name, order_count, created_at")
+        .eq("user_id", userId);
+      if (fallback.error) {
+        setError(fallback.error.message);
+        setRestaurants([]);
+        return;
+      }
+      data = fallback.data as unknown[] | null;
+    } else {
+      data = primary.data as unknown[] | null;
+    }
+    const rows = sortRestaurants(
+      ((data ?? []) as RestaurantRow[]).filter((r) => !isSnapshotRestaurant(r))
+    );
+    setRestaurants(rows);
+    setSelectedRestaurantId((prev) =>
+      prev && rows.some((r) => r.id === prev) ? prev : rows[0]?.id ?? null
+    );
+  }, [supabase, userId]);
+
+  const loadMenus = useCallback(async () => {
+    if (!selectedRestaurantId) {
+      setMenuItems([]);
+      return;
+    }
+    const { data, error: err } = await supabase
+      .from("menu_items")
+      .select(
+        "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, standard_food_code, created_at"
+      )
+      .eq("user_id", userId)
+      .eq("restaurant_id", selectedRestaurantId);
+    if (err) {
+      setError(err.message);
+      setMenuItems([]);
+      return;
+    }
+    setMenuItems(sortMenusForListOrder((data ?? []) as MenuItemRow[]));
+  }, [selectedRestaurantId, supabase, userId]);
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError(null);
+      await Promise.all([loadFavorites(), loadRestaurants(), refreshFavoritedIds()]);
+      if (!cancelled) setLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, reloadNonce, loadFavorites, loadRestaurants, refreshFavoritedIds]);
+
+  useEffect(() => {
+    void loadMenus();
+  }, [loadMenus]);
+
+  useEffect(() => {
+    if (!selectRestaurantIdAfterAdd) return;
+    if (!restaurants.some((r) => r.id === selectRestaurantIdAfterAdd)) return;
+    setTab("shops");
+    setSelectedRestaurantId(selectRestaurantIdAfterAdd);
+    onSelectRestaurantIdAfterAddConsumed?.();
+  }, [restaurants, selectRestaurantIdAfterAdd, onSelectRestaurantIdAfterAddConsumed]);
+
+  const visibleMenus = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return menuItems;
+    return menuItems.filter((m) => m.name.toLowerCase().includes(q));
+  }, [menuItems, query]);
+
+  const menuGroups = useMemo((): MenuGroup[] => {
+    if (tab === "favorites") {
+      return buildFavoriteMenuGroups(favoriteGroups, query);
+    }
+    return buildShopMenuGroups(visibleMenus);
+  }, [tab, favoriteGroups, query, visibleMenus]);
+
+  const collapsibleSectionKeys = useMemo(
+    () => menuGroups.filter((g) => g.groupName !== null).map((g) => g.sectionKey),
+    [menuGroups]
+  );
+
+  const collapsibleJoined = useMemo(
+    () => collapsibleSectionKeys.join("\0"),
+    [collapsibleSectionKeys]
+  );
+
+  const storageScope = useMemo((): string | null => {
+    if (tab === "favorites") return MENU_GROUP_FAVORITES_SCOPE;
+    if (!selectedRestaurantId) return null;
+    return selectedRestaurantId;
+  }, [tab, selectedRestaurantId]);
+
+  const [expandedGroupKeys, setExpandedGroupKeys] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setExpandedGroupKeys(null);
+      if (!storageScope || collapsibleSectionKeys.length <= 1) {
+        if (!cancelled) {
+          setExpandedGroupKeys([...collapsibleSectionKeys]);
+        }
+        return;
+      }
+      const keys = await readMenuGroupExpandedKeysNative(storageScope);
+      const filtered = keys.filter((k) => collapsibleSectionKeys.includes(k));
+      if (!cancelled) setExpandedGroupKeys(filtered);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [storageScope, collapsibleJoined, collapsibleSectionKeys.length]);
+
+  const collapsedSet = useMemo(
+    () =>
+      collapsedMenuGroupsFromExpandedKeys(
+        collapsibleSectionKeys,
+        collapsibleSectionKeys.length <= 1 ? null : storageScope,
+        expandedGroupKeys ?? collapsibleSectionKeys
+      ),
+    [collapsibleSectionKeys, storageScope, expandedGroupKeys]
+  );
+
+  const toggleMenuGroupCollapsed = useCallback(
+    async (sectionKey: string) => {
+      if (!storageScope || collapsibleSectionKeys.length <= 1) return;
+      const base = expandedGroupKeys ?? collapsibleSectionKeys;
+      const expandedSet = new Set(
+        base.filter((k) => collapsibleSectionKeys.includes(k))
+      );
+      if (expandedSet.has(sectionKey)) expandedSet.delete(sectionKey);
+      else expandedSet.add(sectionKey);
+      const next = [...expandedSet];
+      await writeMenuGroupExpandedKeysNative(storageScope, next);
+      setExpandedGroupKeys(next);
+    },
+    [storageScope, collapsibleSectionKeys, expandedGroupKeys]
+  );
+
+  const toggleFavorite = useCallback(
+    async (item: MenuItemRow) => {
+      if (favoritedMenuItemIds.has(item.id)) {
+        const r = await removeMenuItemFromFavoritesMobile(supabase, item.id);
+        if (r.error) {
+          setError(r.error);
+          return;
+        }
+      } else {
+        const r = await addMenuItemToFavoritesMobile(supabase, userId, item.id);
+        if (r.error) {
+          setError(r.error);
+          return;
+        }
+      }
+      await Promise.all([refreshFavoritedIds(), loadFavorites()]);
+    },
+    [favoritedMenuItemIds, supabase, userId, refreshFavoritedIds, loadFavorites]
+  );
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.switchRow}>
+        <Pressable
+          onPress={() => setTab("favorites")}
+          style={({ pressed }) => [
+            styles.favAnchor,
+            tab === "favorites" && styles.favAnchorOn,
+            pressed && { opacity: 0.88 },
+          ]}
+          accessibilityLabel="お気に入り"
+        >
+          <Text style={[styles.favStarGlyph, tab === "favorites" && styles.favStarGlyphOn]}>
+            {tab === "favorites" ? "★" : "☆"}
+          </Text>
+          <Text
+            style={[styles.favAnchorLabel, tab === "favorites" && styles.favAnchorLabelOn]}
+            numberOfLines={1}
+          >
+            お気に入り
+          </Text>
+        </Pressable>
+
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          contentContainerStyle={styles.restaurantTabRow}
+          style={styles.restaurantScroll}
+        >
+          {restaurants.map((r) => (
+            <Pressable
+              key={r.id}
+              onPress={() => {
+                setTab("shops");
+                setSelectedRestaurantId(r.id);
+              }}
+              style={[
+                styles.restaurantTab,
+                tab === "shops" && selectedRestaurantId === r.id && styles.restaurantTabOn,
+              ]}
+            >
+              <Text
+                style={[
+                  styles.restaurantTabText,
+                  tab === "shops" && selectedRestaurantId === r.id && styles.restaurantTabTextOn,
+                ]}
+              >
+                {r.name}
+              </Text>
+            </Pressable>
+          ))}
+        </ScrollView>
+        {onOpenRestaurantAdd ? (
+          <Pressable
+            onPress={onOpenRestaurantAdd}
+            style={({ pressed }) => [styles.restaurantPlusBtn, pressed && { opacity: 0.75 }]}
+            accessibilityLabel="お店を追加"
+            hitSlop={6}
+          >
+            <Text style={styles.restaurantPlusGlyph}>＋</Text>
+          </Pressable>
+        ) : null}
+      </View>
+
+      <TextInput
+        value={query}
+        onChangeText={setQuery}
+        placeholder={tab === "favorites" ? "お気に入りを検索" : "メニューを検索"}
+        placeholderTextColor="#6b7280"
+        style={styles.search}
+      />
+
+      {loading ? (
+        <View style={styles.center}>
+          <ActivityIndicator color="#10b981" />
+        </View>
+      ) : error ? (
+        <Text style={styles.error}>{error}</Text>
+      ) : (
+        <View style={styles.list}>
+          {menuGroups.map((group) => {
+            if (group.groupName === null) {
+              return (
+                <Fragment key={group.sectionKey}>
+                  {group.items.map((item) => (
+                    <MenuLineRow
+                      key={item.id}
+                      item={item}
+                      starred={favoritedMenuItemIds.has(item.id)}
+                      onToggleStar={() => {
+                        void toggleFavorite(item);
+                      }}
+                      onAdd={(g) => onAddToCart(item, g)}
+                      onEdit={onEditMenuItem ? () => onEditMenuItem(item) : undefined}
+                      macroTargets={macroTargets}
+                    />
+                  ))}
+                </Fragment>
+              );
+            }
+            const isCollapsed = collapsedSet.has(group.sectionKey);
+            return (
+              <View key={group.sectionKey}>
+                <Pressable
+                  onPress={() => {
+                    void toggleMenuGroupCollapsed(group.sectionKey);
+                  }}
+                  style={({ pressed }) => [
+                    styles.menuGroupHeader,
+                    pressed && { opacity: 0.88 },
+                  ]}
+                  accessibilityRole="button"
+                  accessibilityState={{ expanded: !isCollapsed }}
+                >
+                  <View style={styles.menuGroupHeaderInner}>
+                    <Text style={styles.menuGroupChevron}>{isCollapsed ? "▶" : "▼"}</Text>
+                    <Text style={styles.menuGroupTitle} numberOfLines={1}>
+                      {group.groupName}（{group.items.length}品）
+                    </Text>
+                  </View>
+                </Pressable>
+                {!isCollapsed
+                  ? group.items.map((item) => (
+                      <MenuLineRow
+                        key={item.id}
+                        item={item}
+                        starred={favoritedMenuItemIds.has(item.id)}
+                        onToggleStar={() => {
+                          void toggleFavorite(item);
+                        }}
+                        onAdd={(g) => onAddToCart(item, g)}
+                        onEdit={onEditMenuItem ? () => onEditMenuItem(item) : undefined}
+                        macroTargets={macroTargets}
+                      />
+                    ))
+                  : null}
+              </View>
+            );
+          })}
+          {tab === "shops" &&
+          selectedRestaurantId &&
+          onOpenMenuEditorAdd &&
+          restaurants.length > 0 ? (
+            <Pressable
+              onPress={() => onOpenMenuEditorAdd(selectedRestaurantId)}
+              style={({ pressed }) => [styles.addMenuItemRow, pressed && { opacity: 0.9 }]}
+              accessibilityLabel="メニューを追加"
+            >
+              <Text style={styles.addMenuItemText}>＋ メニューを追加</Text>
+            </Pressable>
+          ) : null}
+          {tab === "favorites" && menuGroups.length === 0 ? (
+            <Text style={styles.empty}>お気に入りがありません</Text>
+          ) : null}
+          {tab === "shops" && restaurants.length === 0 ? (
+            <Text style={styles.empty}>店舗がありません</Text>
+          ) : null}
+          {tab === "shops" && restaurants.length > 0 && menuGroups.length === 0 ? (
+            <Text style={styles.empty}>この店舗にメニューがありません</Text>
+          ) : null}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  /** TodayScreen の PFC ブロックと同じ全幅ストリップ（左右の余白カードはやめる） */
+  wrap: {
+    marginTop: 0,
+    marginHorizontal: 0,
+    paddingHorizontal: 14,
+    paddingVertical: 12,
+    backgroundColor: "#111827",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "#1f2937",
+    gap: 10,
+  },
+  switchRow: { flexDirection: "row", alignItems: "stretch", gap: 8 },
+  restaurantPlusBtn: {
+    width: 40,
+    alignItems: "center",
+    justifyContent: "center",
+    alignSelf: "stretch",
+  },
+  restaurantPlusGlyph: {
+    fontSize: 22,
+    lineHeight: 26,
+    color: "#6b7280",
+    fontWeight: "300",
+  },
+  addMenuItemRow: {
+    marginTop: 10,
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderWidth: 1,
+    borderStyle: "dashed",
+    borderColor: "#374151",
+    borderRadius: 8,
+    alignItems: "center",
+  },
+  addMenuItemText: { color: "#9ca3af", fontSize: 14, fontWeight: "500" },
+  /** 店舗タブと同じ高さ・1行（成分表タブ追加時も揃えやすい） */
+  favAnchor: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 4,
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    minHeight: 40,
+    alignSelf: "stretch",
+    borderRadius: 0,
+    borderWidth: 1,
+    borderColor: "rgba(113, 63, 18, 0.7)",
+    backgroundColor: "rgba(66, 32, 6, 0.5)",
+  },
+  favAnchorOn: {
+    borderColor: "#fbbf24",
+    backgroundColor: "rgba(251, 191, 36, 0.18)",
+  },
+  favStarGlyph: {
+    fontSize: 12,
+    lineHeight: 14,
+    fontWeight: "700",
+    color: "#6b7280",
+  },
+  favStarGlyphOn: { color: "#fbbf24" },
+  favAnchorLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#a3a3a3",
+    flexShrink: 1,
+  },
+  favAnchorLabelOn: { color: "#fef3c7" },
+  restaurantScroll: { flex: 1 },
+  restaurantTabRow: { gap: 6, paddingRight: 8 },
+  restaurantTab: {
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    minHeight: 40,
+    justifyContent: "center",
+    borderRadius: 0,
+    borderWidth: 1,
+    borderColor: "#374151",
+    backgroundColor: "#111827",
+  },
+  restaurantTabOn: { borderColor: "#10b981", backgroundColor: "rgba(16,185,129,0.18)" },
+  restaurantTabText: { color: "#9ca3af", fontSize: 12, fontWeight: "600" },
+  restaurantTabTextOn: { color: "#d1fae5" },
+  search: {
+    borderWidth: 1,
+    borderColor: "#374151",
+    borderRadius: 0,
+    color: "#e5e7eb",
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    fontSize: 14,
+  },
+  center: { alignItems: "center", paddingVertical: 20 },
+  error: { color: "#fecaca", fontSize: 12, paddingVertical: 8 },
+  list: { gap: 7 },
+  /** Web `MenuItemList` のグループ見出しに近い */
+  menuGroupHeader: {
+    marginHorizontal: -14,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    backgroundColor: "rgba(17, 24, 39, 0.5)",
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(31, 41, 55, 0.6)",
+  },
+  menuGroupHeaderInner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    minWidth: 0,
+  },
+  menuGroupChevron: {
+    color: "#9ca3af",
+    fontSize: 11,
+    width: 14,
+    textAlign: "center",
+  },
+  menuGroupTitle: {
+    flex: 1,
+    color: "#9ca3af",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    borderRadius: 0,
+    backgroundColor: "#111827",
+    paddingLeft: 4,
+    paddingRight: 4,
+    paddingVertical: 8,
+    gap: 4,
+  },
+  starBtn: { width: 26, alignItems: "center", justifyContent: "center" },
+  star: { fontSize: 15, lineHeight: 16, color: "#6b7280", fontWeight: "600" },
+  starOn: { color: "#fbbf24" },
+  rankCol: { width: 18, alignItems: "center", justifyContent: "center" },
+  rankText: { fontSize: 11, fontWeight: "700" },
+  rowBody: { flex: 1, minWidth: 0, paddingRight: 2 },
+  rowTitle: { color: "#f9fafb", fontWeight: "600", fontSize: 14 },
+  rowPfc: { fontSize: 11, marginTop: 4, fontVariant: ["tabular-nums"] },
+  pfcMuted: { color: "#6b7280" },
+  pfcPHi: { color: "#60a5fa" },
+  pfcFHi: { color: "#facc15" },
+  rowPfcUnset: { color: "#6b7280" },
+  gramsTap: {
+    minWidth: 48,
+    paddingVertical: 8,
+    paddingHorizontal: 6,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 0,
+  },
+  gramsTapText: { color: "#9ca3af", fontSize: 12, fontWeight: "600" },
+  gramsInput: {
+    width: 52,
+    textAlign: "center",
+    color: "#fff",
+    fontSize: 13,
+    fontWeight: "600",
+    paddingVertical: 8,
+    borderRadius: 0,
+    borderWidth: 1,
+    borderColor: "#10b981",
+    backgroundColor: "#0f172a",
+  },
+  /** Web `MenuItemRow` の「+」: 丸・緑・白文字 */
+  plusBtn: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: "#059669",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  plusBtnText: {
+    color: "#ffffff",
+    fontWeight: "700",
+    fontSize: 18,
+    lineHeight: 20,
+    marginTop: -1,
+  },
+  empty: { color: "#6b7280", fontSize: 12, textAlign: "center", paddingVertical: 12 },
+});

--- a/apps/mobile/lib/add-restaurant-mobile.ts
+++ b/apps/mobile/lib/add-restaurant-mobile.ts
@@ -1,0 +1,56 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const NAME_MAX = 100;
+
+async function nextRestaurantDisplayOrder(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<number> {
+  const { data: row } = await supabase
+    .from("restaurants")
+    .select("display_order")
+    .eq("user_id", userId)
+    .order("display_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  return (row?.display_order ?? -1) + 1;
+}
+
+export async function addRestaurantMobile(
+  supabase: SupabaseClient,
+  userId: string,
+  name: string,
+  category: string
+): Promise<{ data: { id: string; name: string } | null; error: string | null }> {
+  const trimmed = name.trim();
+  if (!trimmed) return { data: null, error: "お店の名前を入力してください" };
+  if (trimmed.length > NAME_MAX) {
+    return { data: null, error: `店名は${NAME_MAX}文字以内にしてください` };
+  }
+
+  const displayOrder = await nextRestaurantDisplayOrder(supabase, userId);
+
+  const first = await supabase
+    .from("restaurants")
+    .insert({
+      user_id: userId,
+      name: trimmed,
+      category,
+      display_order: displayOrder,
+    })
+    .select("id, name")
+    .single();
+
+  if (first.error && first.error.message.includes("display_order")) {
+    const fallback = await supabase
+      .from("restaurants")
+      .insert({ user_id: userId, name: trimmed, category })
+      .select("id, name")
+      .single();
+    if (fallback.error) return { data: null, error: fallback.error.message };
+    return { data: fallback.data as { id: string; name: string }, error: null };
+  }
+
+  if (first.error) return { data: null, error: first.error.message };
+  return { data: first.data as { id: string; name: string }, error: null };
+}

--- a/apps/mobile/lib/favorite-mutations.ts
+++ b/apps/mobile/lib/favorite-mutations.ts
@@ -1,0 +1,117 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+async function getOrCreateFavoriteGroupByName(
+  supabase: SupabaseClient,
+  userId: string,
+  groupName: string
+): Promise<{ id: string | null; error: string | null }> {
+  const trimmed = groupName.trim();
+  if (!trimmed) return { id: null, error: "グループ名が空です" };
+
+  const { data: existing } = await supabase
+    .from("favorite_groups")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("name", trimmed)
+    .maybeSingle();
+  if (existing?.id) return { id: String(existing.id), error: null };
+
+  const { data: maxRow } = await supabase
+    .from("favorite_groups")
+    .select("display_order")
+    .eq("user_id", userId)
+    .order("display_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const displayOrder = (maxRow?.display_order ?? -1) + 1;
+
+  const { data: inserted, error } = await supabase
+    .from("favorite_groups")
+    .insert({ user_id: userId, name: trimmed, display_order: displayOrder })
+    .select("id")
+    .single();
+
+  if (error) return { id: null, error: error.message };
+  return { id: inserted?.id ? String(inserted.id) : null, error: null };
+}
+
+/** Web `ensureFavoriteEntryForMenuItem` と同じ */
+export async function ensureFavoriteEntryForMenuItem(
+  supabase: SupabaseClient,
+  userId: string,
+  menuItemId: string,
+  restaurantDisplayName: string
+): Promise<{ error: string | null }> {
+  const { data: dup } = await supabase
+    .from("favorite_entries")
+    .select("id")
+    .eq("menu_item_id", menuItemId)
+    .maybeSingle();
+  if (dup) return { error: null };
+
+  const { id: groupId, error: gErr } = await getOrCreateFavoriteGroupByName(
+    supabase,
+    userId,
+    restaurantDisplayName
+  );
+  if (gErr || !groupId) return { error: gErr ?? "お気に入りグループの作成に失敗しました" };
+
+  const { data: maxE } = await supabase
+    .from("favorite_entries")
+    .select("display_order")
+    .eq("favorite_group_id", groupId)
+    .order("display_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const entryOrder = (maxE?.display_order ?? -1) + 1;
+
+  const { error: insErr } = await supabase.from("favorite_entries").insert({
+    favorite_group_id: groupId,
+    menu_item_id: menuItemId,
+    display_order: entryOrder,
+  });
+  if (insErr) return { error: insErr.message };
+  return { error: null };
+}
+
+export async function addMenuItemToFavoritesMobile(
+  supabase: SupabaseClient,
+  userId: string,
+  menuItemId: string
+): Promise<{ error: string | null }> {
+  const { data: mi, error: miErr } = await supabase
+    .from("menu_items")
+    .select("restaurant_id")
+    .eq("id", menuItemId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (miErr || !mi) {
+    return { error: miErr?.message ?? "メニューが見つかりません" };
+  }
+
+  const { data: rest, error: rErr } = await supabase
+    .from("restaurants")
+    .select("name")
+    .eq("id", mi.restaurant_id)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (rErr || !rest) {
+    return { error: rErr?.message ?? "お店が見つかりません" };
+  }
+
+  return ensureFavoriteEntryForMenuItem(
+    supabase,
+    userId,
+    menuItemId,
+    String(rest.name)
+  );
+}
+
+export async function removeMenuItemFromFavoritesMobile(
+  supabase: SupabaseClient,
+  menuItemId: string
+): Promise<{ error: string | null }> {
+  const { error } = await supabase.from("favorite_entries").delete().eq("menu_item_id", menuItemId);
+  if (error) return { error: error.message };
+  return { error: null };
+}

--- a/apps/mobile/lib/fetch-distinct-menu-group-names.ts
+++ b/apps/mobile/lib/fetch-distinct-menu-group-names.ts
@@ -1,0 +1,25 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/** 店舗内の既存グループ名（メニュー行の候補）。Web `existingGroupNames` 相当。 */
+export async function fetchDistinctMenuGroupNames(
+  supabase: SupabaseClient,
+  userId: string,
+  restaurantId: string
+): Promise<{ names: string[]; error: string | null }> {
+  const { data, error } = await supabase
+    .from("menu_items")
+    .select("group_name")
+    .eq("user_id", userId)
+    .eq("restaurant_id", restaurantId)
+    .not("group_name", "is", null);
+
+  if (error) return { names: [], error: error.message };
+
+  const set = new Set<string>();
+  for (const row of data ?? []) {
+    const gn = (row as { group_name?: string | null }).group_name?.trim();
+    if (gn) set.add(gn);
+  }
+  const names = [...set].sort((a, b) => a.localeCompare(b, "ja"));
+  return { names, error: null };
+}

--- a/apps/mobile/lib/fetch-favorite-groups-payload.ts
+++ b/apps/mobile/lib/fetch-favorite-groups-payload.ts
@@ -1,0 +1,141 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/** Web `FavoriteEntryPayload` / `MenuItem` のモバイル用サブセット */
+export type FavoriteMenuItemPayload = {
+  id: string;
+  restaurant_id: string;
+  name: string;
+  protein_per_100g: number | null;
+  fat_per_100g: number | null;
+  carbs_per_100g: number | null;
+  default_grams: number;
+  order_count: number;
+  rank: number;
+  notes: string | null;
+  group_name: string | null;
+  group_order: number;
+  shared_barcode: string | null;
+  standard_food_code?: string | null;
+  created_at?: string;
+};
+
+export type FavoriteEntryPayload = {
+  id: string;
+  favorite_group_id: string;
+  menu_item_id: string;
+  display_order: number;
+  menu_item?: FavoriteMenuItemPayload;
+};
+
+export type FavoriteGroupPayload = {
+  id: string;
+  name: string;
+  display_order: number;
+  entries: FavoriteEntryPayload[];
+};
+
+const FAVORITE_MENU_ITEM_SELECT_WITH_STANDARD_FOOD_CODE =
+  "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, standard_food_code, created_at";
+const FAVORITE_MENU_ITEM_SELECT_LEGACY =
+  "id, restaurant_id, name, protein_per_100g, fat_per_100g, carbs_per_100g, default_grams, order_count, rank, notes, group_name, group_order, shared_barcode, created_at";
+
+function isMissingColumnError(error: { message?: string } | null | undefined): boolean {
+  if (!error?.message) return false;
+  const msg = error.message.toLowerCase();
+  return msg.includes("column") && msg.includes("does not exist");
+}
+
+async function fetchFavoriteGroupsPayloadInternal(
+  supabase: SupabaseClient,
+  userId: string,
+  includeStandardFoodCode: boolean
+): Promise<{ data: FavoriteGroupPayload[]; error: string | null }> {
+  const nestedMenuItemSelect = includeStandardFoodCode
+    ? FAVORITE_MENU_ITEM_SELECT_WITH_STANDARD_FOOD_CODE
+    : FAVORITE_MENU_ITEM_SELECT_LEGACY;
+  const { data: rows, error } = await supabase
+    .from("favorite_groups")
+    .select(
+      `
+      id,
+      name,
+      display_order,
+      favorite_entries (
+        id,
+        favorite_group_id,
+        menu_item_id,
+        display_order,
+        menu_item:menu_items (
+          ${nestedMenuItemSelect}
+        )
+      )
+    `
+    )
+    .eq("user_id", userId)
+    .order("display_order", { ascending: true });
+
+  if (error) return { data: [], error: error.message };
+
+  const groups: FavoriteGroupPayload[] = (rows ?? []).map((g: Record<string, unknown>) => {
+    const rawEntries =
+      (g.favorite_entries as Array<Record<string, unknown>> | null) ?? [];
+    const entries: FavoriteEntryPayload[] = rawEntries
+      .map((e) => {
+        const rawMenuItem = e.menu_item as Record<string, unknown> | null | undefined;
+        return {
+          id: e.id as string,
+          favorite_group_id: e.favorite_group_id as string,
+          menu_item_id: e.menu_item_id as string,
+          display_order: e.display_order as number,
+          menu_item:
+            rawMenuItem && typeof rawMenuItem.id === "string"
+              ? (rawMenuItem as unknown as FavoriteMenuItemPayload)
+              : undefined,
+        };
+      })
+      .sort((a, b) => a.display_order - b.display_order);
+    return {
+      id: g.id as string,
+      name: g.name as string,
+      display_order: g.display_order as number,
+      entries,
+    };
+  });
+
+  return { data: groups, error: null };
+}
+
+/** Web `fetchFavoriteGroupsPayload` と同じネスト SELECT（RLS 下のクライアント用） */
+export async function fetchFavoriteGroupsPayload(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<{ data: FavoriteGroupPayload[]; error: string | null }> {
+  const primary = await fetchFavoriteGroupsPayloadInternal(supabase, userId, true);
+  if (!isMissingColumnError(primary.error ? { message: primary.error } : null)) return primary;
+  return fetchFavoriteGroupsPayloadInternal(supabase, userId, false);
+}
+
+/** メニュー行の ☆ 表示用（軽量・2クエリ） */
+export async function fetchFavoritedMenuItemIds(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<{ data: Set<string>; error: string | null }> {
+  const { data: groups, error } = await supabase
+    .from("favorite_groups")
+    .select("id")
+    .eq("user_id", userId);
+  if (error) return { data: new Set(), error: error.message };
+  const groupIds = (groups ?? []).map((g) => g.id as string).filter(Boolean);
+  if (groupIds.length === 0) return { data: new Set(), error: null };
+  const { data: entries, error: e2 } = await supabase
+    .from("favorite_entries")
+    .select("menu_item_id")
+    .in("favorite_group_id", groupIds);
+  if (e2) return { data: new Set(), error: e2.message };
+  const out = new Set<string>();
+  for (const row of entries ?? []) {
+    const id = (row as { menu_item_id?: string }).menu_item_id;
+    if (id) out.add(String(id));
+  }
+  return { data: out, error: null };
+}

--- a/apps/mobile/lib/fetch-restaurants-excluding-snapshot.ts
+++ b/apps/mobile/lib/fetch-restaurants-excluding-snapshot.ts
@@ -1,0 +1,61 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { isSnapshotRestaurant } from "./snapshot-restaurant";
+
+export type RestaurantRegisterOption = { id: string; name: string };
+
+type Row = {
+  id: string;
+  name: string;
+  order_count: number;
+  display_order?: number | null;
+  created_at: string | null;
+};
+
+function sortRestaurants(list: Row[]): Row[] {
+  return [...list].sort((a, b) => {
+    const ao = a.display_order ?? 0;
+    const bo = b.display_order ?? 0;
+    if (ao !== bo) return ao - bo;
+    if (b.order_count !== a.order_count) return b.order_count - a.order_count;
+    return a.name.localeCompare(b.name, "ja");
+  });
+}
+
+/**
+ * メニュー登録先の候補（スナップショット店を除く）。
+ * `TodayMenuPanel` の店舗取得と同じ `display_order` フォールバック。
+ */
+export async function fetchRestaurantsExcludingSnapshot(
+  supabase: SupabaseClient,
+  userId: string
+): Promise<{ restaurants: RestaurantRegisterOption[]; error: string | null }> {
+  let data: unknown[] | null = null;
+  const primary = await supabase
+    .from("restaurants")
+    .select("id, name, order_count, display_order, created_at")
+    .eq("user_id", userId);
+  if (primary.error) {
+    const missingDisplayOrder =
+      primary.error.message.toLowerCase().includes("display_order") &&
+      primary.error.message.toLowerCase().includes("does not exist");
+    if (!missingDisplayOrder) {
+      return { restaurants: [], error: primary.error.message };
+    }
+    const fallback = await supabase
+      .from("restaurants")
+      .select("id, name, order_count, created_at")
+      .eq("user_id", userId);
+    if (fallback.error) {
+      return { restaurants: [], error: fallback.error.message };
+    }
+    data = fallback.data as unknown[] | null;
+  } else {
+    data = primary.data as unknown[] | null;
+  }
+
+  const rows = sortRestaurants(((data ?? []) as Row[]).filter((r) => !isSnapshotRestaurant(r)));
+  return {
+    restaurants: rows.map((r) => ({ id: r.id, name: r.name })),
+    error: null,
+  };
+}

--- a/apps/mobile/lib/menu-group-expanded-storage-native.ts
+++ b/apps/mobile/lib/menu-group-expanded-storage-native.ts
@@ -1,0 +1,78 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+/**
+ * Web `src/lib/menu-group-expanded-storage.ts` と同一キー・同一 shape。
+ * 将来 WebView やデータ移行で揃えやすくする。
+ */
+const STORAGE_KEY = "ketolog.menuGroupExpanded.v1";
+
+/** Web `FAVORITES_TAB_ID` と同じ */
+export const MENU_GROUP_FAVORITES_SCOPE = "__ketolog_favorites__";
+
+type StoredShape = {
+  v: 1;
+  byScope: Record<string, string[]>;
+};
+
+function parseStored(raw: string | null): StoredShape {
+  if (!raw) return { v: 1, byScope: {} };
+  try {
+    const o = JSON.parse(raw) as unknown;
+    if (
+      o &&
+      typeof o === "object" &&
+      (o as StoredShape).v === 1 &&
+      (o as StoredShape).byScope &&
+      typeof (o as StoredShape).byScope === "object"
+    ) {
+      return o as StoredShape;
+    }
+  } catch {
+    /* ignore */
+  }
+  return { v: 1, byScope: {} };
+}
+
+export async function readMenuGroupExpandedKeysNative(scope: string): Promise<string[]> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    const data = parseStored(raw);
+    const list = data.byScope[scope];
+    return Array.isArray(list) ? list.filter((k): k is string => typeof k === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+export async function writeMenuGroupExpandedKeysNative(
+  scope: string,
+  expandedSectionKeys: string[]
+): Promise<void> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    const data = parseStored(raw);
+    data.byScope[scope] = [...expandedSectionKeys];
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(data));
+  } catch {
+    /* quota 等 */
+  }
+}
+
+/** Web `collapsedMenuGroupsFromStorage` と同じ判定（展開キー配列版） */
+export function collapsedMenuGroupsFromExpandedKeys(
+  collapsibleSectionKeys: string[],
+  scope: string | null,
+  expandedKeys: string[]
+): Set<string> {
+  if (!scope || collapsibleSectionKeys.length <= 1) {
+    return new Set();
+  }
+  const expanded = new Set(
+    expandedKeys.filter((k) => collapsibleSectionKeys.includes(k))
+  );
+  const collapsed = new Set<string>();
+  for (const k of collapsibleSectionKeys) {
+    if (!expanded.has(k)) collapsed.add(k);
+  }
+  return collapsed;
+}

--- a/apps/mobile/lib/menu-row-macro-highlights.ts
+++ b/apps/mobile/lib/menu-row-macro-highlights.ts
@@ -1,0 +1,40 @@
+/**
+ * Web `src/lib/macroHighlights.ts` と同じ閾値・判定（メニュー行の P/F 強調）。
+ */
+
+const HIGHLIGHT_RATIO_P = 0.22;
+const HIGHLIGHT_RATIO_F = 0.22;
+const HIGHLIGHT_PER100_P = 22;
+const HIGHLIGHT_PER100_F = 18;
+
+export type MacroHighlightTargets = {
+  protein_target_g: number;
+  fat_target_g: number;
+};
+
+export function menuRowMacroHighlights(
+  serving: { p: number; f: number },
+  item: {
+    protein_per_100g: number | null;
+    fat_per_100g: number | null;
+  },
+  targets: MacroHighlightTargets
+): { highlightP: boolean; highlightF: boolean } {
+  if (item.protein_per_100g === null) {
+    return { highlightP: false, highlightF: false };
+  }
+
+  const tp = Math.max(targets.protein_target_g, 1e-9);
+  const tf = Math.max(targets.fat_target_g, 1e-9);
+
+  const byRatioP = serving.p / tp >= HIGHLIGHT_RATIO_P;
+  const byRatioF = serving.f / tf >= HIGHLIGHT_RATIO_F;
+
+  const byDensityP = (item.protein_per_100g ?? 0) >= HIGHLIGHT_PER100_P;
+  const byDensityF = (item.fat_per_100g ?? 0) >= HIGHLIGHT_PER100_F;
+
+  return {
+    highlightP: byRatioP || byDensityP,
+    highlightF: byRatioF || byDensityF,
+  };
+}

--- a/apps/mobile/lib/resolve-menu-item-group-order.ts
+++ b/apps/mobile/lib/resolve-menu-item-group-order.ts
@@ -1,0 +1,36 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/** Web `resolveMenuItemGroupOrder` と同じ */
+export async function resolveMenuItemGroupOrder(
+  supabase: SupabaseClient,
+  userId: string,
+  restaurantId: string,
+  groupName: string | null
+): Promise<number> {
+  if (!groupName) return 0;
+
+  const { data: existing } = await supabase
+    .from("menu_items")
+    .select("group_order")
+    .eq("user_id", userId)
+    .eq("restaurant_id", restaurantId)
+    .eq("group_name", groupName)
+    .limit(1)
+    .maybeSingle();
+
+  if (existing && typeof existing.group_order === "number") {
+    return existing.group_order;
+  }
+
+  const { data: maxRow } = await supabase
+    .from("menu_items")
+    .select("group_order")
+    .eq("user_id", userId)
+    .eq("restaurant_id", restaurantId)
+    .not("group_name", "is", null)
+    .order("group_order", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return (maxRow?.group_order ?? -1) + 1;
+}

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Alert,
@@ -15,7 +15,9 @@ import brandHeaderImage from "../assets/brand-header.png";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import Constants from "expo-constants";
-import { sumPfc, type PfcGrams } from "@ketolog/domain/pfc";
+import { pfcGramsFromNullablePer100, sumPfc, type PfcGrams } from "@ketolog/domain/pfc";
+import { getMealTypeForTimeZone } from "@ketolog/domain/meal-timezone";
+import type { MealType } from "@ketolog/types";
 import {
   addDaysJst,
   formatNavDate,
@@ -33,15 +35,27 @@ import {
   FoodLogEntryModal,
   type FoodLogRow,
 } from "../components/FoodLogEntryModal";
-import { MenuPickModal } from "../components/MenuPickModal";
+import {
+  MenuItemEditorModal,
+  type MenuItemEditorState,
+} from "../components/MenuItemEditorModal";
+import { AddRestaurantModal } from "../components/AddRestaurantModal";
+import {
+  TodayCartDock,
+  type CartLineState,
+} from "../components/TodayCartDock";
+import { TodayMenuPanel } from "../components/TodayMenuPanel";
 import type { MenuPrefill } from "../lib/menu-prefill";
 import {
+  enqueueFoodLogDraft,
   loadFoodLogOutbox,
+  newClientRowId,
   removeFoodLogDraft,
   sendFoodLogDraft,
   type FoodLogOutboxDraft,
 } from "../lib/food-log-outbox";
-import { getIsOnline } from "../lib/network";
+import type { FavoriteMenuItemPayload } from "../lib/fetch-favorite-groups-payload";
+import { getIsOnline, isTransientNetworkError } from "../lib/network";
 import { getOrCreateSnapshotRestaurant } from "../lib/get-or-create-snapshot-restaurant";
 
 type UserSettingsState = {
@@ -56,6 +70,15 @@ const MEAL_SHORT: Record<string, string> = {
   lunch: "昼",
   dinner: "夕",
   snack: "間",
+};
+
+/** Web `MEAL_LABELS` と同順・同表記（記録パネルの見出し用） */
+const MEAL_LOG_ORDER: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
+const MEAL_LABEL_FULL: Record<MealType, string> = {
+  breakfast: "朝食",
+  lunch: "昼食",
+  dinner: "夕食",
+  snack: "間食",
 };
 
 const COLORS = {
@@ -137,11 +160,24 @@ export function TodayScreen() {
   const [entryModalMode, setEntryModalMode] = useState<"add" | "edit">("add");
   const [editingEntry, setEditingEntry] = useState<FoodLogRow | null>(null);
   const [menuPrefill, setMenuPrefill] = useState<MenuPrefill | null>(null);
-  const [menuPickOpen, setMenuPickOpen] = useState(false);
+  const [menuEditorOpen, setMenuEditorOpen] = useState(false);
+  const [menuEditorState, setMenuEditorState] = useState<MenuItemEditorState | null>(null);
+  const [restaurantAddOpen, setRestaurantAddOpen] = useState(false);
+  const [selectRestaurantIdAfterAdd, setSelectRestaurantIdAfterAdd] = useState<string | null>(
+    null
+  );
   const [toast, setToast] = useState<string | null>(null);
   const [outbox, setOutbox] = useState<FoodLogOutboxDraft[]>([]);
   const [resendingDraftId, setResendingDraftId] = useState<string | null>(null);
   const [loadingDate, setLoadingDate] = useState(false);
+  const [dataNonce, setDataNonce] = useState(0);
+  const [showLogEntries, setShowLogEntries] = useState(false);
+  const [cart, setCart] = useState<Map<string, CartLineState>>(() => new Map());
+  const [cartExpanded, setCartExpanded] = useState(false);
+  const [cartMealType, setCartMealType] = useState<MealType>(() =>
+    getMealTypeForTimeZone(new Date(), "Asia/Tokyo")
+  );
+  const [cartSaving, setCartSaving] = useState(false);
   const initialLoadDoneForUser = useRef(false);
   const prevUserIdForDate = useRef<string | null>(null);
 
@@ -152,6 +188,11 @@ export function TodayScreen() {
     if (!userId) return;
     setOutbox(await loadFoodLogOutbox(userId));
   }, [userId]);
+
+  useEffect(() => {
+    setCart(new Map());
+    setCartExpanded(false);
+  }, [selectedDate, userId]);
 
   const showToast = useCallback((message: string) => {
     setToast(message);
@@ -225,19 +266,234 @@ export function TodayScreen() {
     );
   }, [supabase, userId, selectedDate]);
 
-  const openAddEntry = useCallback(() => {
-    if (!snapshotRestaurantId) {
-      showToast(
-        snapshotError ??
-          "手入力の準備ができていません。通信を確認してから再度お試しください。"
+  const cartLinesSorted = useMemo(
+    () => [...cart.values()].sort((a, b) => a.name.localeCompare(b.name, "ja")),
+    [cart]
+  );
+
+  const cartPfcTotal = useMemo(() => {
+    return sumPfc(
+      ...cartLinesSorted.map((line) =>
+        pfcGramsFromNullablePer100(
+          line.protein_per_100g,
+          line.fat_per_100g,
+          line.carbs_per_100g,
+          line.gramsPerServing * line.count
+        )
+      )
+    );
+  }, [cartLinesSorted]);
+
+  const mergeCartLine = useCallback(
+    (line: CartLineState) => {
+      setCart((prev) => {
+        const next = new Map(prev);
+        const cur = next.get(line.menuItemId);
+        if (cur) {
+          next.set(line.menuItemId, { ...cur, count: cur.count + 1 });
+        } else {
+          next.set(line.menuItemId, line);
+        }
+        return next;
+      });
+      setCartExpanded(true);
+    },
+    []
+  );
+
+  const addToCartFromItem = useCallback(
+    (item: FavoriteMenuItemPayload, gramsPerServing: number) => {
+      const g =
+        Number.isFinite(gramsPerServing) && gramsPerServing > 0 ? gramsPerServing : 100;
+      mergeCartLine({
+        menuItemId: item.id,
+        restaurantId: item.restaurant_id,
+        name: item.name,
+        gramsPerServing: g,
+        count: 1,
+        protein_per_100g:
+          item.protein_per_100g != null ? Number(item.protein_per_100g) : null,
+        fat_per_100g: item.fat_per_100g != null ? Number(item.fat_per_100g) : null,
+        carbs_per_100g: item.carbs_per_100g != null ? Number(item.carbs_per_100g) : null,
+      });
+    },
+    [mergeCartLine]
+  );
+
+  const addSnapshotDraftToCart = useCallback(
+    (draft: {
+      name: string;
+      protein_per_100g: number | null;
+      fat_per_100g: number | null;
+      carbs_per_100g: number | null;
+      grams: number;
+    }) => {
+      if (!snapshotRestaurantId) return;
+      const g = Number.isFinite(draft.grams) && draft.grams > 0 ? draft.grams : 100;
+      mergeCartLine({
+        menuItemId: newClientRowId(),
+        restaurantId: snapshotRestaurantId,
+        name: draft.name,
+        gramsPerServing: g,
+        count: 1,
+        protein_per_100g: draft.protein_per_100g,
+        fat_per_100g: draft.fat_per_100g,
+        carbs_per_100g: draft.carbs_per_100g,
+        snapshotDraft: true,
+      });
+    },
+    [mergeCartLine, snapshotRestaurantId]
+  );
+
+  const openMenuEditorAdd = useCallback((registerRestaurantIdHint?: string | null) => {
+    setMenuEditorState({
+      kind: "add",
+      registerRestaurantIdHint: registerRestaurantIdHint ?? null,
+    });
+    setMenuEditorOpen(true);
+  }, []);
+
+  const openMenuEditorEdit = useCallback((item: FavoriteMenuItemPayload) => {
+    setMenuEditorState({ kind: "edit", menuItemId: item.id });
+    setMenuEditorOpen(true);
+  }, []);
+
+  const handleMenuEditorSaved = useCallback(async () => {
+    await load();
+    setDataNonce((n) => n + 1);
+  }, [load]);
+
+  const onSelectRestaurantIdAfterAddConsumed = useCallback(() => {
+    setSelectRestaurantIdAfterAdd(null);
+  }, []);
+
+  const onRestaurantCreated = useCallback((r: { id: string }) => {
+    setSelectRestaurantIdAfterAdd(r.id);
+    setDataNonce((n) => n + 1);
+  }, []);
+
+  const removeCartLine = useCallback((menuItemId: string) => {
+    setCart((prev) => {
+      const next = new Map(prev);
+      next.delete(menuItemId);
+      return next;
+    });
+  }, []);
+
+  const updateCartGramsPerServing = useCallback((menuItemId: string, grams: number) => {
+    setCart((prev) => {
+      const next = new Map(prev);
+      const cur = next.get(menuItemId);
+      if (!cur) return prev;
+      next.set(menuItemId, { ...cur, gramsPerServing: grams });
+      return next;
+    });
+  }, []);
+
+  const saveCartToLog = useCallback(async () => {
+    if (!userId || cart.size === 0) return;
+    setCartSaving(true);
+    const lines = [...cart.values()];
+    const mkRow = (line: CartLineState) => {
+      const totalGrams = line.gramsPerServing * line.count;
+      const v = pfcGramsFromNullablePer100(
+        line.protein_per_100g,
+        line.fat_per_100g,
+        line.carbs_per_100g,
+        totalGrams
       );
+      return {
+        user_id: userId,
+        date: selectedDate,
+        meal_type: cartMealType,
+        item_name: line.name,
+        grams: totalGrams,
+        protein_g: v.p,
+        fat_g: v.f,
+        carbs_g: v.c,
+        source: line.restaurantId,
+        menu_item_id: line.snapshotDraft ? null : line.menuItemId,
+      };
+    };
+
+    const enqueueAll = async () => {
+      const now = new Date().toISOString();
+      for (const line of lines) {
+        const totalGrams = line.gramsPerServing * line.count;
+        const v = pfcGramsFromNullablePer100(
+          line.protein_per_100g,
+          line.fat_per_100g,
+          line.carbs_per_100g,
+          totalGrams
+        );
+        await enqueueFoodLogDraft(userId, {
+          id: newClientRowId(),
+          date: selectedDate,
+          meal_type: cartMealType,
+          item_name: line.name,
+          grams: totalGrams,
+          protein_g: v.p,
+          fat_g: v.f,
+          carbs_g: v.c,
+          source: line.restaurantId,
+          menu_item_id: line.snapshotDraft ? null : line.menuItemId,
+          saved_at: now,
+        });
+      }
+    };
+
+    const online = await getIsOnline();
+    if (!online) {
+      await enqueueAll();
+      setCart(new Map());
+      setCartExpanded(false);
+      await refreshOutbox();
+      await load();
+      showToast("オフラインのため端末に下書きを保存しました。通信が戻ったら再送してください。");
+      setCartSaving(false);
       return;
     }
-    setMenuPrefill(null);
-    setEditingEntry(null);
-    setEntryModalMode("add");
-    setEntryModalOpen(true);
-  }, [showToast, snapshotError, snapshotRestaurantId]);
+
+    const { error } = await supabase.from("food_log").insert(lines.map(mkRow));
+    if (error) {
+      if (isTransientNetworkError(error)) {
+        await enqueueAll();
+        setCart(new Map());
+        setCartExpanded(false);
+        await refreshOutbox();
+        await load();
+        showToast("通信に失敗しました。端末に下書きを残しました。");
+        setCartSaving(false);
+        return;
+      }
+      showToast(`記録に失敗しました: ${error.message}`);
+      setCartSaving(false);
+      return;
+    }
+
+    setCart(new Map());
+    setCartExpanded(false);
+    await load();
+    await refreshOutbox();
+    const totalItems = lines.reduce((s, l) => s + l.count, 0);
+    showToast(`${totalItems} 品目を記録しました`);
+    setCartSaving(false);
+  }, [
+    userId,
+    cart,
+    selectedDate,
+    cartMealType,
+    supabase,
+    refreshOutbox,
+    load,
+    showToast,
+  ]);
+
+  /** Web 今日ビューの「＋」と同じく、メニュー追加ドロワー（`MenuItemEditorModal`）を開く */
+  const openAddEntry = useCallback(() => {
+    setMenuEditorState({ kind: "add", registerRestaurantIdHint: null });
+    setMenuEditorOpen(true);
+  }, []);
 
   const goPrevDate = useCallback(() => {
     setSelectedDate((d) => addDaysJst(d, -1));
@@ -253,18 +509,6 @@ export function TodayScreen() {
 
   const goToday = useCallback(() => {
     setSelectedDate(toJstDateString());
-  }, []);
-
-  const openMenuPick = useCallback(() => {
-    setMenuPickOpen(true);
-  }, []);
-
-  const onMenuPicked = useCallback((prefill: MenuPrefill) => {
-    setMenuPrefill(prefill);
-    setEditingEntry(null);
-    setEntryModalMode("add");
-    setMenuPickOpen(false);
-    setEntryModalOpen(true);
   }, []);
 
   const openEditEntry = useCallback((e: FoodLogRow) => {
@@ -342,6 +586,7 @@ export function TodayScreen() {
     if (!userId) return;
     setRefreshing(true);
     await Promise.all([load(), refreshOutbox()]);
+    setDataNonce((n) => n + 1);
     setRefreshing(false);
   }, [load, refreshOutbox, userId]);
 
@@ -525,6 +770,7 @@ export function TodayScreen() {
           </Pressable>
         </View>
 
+        <View style={styles.bodyColumn}>
         <ScrollView
           style={styles.scroll}
           contentContainerStyle={styles.scrollContent}
@@ -590,8 +836,9 @@ export function TodayScreen() {
             />
           </View>
 
-          <View style={styles.logSection}>
+          <View style={[styles.logOuter, !showLogEntries && styles.logOuterCollapsed]}>
             {outbox.length > 0 ? (
+              <View style={styles.outboxWrap}>
               <View style={styles.outboxBlock}>
                 <Text style={styles.outboxTitle}>未送信の下書き</Text>
                 <Text style={styles.outboxHint}>
@@ -647,99 +894,145 @@ export function TodayScreen() {
                   </View>
                 ))}
               </View>
+              </View>
             ) : null}
-            <View style={styles.logSectionHeader}>
-              <Text style={styles.logSectionTitle}>
-                {selectedDate === todayJst ? "今日の記録" : "この日の記録"}
-              </Text>
-              <View style={styles.logActions}>
+
+            <View style={styles.logPanel}>
+              <View
+                style={[
+                  styles.logPanelHeader,
+                  showLogEntries && styles.logPanelHeaderExpanded,
+                  !showLogEntries && styles.logPanelHeaderCollapsed,
+                ]}
+              >
                 <Pressable
-                  onPress={openMenuPick}
+                  onPress={() => setShowLogEntries((v) => !v)}
                   style={({ pressed }) => [
-                    styles.menuChip,
+                    styles.logExpandTap,
                     pressed && { opacity: 0.85 },
                   ]}
-                  accessibilityLabel="登録メニューから追加"
+                  accessibilityLabel={showLogEntries ? "記録一覧を閉じる" : "記録一覧を開く"}
                 >
-                  <Ionicons name="restaurant-outline" size={16} color="#e5e7eb" />
-                  <Text style={styles.menuChipText}>メニュー</Text>
+                  <View style={styles.logTitleRow}>
+                    <Text style={styles.logPanelTitle}>
+                      {selectedDate === todayJst ? "今日の記録" : "この日の記録"}
+                    </Text>
+                    <Text style={styles.logPanelCount}>
+                      （{logEntries.length}件）
+                    </Text>
+                  </View>
+                  <Ionicons
+                    name={showLogEntries ? "chevron-up" : "chevron-down"}
+                    size={18}
+                    color="#6b7280"
+                  />
                 </Pressable>
                 <Pressable
                   onPress={openAddEntry}
                   style={({ pressed }) => [
-                    styles.addChip,
-                    pressed && { opacity: 0.85 },
+                    styles.logAddOutline,
+                    pressed && { opacity: 0.88 },
                   ]}
-                  accessibilityLabel="食事を手入力で追加"
+                  accessibilityLabel="メニュー追加・今すぐ記録・カート（店舗タブのメニュー追加と同じ）"
                 >
-                  <Ionicons name="add" size={18} color="#022c22" />
-                  <Text style={styles.addChipText}>追加</Text>
+                  <Ionicons name="create-outline" size={17} color="#d1d5db" />
+                  <Text style={styles.logAddOutlineText}>手入力</Text>
                 </Pressable>
               </View>
+              {showLogEntries ? (
+                logEntries.length === 0 ? (
+                  <Text style={styles.logEmptyOnDark}>
+                    メニューまたはお気に入りの「＋」でカートに入れ、画面下のカートからまとめて記録するのがいちばん早いです。手入力で足すときは「手入力」から。
+                  </Text>
+                ) : (
+                  <ScrollView
+                    style={styles.logListScroll}
+                    nestedScrollEnabled
+                    keyboardShouldPersistTaps="handled"
+                  >
+                    {MEAL_LOG_ORDER.map((mt) => {
+                      const items = logEntries.filter((e) => e.meal_type === mt);
+                      if (items.length === 0) return null;
+                      return (
+                        <View key={mt}>
+                          <Text style={styles.logMealSectionLabel}>
+                            {MEAL_LABEL_FULL[mt]}
+                          </Text>
+                          {items.map((e) => (
+                            <View key={e.id} style={styles.logEntryRow}>
+                              <Text style={styles.logEntryName} numberOfLines={1}>
+                                {e.item_name}
+                              </Text>
+                              <Text style={styles.logEntryGrams}>{e.grams}g</Text>
+                              <Text style={styles.logEntryPfc} numberOfLines={1}>
+                                {`P${fmtMacroGrams(e.protein_g)} F${fmtMacroGrams(e.fat_g)} C${fmtMacroGrams(e.carbs_g)}`}
+                              </Text>
+                              <Pressable
+                                onPress={() => openEditEntry(e)}
+                                hitSlop={8}
+                                style={({ pressed }) => [
+                                  styles.logEntryIconBtn,
+                                  pressed && { opacity: 0.75 },
+                                ]}
+                                accessibilityLabel="編集"
+                              >
+                                <Text style={styles.logEntryEditGlyph}>✎</Text>
+                              </Pressable>
+                              <Pressable
+                                onPress={() => confirmDeleteEntry(e)}
+                                hitSlop={8}
+                                style={({ pressed }) => [
+                                  styles.logEntryIconBtn,
+                                  pressed && { opacity: 0.75 },
+                                ]}
+                                accessibilityLabel="削除"
+                              >
+                                <Text style={styles.logEntryDeleteGlyph}>✕</Text>
+                              </Pressable>
+                            </View>
+                          ))}
+                        </View>
+                      );
+                    })}
+                  </ScrollView>
+                )
+              ) : null}
             </View>
-            {logEntries.length === 0 ? (
-              <Text style={styles.logEmpty}>
-                まだ記録がありません。「メニュー」で Web
-                に登録した店のメニューから、「追加」から手入力で登録できます（Web
-                での記録もここに表示されます）。過去の日付は上の矢印で切り替えられます。
-              </Text>
-            ) : (
-              logEntries.map((e) => (
-                <View key={e.id} style={styles.logRow}>
-                  <Pressable
-                    onPress={() => openEditEntry(e)}
-                    style={({ pressed }) => [
-                      styles.logRowMain,
-                      pressed && { opacity: 0.85 },
-                    ]}
-                  >
-                    <Text style={styles.logMealBadge}>
-                      {MEAL_SHORT[e.meal_type] ?? e.meal_type}
-                    </Text>
-                    <View style={styles.logRowBody}>
-                      <Text style={styles.logItemName} numberOfLines={2}>
-                        {e.item_name}
-                      </Text>
-                      <Text style={styles.logMeta}>
-                        {e.grams}g · P {fmtMacroGrams(e.protein_g)} / F{" "}
-                        {fmtMacroGrams(e.fat_g)} / C {fmtMacroGrams(e.carbs_g)}
-                      </Text>
-                    </View>
-                    <Ionicons
-                      name="chevron-forward"
-                      size={18}
-                      color={COLORS.textMuted}
-                    />
-                  </Pressable>
-                  <Pressable
-                    onPress={() => confirmDeleteEntry(e)}
-                    hitSlop={10}
-                    style={({ pressed }) => [
-                      styles.logDeleteBtn,
-                      pressed && { opacity: 0.7 },
-                    ]}
-                    accessibilityLabel="削除"
-                  >
-                    <Ionicons
-                      name="trash-outline"
-                      size={20}
-                      color="#f87171"
-                    />
-                  </Pressable>
-                </View>
-              ))
-            )}
           </View>
-        </ScrollView>
-      </View>
 
-      <MenuPickModal
-        visible={menuPickOpen}
-        supabase={supabase}
-        userId={userId}
-        onClose={() => setMenuPickOpen(false)}
-        onPick={onMenuPicked}
-      />
+          <TodayMenuPanel
+            supabase={supabase}
+            userId={userId}
+            reloadNonce={dataNonce}
+            onAddToCart={addToCartFromItem}
+            onEditMenuItem={openMenuEditorEdit}
+            onOpenRestaurantAdd={() => setRestaurantAddOpen(true)}
+            onOpenMenuEditorAdd={openMenuEditorAdd}
+            selectRestaurantIdAfterAdd={selectRestaurantIdAfterAdd}
+            onSelectRestaurantIdAfterAddConsumed={onSelectRestaurantIdAfterAddConsumed}
+            macroTargets={{
+              protein_target_g: activeProfile.protein_target_g,
+              fat_target_g: activeProfile.fat_target_g,
+            }}
+          />
+        </ScrollView>
+
+        <TodayCartDock
+          lines={cartLinesSorted}
+          expanded={cartExpanded}
+          onToggleExpanded={() => setCartExpanded((v) => !v)}
+          cartPfc={cartPfcTotal}
+          mealType={cartMealType}
+          onMealType={setCartMealType}
+          saving={cartSaving}
+          onSave={() => {
+            void saveCartToLog();
+          }}
+          onRemoveLine={removeCartLine}
+          onUpdateGramsPerServing={updateCartGramsPerServing}
+        />
+        </View>
+      </View>
 
       <FoodLogEntryModal
         visible={entryModalOpen}
@@ -758,6 +1051,33 @@ export function TodayScreen() {
         onSaved={load}
         onToast={showToast}
         onOutboxChanged={refreshOutbox}
+      />
+
+      <MenuItemEditorModal
+        visible={menuEditorOpen}
+        state={menuEditorState}
+        supabase={supabase}
+        userId={userId}
+        date={selectedDate}
+        mealTypeForLog={cartMealType}
+        snapshotRestaurantId={snapshotRestaurantId}
+        onClose={() => {
+          setMenuEditorOpen(false);
+          setMenuEditorState(null);
+        }}
+        onSaved={handleMenuEditorSaved}
+        onToast={showToast}
+        onAddSnapshotDraftToCart={addSnapshotDraftToCart}
+        onOutboxChanged={refreshOutbox}
+      />
+
+      <AddRestaurantModal
+        visible={restaurantAddOpen}
+        supabase={supabase}
+        userId={userId}
+        onClose={() => setRestaurantAddOpen(false)}
+        onAdded={onRestaurantCreated}
+        onToast={showToast}
       />
 
       {toast ? (
@@ -812,6 +1132,10 @@ const styles = StyleSheet.create({
   },
   root: {
     flex: 1,
+  },
+  bodyColumn: {
+    flex: 1,
+    minHeight: 0,
   },
   scroll: { flex: 1 },
   scrollContent: {
@@ -973,13 +1297,19 @@ const styles = StyleSheet.create({
     color: COLORS.text,
     fontVariant: ["tabular-nums"],
   },
-  logSection: {
-    marginHorizontal: 12,
+  logOuter: {
     marginTop: 8,
-    paddingBottom: 72,
+    paddingBottom: 20,
+  },
+  logOuterCollapsed: {
+    paddingBottom: 8,
+  },
+  outboxWrap: {
+    marginHorizontal: 12,
+    marginBottom: 10,
   },
   outboxBlock: {
-    marginBottom: 14,
+    marginBottom: 0,
     padding: 12,
     borderRadius: 10,
     borderWidth: 1,
@@ -1031,92 +1361,131 @@ const styles = StyleSheet.create({
   outboxResendText: { color: "#022c22", fontWeight: "700", fontSize: 13 },
   outboxDiscardBtn: { paddingVertical: 4, paddingHorizontal: 4 },
   outboxDiscardText: { color: "#fecaca", fontSize: 12, fontWeight: "600" },
-  logSectionHeader: {
+  /** Web Today の記録済みパネル相当: bg-gray-950 + border-gray-800 */
+  logPanel: {
+    backgroundColor: "#030712",
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderColor: "#1f2937",
+  },
+  logPanelHeader: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    marginBottom: 10,
-  },
-  logActions: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-  },
-  logSectionTitle: {
-    color: COLORS.text,
-    fontSize: 15,
-    fontWeight: "600",
-  },
-  menuChip: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-    backgroundColor: "#1f2937",
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    borderRadius: 20,
-    borderWidth: 1,
-    borderColor: COLORS.headerBorder,
-  },
-  menuChipText: { color: COLORS.text, fontWeight: "600", fontSize: 13 },
-  addChip: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 4,
-    backgroundColor: COLORS.c,
+    gap: 10,
     paddingHorizontal: 12,
     paddingVertical: 8,
-    borderRadius: 20,
   },
-  addChipText: { color: "#022c22", fontWeight: "700", fontSize: 13 },
-  logEmpty: {
-    color: COLORS.textMuted,
-    fontSize: 12,
-    lineHeight: 18,
-    paddingVertical: 8,
+  logPanelHeaderExpanded: {
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(31, 41, 55, 0.9)",
   },
-  logRow: {
-    flexDirection: "row",
-    alignItems: "stretch",
-    backgroundColor: COLORS.sectionBg,
-    borderRadius: 10,
-    marginBottom: 8,
-    borderWidth: 1,
-    borderColor: COLORS.headerBorder,
-    overflow: "hidden",
+  logPanelHeaderCollapsed: {
+    paddingBottom: 8,
   },
-  logRowMain: {
+  logExpandTap: {
     flex: 1,
     flexDirection: "row",
     alignItems: "center",
-    paddingVertical: 10,
-    paddingLeft: 10,
-    paddingRight: 4,
-    gap: 8,
+    justifyContent: "space-between",
+    minWidth: 0,
   },
-  logMealBadge: {
-    fontSize: 11,
-    fontWeight: "700",
-    color: "#a7f3d0",
-    backgroundColor: "rgba(16, 185, 129, 0.2)",
-    paddingHorizontal: 8,
-    paddingVertical: 4,
-    borderRadius: 6,
-    overflow: "hidden",
+  logTitleRow: {
+    flexDirection: "row",
+    alignItems: "baseline",
+    gap: 4,
+    flexShrink: 1,
+    minWidth: 0,
   },
-  logRowBody: { flex: 1, minWidth: 0 },
-  logItemName: { color: COLORS.text, fontSize: 14, fontWeight: "500" },
-  logMeta: {
-    color: COLORS.textMuted,
-    fontSize: 11,
-    marginTop: 4,
+  logPanelTitle: {
+    color: "#d1d5db",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  logPanelCount: {
+    color: "#9ca3af",
+    fontSize: 12,
     fontVariant: ["tabular-nums"],
   },
-  logDeleteBtn: {
-    justifyContent: "center",
+  logAddOutline: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#374151",
+    backgroundColor: "rgba(17, 24, 39, 0.6)",
+  },
+  logAddOutlineText: {
+    color: "#e5e7eb",
+    fontSize: 12,
+    fontWeight: "600",
+  },
+  logEmptyOnDark: {
+    color: "#6b7280",
+    fontSize: 12,
+    lineHeight: 18,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    paddingBottom: 12,
+  },
+  logListScroll: {
+    maxHeight: 240,
+  },
+  logMealSectionLabel: {
+    paddingHorizontal: 14,
+    paddingVertical: 4,
+    fontSize: 11,
+    color: "#6b7280",
+    backgroundColor: "rgba(17, 24, 39, 0.5)",
+  },
+  logEntryRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
     paddingHorizontal: 12,
-    borderLeftWidth: StyleSheet.hairlineWidth,
-    borderLeftColor: COLORS.headerBorder,
+    paddingVertical: 8,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: "rgba(31, 41, 55, 0.4)",
+  },
+  logEntryName: {
+    flex: 1,
+    minWidth: 0,
+    color: "#ffffff",
+    fontSize: 13,
+    fontWeight: "400",
+  },
+  logEntryGrams: {
+    width: 44,
+    fontSize: 11,
+    color: "#9ca3af",
+    textAlign: "right",
+    fontVariant: ["tabular-nums"],
+  },
+  logEntryPfc: {
+    width: 108,
+    fontSize: 11,
+    color: "#6b7280",
+    textAlign: "right",
+    fontVariant: ["tabular-nums"],
+  },
+  logEntryIconBtn: {
+    width: 32,
+    height: 32,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  logEntryEditGlyph: {
+    color: "#9ca3af",
+    fontSize: 14,
+    fontWeight: "500",
+  },
+  logEntryDeleteGlyph: {
+    color: "#f87171",
+    fontSize: 14,
+    fontWeight: "500",
   },
   toast: {
     position: "absolute",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.51.0",
+  "version": "1.52.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## 概要
モバイル Today のメニュー・店舗・カートまわりを Web の挙動に寄せる。

## 変更内容
- `MenuItemEditorModal`: メニュー品の追加・編集・削除、栄養素単位、記録・カート・メニュー登録
- `AddRestaurantModal` と店舗タブの「＋」、メニュー一覧下の「＋ メニューを追加」
- メニュー行は品名・PFC タップで編集。記録の「手入力」は同一モーダルへ統一
- `FoodLogEntryModal` は食事ログ（プリフィル・編集）に限定
- `MenuPickModal` のお気に入り・`display_order` 対応、カート `snapshotDraft` 対応
- CHANGELOG `1.52.0`、`package.json` を `1.52.0` に（バージョンは単独コミット）

## 備考
未使用だった `TodayFavoritesStrip` はコミットに含めていません。

Made with [Cursor](https://cursor.com)