### PR TITLE
feat(mobile): 分析の未送信注記と法務導線（#293 PR1）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.56.0] - 2026-04-24
+
+### Added
+
+- **Mobile / 分析・法務（[#293](https://github.com/kzkski/ketolog/issues/293)）**: 未送信の食事下書きが1件以上ある場合のみ、分析画面に「集計に含まれない」旨の注意を表示する。`EXPO_PUBLIC_KETOLOG_WEB_ORIGIN` または `EXPO_PUBLIC_KETOLOG_LEGAL_*_URL` で解決した利用規約・プライバシーポリシーを、ログイン・新規登録・Today の設定からブラウザで開ける（https のみ）。
+
+### Changed
+
+- **Mobile / 法務・分析補足**: 法務 URL 解決は `apps/mobile/lib/ketolog-legal-urls.ts` に集約。分析の未送信下書きの有無の再取得には `@react-navigation/native` の `useFocusEffect` を使う。
+
 ## [1.55.0] - 2026-04-24
 
 ### Added

--- a/apps/mobile/.env.example
+++ b/apps/mobile/.env.example
@@ -7,3 +7,10 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=your-local-anon-key
 # 本番（またはステージング）プロジェクト。未設定のまま実機で起動すると Supabase 未設定になる。
 EXPO_PUBLIC_SUPABASE_PRODUCTION_URL=https://your-production-project.supabase.co
 EXPO_PUBLIC_SUPABASE_PRODUCTION_ANON_KEY=your-production-anon-key
+
+# --- 法務リンク（任意。未設定のとき利用規約セクションは非表示）---
+# 本番 Web PWA の origin（末尾スラなし）。設定時は /legal/terms と /legal/privacy を連結する。
+# EXPO_PUBLIC_KETOLOG_WEB_ORIGIN=https://your-vercel-or-custom-domain
+# 完全 URL を個別に指定する場合（指定があれば origin より優先）:
+# EXPO_PUBLIC_KETOLOG_LEGAL_TERMS_URL=
+# EXPO_PUBLIC_KETOLOG_LEGAL_PRIVACY_URL=

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -41,6 +41,8 @@ npm install
    - **Expo Go 開発時**は、ターミナルに表示される `exp://` 系のリダイレクトが変わるため、エラーに含まれる URL を見ながら **Redirect URLs に都度追加**するか、通し用の `exp://**` が許可できる場合はルールに従って登録する。
 3. 環境変数を変えたら `npx expo start`（Metro）を**再起動**する。
 
+**利用規約・プライバシー**（`Login` / `Signup` / 設定）: 表示するには `EXPO_PUBLIC_KETOLOG_WEB_ORIGIN` または `EXPO_PUBLIC_KETOLOG_LEGAL_TERMS_URL` / `EXPO_PUBLIC_KETOLOG_LEGAL_PRIVACY_URL` のいずれかで **https** の URL を解決できる必要がある。`apps/mobile/.env.example` を参照。未設定のとき当該ブロックは出ない。
+
 **Email/Password** と **Google ログアウト** は、未ログイン時に Today 等の保護画面へは遷移しない（ログイン / 再ログイン画面のみ）構成になっている。セッションは `AsyncStorage` に永続化し、アプリ再起動後も `getSession` で復元する。
 
 **Web との競合を避けるには**: 同じ Supabase プロジェクト内で、Next.js 用（例: Vercel の `https://.../auth/callback`）は既存のまま、上記に **Expo 用の `ketolog://` / `exp://` を足す**だけにするとよい。Site URL や他プロバイダー設定を差し替えない。

--- a/apps/mobile/components/LegalDocumentLinks.tsx
+++ b/apps/mobile/components/LegalDocumentLinks.tsx
@@ -1,0 +1,83 @@
+import { useCallback, useMemo } from "react";
+import { Pressable, StyleSheet, Text, View } from "react-native";
+import { openKetologLegalUrl, resolveKetologLegalUrls } from "../lib/ketolog-legal-urls";
+
+type Props = {
+  /** 薄い補足（例: 認証画面。variant auth のみ） */
+  introText?: string;
+  /** 認証画面は中央、設定は左寄せ＋セクション見出し */
+  variant: "auth" | "settings";
+  onOpenError?: (message: string) => void;
+};
+
+/**
+ * 利用規約・プライバシー。URL が1つも解決できなければ null（行自体非表示）。
+ */
+export function LegalDocumentLinks({ introText, variant, onOpenError }: Props) {
+  const { terms, privacy } = useMemo(() => resolveKetologLegalUrls(), []);
+  if (!terms && !privacy) return null;
+
+  const openTerms = useCallback(() => {
+    if (terms) void openKetologLegalUrl(terms, onOpenError);
+  }, [terms, onOpenError]);
+  const openPrivacy = useCallback(() => {
+    if (privacy) void openKetologLegalUrl(privacy, onOpenError);
+  }, [privacy, onOpenError]);
+
+  const linkRow = (
+    <View style={variant === "auth" ? styles.rowAuth : styles.rowSettings}>
+      {terms ? (
+        <Pressable
+          onPress={openTerms}
+          accessibilityRole="link"
+          accessibilityLabel="利用規約を外部ブラウザで開く"
+          style={({ pressed }) => [pressed && { opacity: 0.75 }]}
+        >
+          <Text style={styles.link}>利用規約</Text>
+        </Pressable>
+      ) : null}
+      {terms && privacy ? <Text style={styles.sep}> ・ </Text> : null}
+      {privacy ? (
+        <Pressable
+          onPress={openPrivacy}
+          accessibilityRole="link"
+          accessibilityLabel="プライバシーポリシーを外部ブラウザで開く"
+          style={({ pressed }) => [pressed && { opacity: 0.75 }]}
+        >
+          <Text style={styles.link}>プライバシーポリシー</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+
+  if (variant === "settings") {
+    return (
+      <View style={styles.settingsBlock}>
+        <Text style={styles.settingsSectionTitle}>利用規約・プライバシー</Text>
+        <Text style={styles.settingsHint}>
+          リンク先は https のみ開きます。別アプリ（ブラウザ）で表示されます。
+        </Text>
+        {linkRow}
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.wrapAuth}>
+      {introText ? <Text style={styles.introAuth}>{introText}</Text> : null}
+      {linkRow}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  settingsBlock: { marginTop: 22 },
+  settingsSectionTitle: { color: "#fff", fontSize: 14, fontWeight: "600", marginBottom: 4 },
+  settingsHint: { color: "#6b7280", fontSize: 11, lineHeight: 16, marginBottom: 8 },
+  wrapAuth: { alignItems: "center", marginTop: 8 },
+  introAuth: { color: "#6b7280", fontSize: 12, textAlign: "center", marginBottom: 6, lineHeight: 16 },
+  rowAuth: { flexDirection: "row", flexWrap: "wrap", justifyContent: "center" },
+  rowSettings: { flexDirection: "row", flexWrap: "wrap", justifyContent: "flex-start" },
+  sep: { color: "#6b7280", fontSize: 12 },
+  link: { color: "#34d399", fontSize: 12, textDecorationLine: "underline", fontWeight: "500" },
+});

--- a/apps/mobile/components/TodaySettingsModal.tsx
+++ b/apps/mobile/components/TodaySettingsModal.tsx
@@ -20,6 +20,7 @@ import {
   type MenuItemExportRow,
   type RestaurantExportRow,
 } from "../lib/export-full-user-data-mobile";
+import { LegalDocumentLinks } from "./LegalDocumentLinks";
 import { isSnapshotRestaurant } from "../lib/snapshot-restaurant";
 import { shareUtf8JsonFile } from "../lib/share-json-mobile";
 
@@ -430,6 +431,11 @@ export function TodaySettingsModal({
                 Open Food Facts
               </Text>
             </Text>
+
+            <LegalDocumentLinks
+              variant="settings"
+              onOpenError={(m) => onToast?.(m)}
+            />
 
             <Pressable
               onPress={() => {

--- a/apps/mobile/lib/ketolog-legal-urls.ts
+++ b/apps/mobile/lib/ketolog-legal-urls.ts
@@ -1,0 +1,76 @@
+import { Linking } from "react-native";
+
+/**
+ * 利用規約・プライバシーポリシー URL 解決（#293 法務導線）。
+ * https のみ開く。完全 URL 環境変数があれば origin より優先。
+ */
+const DEFAULT_TERMS_PATH = "/legal/terms";
+const DEFAULT_PRIVACY_PATH = "/legal/privacy";
+
+function trimOrigin(origin: string): string {
+  return origin.replace(/\/$/, "");
+}
+
+function isValidHttpsUrl(url: string): boolean {
+  try {
+    return new URL(url).protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+function fullUrlOrNullFromEnv(key: "EXPO_PUBLIC_KETOLOG_LEGAL_TERMS_URL" | "EXPO_PUBLIC_KETOLOG_LEGAL_PRIVACY_URL"):
+  | string
+  | null {
+  const raw = process.env[key];
+  if (raw === undefined || raw === null) return null;
+  const t = String(raw).trim();
+  if (t === "" || !isValidHttpsUrl(t)) return null;
+  return t;
+}
+
+function fromOriginPath(path: string): string | null {
+  const raw = process.env.EXPO_PUBLIC_KETOLOG_WEB_ORIGIN;
+  if (raw === undefined || raw === null) return null;
+  const origin = String(raw).trim();
+  if (origin === "" || !isValidHttpsUrl(origin) || !isValidHttpsUrl(`${origin}/`)) return null;
+  return `${trimOrigin(origin)}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+/** 表示・オープン用: 解決不可なら null。 */
+export function getKetologTermsUrl(): string | null {
+  return fullUrlOrNullFromEnv("EXPO_PUBLIC_KETOLOG_LEGAL_TERMS_URL") ?? fromOriginPath(DEFAULT_TERMS_PATH);
+}
+
+export function getKetologPrivacyUrl(): string | null {
+  return fullUrlOrNullFromEnv("EXPO_PUBLIC_KETOLOG_LEGAL_PRIVACY_URL") ?? fromOriginPath(DEFAULT_PRIVACY_PATH);
+}
+
+/** 同一レンダーで複数箇所に分けず使う。 */
+export function resolveKetologLegalUrls(): { terms: string | null; privacy: string | null } {
+  return { terms: getKetologTermsUrl(), privacy: getKetologPrivacyUrl() };
+}
+
+/**
+ * 規約類 URL のみ。失敗しても例外は投げない。
+ * @param onError UI 用（任意）
+ */
+export async function openKetologLegalUrl(
+  url: string,
+  onError?: (message: string) => void
+): Promise<void> {
+  if (!isValidHttpsUrl(url)) {
+    onError?.("有効な https URL ではありません。");
+    return;
+  }
+  try {
+    const can = await Linking.canOpenURL(url);
+    if (!can) {
+      onError?.("このリンクを開けませんでした。");
+      return;
+    }
+    await Linking.openURL(url);
+  } catch {
+    onError?.("ブラウザを開けませんでした。");
+  }
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,6 +20,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@ketolog/domain": "*",
     "@ketolog/types": "*",
+    "@react-navigation/native": "^7.2.2",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@supabase/supabase-js": "^2.104.0",

--- a/apps/mobile/screens/InsightsScreen.tsx
+++ b/apps/mobile/screens/InsightsScreen.tsx
@@ -1,3 +1,4 @@
+import { useFocusEffect } from "@react-navigation/native";
 import { useRouter } from "expo-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
@@ -20,6 +21,7 @@ import {
   type InsightFoodLogEntry,
 } from "@ketolog/domain/insights";
 import { useAuthSessionContext } from "../contexts/AuthSessionContext";
+import { loadFoodLogOutbox } from "../lib/food-log-outbox";
 import { getSupabase } from "../lib/supabase";
 import { fetchInsightsFoodLogForDateRange } from "../lib/fetch-insights-food-log-mobile";
 import { shareUtf8JsonFile } from "../lib/share-json-mobile";
@@ -85,6 +87,8 @@ export function InsightsScreen() {
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [shareErr, setShareErr] = useState<string | null>(null);
+  const [outboxLoaded, setOutboxLoaded] = useState(false);
+  const [outboxHasUnsent, setOutboxHasUnsent] = useState(false);
 
   const loadRange = useCallback(
     async (nextStart: string, nextEnd: string, nextPreset: Preset) => {
@@ -118,6 +122,27 @@ export function InsightsScreen() {
     });
     return () => cancelAnimationFrame(id);
   }, [userId, loadRange, preset7.start, preset7.end]);
+
+  const refreshOutbox = useCallback(async () => {
+    if (!userId) return;
+    const drafts = await loadFoodLogOutbox(userId);
+    setOutboxHasUnsent(drafts.length > 0);
+    setOutboxLoaded(true);
+  }, [userId]);
+
+  useEffect(() => {
+    if (!userId) {
+      setOutboxLoaded(false);
+      setOutboxHasUnsent(false);
+    }
+  }, [userId]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (!userId) return;
+      void refreshOutbox();
+    }, [userId, refreshOutbox])
+  );
 
   const insight = useMemo(
     () => buildInsights(entries, start, end),
@@ -187,6 +212,20 @@ export function InsightsScreen() {
         </View>
         <Text style={styles.sub}>JST の日付で集計します</Text>
       </View>
+
+      {outboxLoaded && outboxHasUnsent ? (
+        <View
+          style={styles.outboxBanner}
+          accessibilityRole="alert"
+          accessibilityLabel="未送信の下書きは分析に含まれません。Todayで再送または破棄できます。"
+        >
+          <Ionicons name="alert-circle" size={18} color="#fcd34d" style={styles.outboxIcon} />
+          <Text style={styles.outboxText}>
+            未送信の下書きはクラウドに未同期のため、この分析の集計には含まれません。Today
+            の「未送信の下書き」から再送するか、破棄してください。
+          </Text>
+        </View>
+      ) : null}
 
       <ScrollView
         style={styles.scroll}
@@ -443,6 +482,21 @@ const styles = StyleSheet.create({
   },
   closeBtnText: { color: COLORS.text, fontSize: 13, fontWeight: "600" },
   sub: { color: COLORS.muted, fontSize: 11, marginTop: 6 },
+  outboxBanner: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+    gap: 8,
+    marginHorizontal: 12,
+    marginTop: 8,
+    marginBottom: 0,
+    padding: 10,
+    borderRadius: 10,
+    backgroundColor: "rgba(120, 53, 15, 0.35)",
+    borderWidth: 1,
+    borderColor: "rgba(234, 179, 8, 0.4)",
+  },
+  outboxIcon: { marginTop: 1 },
+  outboxText: { color: "#fef3c7", fontSize: 12, lineHeight: 17, flex: 1 },
   scroll: { flex: 1 },
   scrollContent: { paddingHorizontal: 12, paddingTop: 12 },
   card: {

--- a/apps/mobile/screens/LoginScreen.tsx
+++ b/apps/mobile/screens/LoginScreen.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from "react-native";
 import { Link, useLocalSearchParams } from "expo-router";
+import { LegalDocumentLinks } from "../components/LegalDocumentLinks";
 import { getSupabase } from "../lib/supabase";
 import { signInWithGoogle } from "../lib/googleSignIn";
 
@@ -112,6 +113,8 @@ export function LoginScreen() {
         >
           {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.primaryBtnText}>ログイン</Text>}
         </Pressable>
+
+        <LegalDocumentLinks variant="auth" onOpenError={setError} />
 
         <Text style={styles.footer}>
           アカウントがない方は{" "}

--- a/apps/mobile/screens/SignupScreen.tsx
+++ b/apps/mobile/screens/SignupScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from "react-native";
 import { Link, router } from "expo-router";
 import { makeRedirectUri } from "expo-auth-session";
+import { LegalDocumentLinks } from "../components/LegalDocumentLinks";
 import { getSupabase } from "../lib/supabase";
 import { signInWithGoogle } from "../lib/googleSignIn";
 
@@ -131,6 +132,8 @@ export function SignupScreen() {
             <Text style={styles.primaryBtnText}>アカウント作成</Text>
           )}
         </Pressable>
+
+        <LegalDocumentLinks variant="auth" onOpenError={setError} />
 
         <Text style={styles.footer}>
           すでにアカウントをお持ちの方は{" "}

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@ketolog/types": "*",
         "@react-native-async-storage/async-storage": "2.2.0",
         "@react-native-community/netinfo": "11.4.1",
+        "@react-navigation/native": "^7.2.2",
         "@supabase/supabase-js": "^2.104.0",
         "expo": "~54.0.33",
         "expo-auth-session": "~7.0.10",
@@ -625,23 +626,6 @@
         }
       }
     },
-    "apps/mobile/node_modules/expo-router/node_modules/@react-navigation/native": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
-      "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/core": "^7.17.2",
-        "escape-string-regexp": "^4.0.0",
-        "fast-deep-equal": "^3.1.3",
-        "nanoid": "^3.3.11",
-        "use-latest-callback": "^0.2.4"
-      },
-      "peerDependencies": {
-        "react": ">= 18.2.0",
-        "react-native": "*"
-      }
-    },
     "apps/mobile/node_modules/expo-router/node_modules/@react-navigation/native-stack": {
       "version": "7.14.11",
       "resolved": "https://registry.npmjs.org/@react-navigation/native-stack/-/native-stack-7.14.11.tgz",
@@ -682,34 +666,6 @@
         "@react-native-masked-view/masked-view": {
           "optional": true
         }
-      }
-    },
-    "apps/mobile/node_modules/expo-router/node_modules/@react-navigation/native/node_modules/@react-navigation/core": {
-      "version": "7.17.2",
-      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.17.2.tgz",
-      "integrity": "sha512-Rt2OZwcgOmjv401uLGAKaRM6xo0fiBce/A7LfRHI1oe5FV+KooWcgAoZ2XOtgKj6UzVMuQWt3b2e6rxo/mDJRA==",
-      "license": "MIT",
-      "dependencies": {
-        "@react-navigation/routers": "^7.5.3",
-        "escape-string-regexp": "^4.0.0",
-        "fast-deep-equal": "^3.1.3",
-        "nanoid": "^3.3.11",
-        "query-string": "^7.1.3",
-        "react-is": "^19.1.0",
-        "use-latest-callback": "^0.2.4",
-        "use-sync-external-store": "^1.5.0"
-      },
-      "peerDependencies": {
-        "react": ">= 18.2.0"
-      }
-    },
-    "apps/mobile/node_modules/expo-router/node_modules/use-latest-callback": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
-      "integrity": "sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "react": ">=16.8"
       }
     },
     "apps/mobile/node_modules/expo-router/node_modules/vaul": {
@@ -1221,12 +1177,6 @@
           "optional": true
         }
       }
-    },
-    "apps/mobile/node_modules/react-is": {
-      "version": "19.2.5",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
-      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
-      "license": "MIT"
     },
     "apps/mobile/node_modules/semver": {
       "version": "7.6.3",
@@ -6845,6 +6795,48 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-navigation/core": {
+      "version": "7.17.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/core/-/core-7.17.2.tgz",
+      "integrity": "sha512-Rt2OZwcgOmjv401uLGAKaRM6xo0fiBce/A7LfRHI1oe5FV+KooWcgAoZ2XOtgKj6UzVMuQWt3b2e6rxo/mDJRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/routers": "^7.5.3",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "query-string": "^7.1.3",
+        "react-is": "^19.1.0",
+        "use-latest-callback": "^0.2.4",
+        "use-sync-external-store": "^1.5.0"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0"
+      }
+    },
+    "node_modules/@react-navigation/core/node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@react-navigation/native": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.2.2.tgz",
+      "integrity": "sha512-kem1Ko2BcbAjmbQIv66dNmr6EtfDut3QU0qjsVhMnLLhktwyXb6FzZYp8gTrUb6AvkAbaJoi+BF5Pl55pAUa5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@react-navigation/core": "^7.17.2",
+        "escape-string-regexp": "^4.0.0",
+        "fast-deep-equal": "^3.1.3",
+        "nanoid": "^3.3.11",
+        "use-latest-callback": "^0.2.4"
+      },
+      "peerDependencies": {
+        "react": ">= 18.2.0",
+        "react-native": "*"
       }
     },
     "node_modules/@react-navigation/routers": {
@@ -19897,6 +19889,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-latest-callback": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/use-latest-callback/-/use-latest-callback-0.2.6.tgz",
+      "integrity": "sha512-FvRG9i1HSo0wagmX63Vrm8SnlUU3LMM3WyZkQ76RnslpBrX694AdG4A0zQBx2B3ZifFA0yv/BaEHGBnEax5rZg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8"
       }
     },
     "node_modules/use-sync-external-store": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.55.0",
+  "version": "1.56.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## 概要
[#293](https://github.com/kzkski/ketolog/issues/293) の分割 PR（**第1弾**）。`expo-updates` は含めない。

## 内容
- **分析**: 未送信の食事下書きが1件以上ある場合のみ、集計に含まれない旨のバナーを表示。`useFocusEffect` で画面フォーカス時に outbox を再取得。
- **法務**: `EXPO_PUBLIC_KETOLOG_WEB_ORIGIN` または `EXPO_PUBLIC_KETOLOG_LEGAL_*_URL`（https）で解決した利用規約・プライバシーを、ログイン / 新規登録 / Today 設定から `Linking.openURL`。未設定時は法務ブロック非表示。
- 依存: `@react-navigation/native`（`useFocusEffect` 用に直接指定）。

## 受け入れ
- [ ] 型: `npm run mobile:typecheck`
- 手動: 下書き有→分析でバナー、なしで非表示。EAS/本番向けに env を入れたうえで規約リンクが開くこと（任意）

## Issue
`refs #293`（**closes しない** — 第2弾 OTA 残り）

Made with [Cursor](https://cursor.com)