### PR TITLE
fix: Server Actions の ImportData 再エクスポート

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@
 
 ## [1.59.0] - 2026-04-24
 
+### Fixed
+
+- **Web / Today**: `import-export` の `ImportData` 型の再エクスポートを `@ketolog/domain` 直指定にし、dev / Server Actions で `ReferenceError: ImportData is not defined` になる問題を解消（[#303](https://github.com/kzkski/ketolog/issues/303)）。
+
 ### Changed
 
 - **Web / Today**: 「お店を追加」各ドロワー（手入力 / JSON インポート / プリセット）の**見出し**を、モバイル同様**中央揃え**にし、**キャンセル**を右上に固定（`TodayClient`）。

--- a/src/app/today/actions/import-export.ts
+++ b/src/app/today/actions/import-export.ts
@@ -2,14 +2,15 @@
 
 import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import type { MenuItem, Restaurant } from "@/types/database";
-import type { ImportData, ImportRestaurantEntry } from "@ketolog/domain/restaurant-import";
+import type { ImportData } from "@ketolog/domain/restaurant-import";
 import type { MenuShareImportItem } from "@ketolog/domain/menu-share-qr";
 import { ensureFavoriteEntryForMenuItem } from "./favorites";
 import { nextRestaurantDisplayOrder } from "./restaurant";
 
 export type ImportRestaurantItem = MenuShareImportItem;
 
-export type { ImportData, ImportRestaurantEntry };
+/** ローカルの `import type` 再エクスポートは Server Actions バンドルで実行時参照になることがあるため、直に再エクスポートする */
+export type { ImportData, ImportRestaurantEntry } from "@ketolog/domain/restaurant-import";
 
 export async function importRestaurantData(data: ImportData): Promise<{
   added: number;


### PR DESCRIPTION
## 内容
`import-export.ts` の `import type` 直後の `export type { ImportData, ... }` が、Next Server Actions バンドルで実行時 `ReferenceError: ImportData is not defined` になる事象の修正。型は `@ketolog/domain/restaurant-import` から直に re-export。

CHANGELOG の 1.59.0 追記を含みます。

Made with [Cursor](https://cursor.com)