### PR TITLE
feat(mobile): EAS Update 確認と再読み込み案内（#293 PR2）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.57.0] - 2026-04-24
+
+### Added
+
+- **Mobile / 更新配布（[#293](https://github.com/kzkski/ketolog/issues/293)）**: 本番相当で `expo-updates` が有効なビルドでは、起動直後（短い遅延後）とアプリのフォアグラウンド復帰時に EAS Update の確認・取得を行い、新しい JavaScript バンドルがあれば**再読み込み**を案内する（`__DEV__` や無効ビルドでは no-op。同一セッションは冷却あり）。実装は `useEASUpdatePrompt`（`app/_layout`）。
+
 ## [1.56.0] - 2026-04-24
 
 ### Added

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -81,6 +81,8 @@ npm run mobile:typecheck
 - `npm --prefix apps/mobile run eas:submit:ios:production`
 - `npm --prefix apps/mobile run eas:credentials:ios`
 
+**EAS Update（Over-The-Air）**: `app.config` の `updates` / `runtimeVersion` が有効な**本番相当**のインストールでは、起動直後（短い遅延のあと）と**フォアグラウンド復帰**時に更新の確認・取得を行い、新しい JS バンドルがあれば再読み込みを案内する。`npx expo start` の開発中（`__DEV__`）や `expo-updates` が無効なビルドでは何もしない。
+
 ## 共有パッケージ（`@ketolog/domain` / `@ketolog/types`）
 
 モノレポ直下の `packages/` を `package.json` の workspaces から参照する。`App.tsx` で共有ロジックの import を確認できる。

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -8,6 +8,7 @@ import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
 import { AuthSessionProvider, useAuthSessionContext } from "../contexts/AuthSessionContext";
 import { MissingSupabaseConfigScreen } from "../components/MissingSupabaseConfigScreen";
+import { useEASUpdatePrompt } from "../hooks/useEASUpdatePrompt";
 import { isSupabaseConfigured } from "../lib/supabase";
 
 WebBrowser.maybeCompleteAuthSession();
@@ -40,6 +41,7 @@ function MissingSupabaseRoot() {
 
 function ConfiguredRootLayout() {
   const { loading, initError } = useAuthSessionContext();
+  useEASUpdatePrompt();
 
   /** `getSession` が返らない環境でもネイティブスプラッシュで止まらないようにする */
   useEffect(() => {

--- a/apps/mobile/hooks/useEASUpdatePrompt.ts
+++ b/apps/mobile/hooks/useEASUpdatePrompt.ts
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef } from "react";
+import { Alert, AppState, type AppStateStatus } from "react-native";
+import * as Updates from "expo-updates";
+
+const COOLDOWN_MS = 60_000;
+const START_DELAY_MS = 2_000;
+
+/**
+ * EAS Update: 起動遅延後とフォアグラウンド復帰時に `check` → `fetch` し、必要なら再読み込みを案内する。
+ * `__DEV__` または `Updates.isEnabled === false` では no-op（例外は握る）。
+ */
+export function useEASUpdatePrompt(): void {
+  const inFlight = useRef(false);
+  const lastRunEndAt = useRef(0);
+  const appStateRef = useRef<AppStateStatus>(AppState.currentState);
+
+  const run = useCallback(async () => {
+    if (__DEV__ || !Updates.isEnabled) return;
+    if (inFlight.current) return;
+    const now = Date.now();
+    if (now - lastRunEndAt.current < COOLDOWN_MS && lastRunEndAt.current > 0) return;
+
+    inFlight.current = true;
+    try {
+      const check = await Updates.checkForUpdateAsync();
+      if (check.isAvailable) {
+        const fetched = await Updates.fetchUpdateAsync();
+        if (fetched.isNew) {
+          Alert.alert(
+            "アップデート",
+            "新しい内容が配信されています。再読み込みで反映できます。",
+            [
+              { text: "あとで", style: "cancel" },
+              { text: "再読み込み", onPress: () => void Updates.reloadAsync() },
+            ],
+            { cancelable: true }
+          );
+        }
+        return;
+      }
+      if (check.isRollBackToEmbedded) {
+        const fetched = await Updates.fetchUpdateAsync();
+        if (fetched.isRollBackToEmbedded) {
+          Alert.alert(
+            "更新",
+            "内蔵バージョンに戻す更新です。再読み込みで反映できます。",
+            [
+              { text: "あとで", style: "cancel" },
+              { text: "再読み込み", onPress: () => void Updates.reloadAsync() },
+            ],
+            { cancelable: true }
+          );
+        }
+      }
+    } catch (e) {
+      if (__DEV__) {
+        const msg = e instanceof Error ? e.message : String(e);
+        // eslint-disable-next-line no-console -- 開発時のみ
+        console.warn("[expo-updates]", msg);
+      }
+    } finally {
+      inFlight.current = false;
+      lastRunEndAt.current = Date.now();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (__DEV__ || !Updates.isEnabled) return;
+
+    const sub = AppState.addEventListener("change", (next: AppStateStatus) => {
+      if (appStateRef.current.match(/inactive|background/) && next === "active") {
+        void run();
+      }
+      appStateRef.current = next;
+    });
+
+    const startTimer = setTimeout(() => {
+      void run();
+    }, START_DELAY_MS);
+
+    return () => {
+      sub.remove();
+      clearTimeout(startTimer);
+    };
+  }, [run]);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.56.0",
+  "version": "1.57.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## 概要
[#293](https://github.com/kzkski/ketolog/issues/293) の **第2弾**（`expo-updates` / EAS Update）。

## 内容
- `useEASUpdatePrompt`（`apps/mobile/hooks/useEASUpdatePrompt.ts`）: `checkForUpdateAsync` → `fetchUpdateAsync`、新規バンドル／内蔵ロールバック時に `Alert` で再読み込みを案内。
- `__DEV__` または `!Updates.isEnabled` では no-op。取得失敗は本番では握り、開発時のみ `console.warn`。
- 起動後 2 秒遅延で1回、あとは `AppState` の foreground 遷移で実行。60s 冷却で連続 check を抑制。
- `ConfiguredRootLayout` でフックを有効化。
- `apps/mobile/README.md` に EAS Update の挙動を追記。リポジトリ版 **1.57.0**。

## 受け入れ
- `npm run mobile:typecheck` 済み。

closes #293

Made with [Cursor](https://cursor.com)