### PR TITLE
feat(mobile): Todayを固定ヘッダー+メニュー専用スクロールに再構成

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.60.0] - 2026-04-25
+
+### Changed
+
+- **Mobile / Today（[#310](https://github.com/kzkski/ketolog/issues/310)）**: 画面全体の外側 `ScrollView` を廃止し、`topHeader`・日付ナビ・フェーズ・PFC・記録パネルを固定表示にした。`TodayMenuPanel` はモード/店舗タブ/検索を固定し、メニュー行エリアのみを縦スクロール化して pull-to-refresh を移設。カートドック展開時でも末尾操作がしやすいように下余白を追加した。
+
 ## [1.59.0] - 2026-04-24
 
 ### Fixed

--- a/apps/mobile/components/TodayMenuPanel.tsx
+++ b/apps/mobile/components/TodayMenuPanel.tsx
@@ -8,6 +8,7 @@ import {
   Alert,
   Platform,
   Pressable,
+  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
@@ -163,6 +164,9 @@ type Props = {
   onToast?: (message: string) => void;
   /** 店舗削除後（カートの該当行除去など） */
   onRestaurantDeleted?: (restaurantId: string) => void;
+  refreshing?: boolean;
+  onRefresh?: () => void;
+  menuBottomInset?: number;
 };
 
 /** Web `compareMenuItemsForListOrder` / `sortMenuItemsForListOrder` と同順 */
@@ -335,6 +339,9 @@ export function TodayMenuPanel({
   onPickStandardFoodForMenu,
   onToast,
   onRestaurantDeleted,
+  refreshing = false,
+  onRefresh,
+  menuBottomInset = 24,
 }: Props) {
   const [tab, setTab] = useState<BrowseTab>("favorites");
   const [restaurants, setRestaurants] = useState<RestaurantRow[]>([]);
@@ -829,23 +836,43 @@ export function TodayMenuPanel({
         style={styles.search}
       />
 
-      {tab === "composition" ? (
-        <StandardFoodCompositionPanel
-          supabase={supabase}
-          searchQuery={compositionQuery}
-          onPickFood={(row) => {
-            onPickStandardFoodForMenu?.(row, null);
-          }}
-        />
-      ) : loading ? (
-        <View style={styles.center}>
-          <ActivityIndicator color="#10b981" />
-        </View>
-      ) : error ? (
-        <Text style={styles.error}>{error}</Text>
-      ) : (
-        <View style={styles.list}>
-          {menuGroups.map((group) => {
+      <View style={styles.contentArea}>
+        {tab === "composition" ? (
+          <View style={styles.compositionArea}>
+            <StandardFoodCompositionPanel
+              supabase={supabase}
+              searchQuery={compositionQuery}
+              onPickFood={(row) => {
+                onPickStandardFoodForMenu?.(row, null);
+              }}
+            />
+          </View>
+        ) : (
+          <ScrollView
+            style={styles.menuScroll}
+            contentContainerStyle={[
+              styles.list,
+              {
+                paddingBottom: menuBottomInset,
+              },
+            ]}
+            nestedScrollEnabled
+            keyboardShouldPersistTaps="handled"
+            refreshControl={
+              onRefresh ? (
+                <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+              ) : undefined
+            }
+          >
+            {loading ? (
+              <View style={styles.center}>
+                <ActivityIndicator color="#10b981" />
+              </View>
+            ) : error ? (
+              <Text style={styles.error}>{error}</Text>
+            ) : (
+              <>
+                {menuGroups.map((group) => {
             if (group.groupName === null) {
               return (
                 <Fragment key={group.sectionKey}>
@@ -903,82 +930,85 @@ export function TodayMenuPanel({
                   : null}
               </View>
             );
-          })}
-          {tab === "shops" &&
-          selectedRestaurantId &&
-          onOpenMenuEditorAdd &&
-          restaurants.length > 0 ? (
-            <Pressable
-              onPress={() => onOpenMenuEditorAdd(selectedRestaurantId)}
-              style={({ pressed }) => [styles.addMenuItemRow, pressed && { opacity: 0.9 }]}
-              accessibilityLabel="メニューを追加"
-            >
-              <Text style={styles.addMenuItemText}>＋ メニューを追加</Text>
-            </Pressable>
-          ) : null}
-          {tab === "shops" && selectedShop && restaurants.length > 0 ? (
-            <View style={styles.shopActionsBlock}>
-              <View style={styles.jsonBtnRow}>
-                <Pressable
-                  onPress={() => {
-                    void handleDownloadRestaurantJson();
-                  }}
-                  style={({ pressed }) => [styles.jsonBtn, pressed && { opacity: 0.88 }]}
-                >
-                  <Text style={styles.jsonBtnText}>JSONでエクスポート</Text>
-                </Pressable>
-                <Pressable
-                  onPress={() => setImportMenuOpen(true)}
-                  style={({ pressed }) => [styles.jsonBtn, pressed && { opacity: 0.88 }]}
-                >
-                  <Text style={styles.jsonBtnText}>JSONでメニューを追加</Text>
-                </Pressable>
-              </View>
-              {confirmDeleteRestaurant ? (
-                <View style={styles.delConfirmRow}>
+                })}
+                {tab === "shops" &&
+                selectedRestaurantId &&
+                onOpenMenuEditorAdd &&
+                restaurants.length > 0 ? (
                   <Pressable
-                    onPress={() => setConfirmDeleteRestaurant(false)}
-                    style={({ pressed }) => [styles.delCancelBtn, pressed && { opacity: 0.9 }]}
+                    onPress={() => onOpenMenuEditorAdd(selectedRestaurantId)}
+                    style={({ pressed }) => [styles.addMenuItemRow, pressed && { opacity: 0.9 }]}
+                    accessibilityLabel="メニューを追加"
                   >
-                    <Text style={styles.delCancelText}>キャンセル</Text>
+                    <Text style={styles.addMenuItemText}>＋ メニューを追加</Text>
                   </Pressable>
-                  <Pressable
-                    onPress={() => {
-                      void handleDeleteRestaurant();
-                    }}
-                    disabled={deletingRestaurant}
-                    style={({ pressed }) => [
-                      styles.delGoBtn,
-                      (deletingRestaurant || pressed) && { opacity: 0.85 },
-                      deletingRestaurant && { opacity: 0.5 },
-                    ]}
-                  >
-                    <Text style={styles.delGoText}>
-                      {deletingRestaurant ? "削除中..." : "削除する"}
-                    </Text>
-                  </Pressable>
-                </View>
-              ) : (
-                <Pressable
-                  onPress={() => setConfirmDeleteRestaurant(true)}
-                  style={({ pressed }) => [styles.delHintBtn, pressed && { opacity: 0.88 }]}
-                >
-                  <Text style={styles.delHintText}>このお店を削除</Text>
-                </Pressable>
-              )}
-            </View>
-          ) : null}
-          {tab === "favorites" && menuGroups.length === 0 ? (
-            <Text style={styles.empty}>お気に入りがありません</Text>
-          ) : null}
-          {tab === "shops" && restaurants.length === 0 ? (
-            <Text style={styles.empty}>店舗がありません</Text>
-          ) : null}
-          {tab === "shops" && restaurants.length > 0 && menuGroups.length === 0 ? (
-            <Text style={styles.empty}>この店舗にメニューがありません</Text>
-          ) : null}
-        </View>
-      )}
+                ) : null}
+                {tab === "shops" && selectedShop && restaurants.length > 0 ? (
+                  <View style={styles.shopActionsBlock}>
+                    <View style={styles.jsonBtnRow}>
+                      <Pressable
+                        onPress={() => {
+                          void handleDownloadRestaurantJson();
+                        }}
+                        style={({ pressed }) => [styles.jsonBtn, pressed && { opacity: 0.88 }]}
+                      >
+                        <Text style={styles.jsonBtnText}>JSONでエクスポート</Text>
+                      </Pressable>
+                      <Pressable
+                        onPress={() => setImportMenuOpen(true)}
+                        style={({ pressed }) => [styles.jsonBtn, pressed && { opacity: 0.88 }]}
+                      >
+                        <Text style={styles.jsonBtnText}>JSONでメニューを追加</Text>
+                      </Pressable>
+                    </View>
+                    {confirmDeleteRestaurant ? (
+                      <View style={styles.delConfirmRow}>
+                        <Pressable
+                          onPress={() => setConfirmDeleteRestaurant(false)}
+                          style={({ pressed }) => [styles.delCancelBtn, pressed && { opacity: 0.9 }]}
+                        >
+                          <Text style={styles.delCancelText}>キャンセル</Text>
+                        </Pressable>
+                        <Pressable
+                          onPress={() => {
+                            void handleDeleteRestaurant();
+                          }}
+                          disabled={deletingRestaurant}
+                          style={({ pressed }) => [
+                            styles.delGoBtn,
+                            (deletingRestaurant || pressed) && { opacity: 0.85 },
+                            deletingRestaurant && { opacity: 0.5 },
+                          ]}
+                        >
+                          <Text style={styles.delGoText}>
+                            {deletingRestaurant ? "削除中..." : "削除する"}
+                          </Text>
+                        </Pressable>
+                      </View>
+                    ) : (
+                      <Pressable
+                        onPress={() => setConfirmDeleteRestaurant(true)}
+                        style={({ pressed }) => [styles.delHintBtn, pressed && { opacity: 0.88 }]}
+                      >
+                        <Text style={styles.delHintText}>このお店を削除</Text>
+                      </Pressable>
+                    )}
+                  </View>
+                ) : null}
+                {tab === "favorites" && menuGroups.length === 0 ? (
+                  <Text style={styles.empty}>お気に入りがありません</Text>
+                ) : null}
+                {tab === "shops" && restaurants.length === 0 ? (
+                  <Text style={styles.empty}>店舗がありません</Text>
+                ) : null}
+                {tab === "shops" && restaurants.length > 0 && menuGroups.length === 0 ? (
+                  <Text style={styles.empty}>この店舗にメニューがありません</Text>
+                ) : null}
+              </>
+            )}
+          </ScrollView>
+        )}
+      </View>
 
       <RenameRestaurantModal
         visible={renameRestaurantTarget != null}
@@ -1012,6 +1042,8 @@ export function TodayMenuPanel({
 const styles = StyleSheet.create({
   /** TodayScreen の PFC ブロックと同じ全幅ストリップ（左右の余白カードはやめる） */
   wrap: {
+    flex: 1,
+    minHeight: 0,
     marginTop: 0,
     marginHorizontal: 0,
     paddingHorizontal: 10,
@@ -1020,6 +1052,18 @@ const styles = StyleSheet.create({
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: "#1f2937",
     gap: 10,
+  },
+  contentArea: {
+    flex: 1,
+    minHeight: 0,
+  },
+  compositionArea: {
+    flex: 1,
+    minHeight: 0,
+  },
+  menuScroll: {
+    flex: 1,
+    minHeight: 0,
   },
   switchRow: { flexDirection: "row", alignItems: "stretch", gap: 4, minWidth: 0 },
   /** お気に入り・成分表を店舗タブ行の左に詰めて並べる（枠ボタンは使わない） */
@@ -1190,7 +1234,7 @@ const styles = StyleSheet.create({
   },
   center: { alignItems: "center", paddingVertical: 20 },
   error: { color: "#fecaca", fontSize: 12, paddingVertical: 8 },
-  list: { gap: 7 },
+  list: { gap: 7, paddingBottom: 24 },
   /** Web `MenuItemList` のグループ見出しに近い */
   menuGroupHeader: {
     marginHorizontal: -10,

--- a/apps/mobile/components/TodayMenuPanel.tsx
+++ b/apps/mobile/components/TodayMenuPanel.tsx
@@ -15,6 +15,11 @@ import {
   TextInput,
   View,
 } from "react-native";
+import DraggableFlatList, {
+  ScaleDecorator,
+  type DragEndParams,
+  type RenderItemParams,
+} from "react-native-draggable-flatlist";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   addMenuItemToFavoritesMobile,
@@ -44,6 +49,7 @@ import { RenameRestaurantModal } from "./RenameRestaurantModal";
 import { StandardFoodCompositionPanel } from "./StandardFoodCompositionPanel";
 import { ImportMenuItemsModal } from "./ImportMenuItemsModal";
 import { deleteRestaurantMobile } from "../lib/delete-restaurant-mobile";
+import { reorderRestaurantsMobile } from "../lib/reorder-restaurants-mobile";
 import { shareUtf8JsonFile } from "../lib/share-json-mobile";
 
 type BrowseTab = "favorites" | "shops" | "composition";
@@ -445,6 +451,79 @@ export function TodayMenuPanel({
     [loadFavorites]
   );
 
+  const handleRestaurantDragEnd = useCallback(
+    ({ data }: DragEndParams<RestaurantRow>) => {
+      const next = data.map((r, index) => ({ ...r, display_order: index }));
+      setRestaurants(next);
+      void (async () => {
+        const { error } = await reorderRestaurantsMobile(
+          supabase,
+          userId,
+          next.map((r) => r.id)
+        );
+        if (error) {
+          setError(error);
+          await loadRestaurants();
+        }
+      })();
+    },
+    [supabase, userId, loadRestaurants]
+  );
+
+  const renderRestaurantDraggableItem = useCallback(
+    ({ item, drag, isActive }: RenderItemParams<RestaurantRow>) => {
+      const selected = tab === "shops" && selectedRestaurantId === item.id;
+      return (
+        <ScaleDecorator>
+          <View
+            style={[
+              styles.restaurantTabStrip,
+              selected ? styles.restaurantTabStripOn : null,
+              isActive ? styles.restaurantTabStripDragging : null,
+            ]}
+          >
+            <Pressable
+              onLongPress={drag}
+              delayLongPress={220}
+              disabled={isActive}
+              style={({ pressed }) => [
+                styles.restaurantDragHandle,
+                (pressed || isActive) && { opacity: 0.78 },
+              ]}
+              accessibilityLabel={`${item.name}の表示順を変更`}
+              hitSlop={{ top: 6, bottom: 6, left: 2, right: 2 }}
+            >
+              <Text style={styles.restaurantDragHandleGlyph}>⣿</Text>
+            </Pressable>
+            <Pressable
+              onPress={() => {
+                setTab("shops");
+                setSelectedRestaurantId(item.id);
+              }}
+              onLongPress={() => openRestaurantTabMenu(item)}
+              delayLongPress={520}
+              disabled={isActive}
+              style={({ pressed }) => [styles.restaurantNameHit, pressed && { opacity: 0.88 }]}
+              accessibilityLabel={item.name}
+              accessibilityHint="長押しで名前を変更"
+            >
+              <Text
+                style={[
+                  styles.restaurantNameText,
+                  selected ? styles.restaurantNameTextOn : null,
+                ]}
+                numberOfLines={1}
+              >
+                {item.name}
+              </Text>
+            </Pressable>
+          </View>
+        </ScaleDecorator>
+      );
+    },
+    [tab, selectedRestaurantId, openRestaurantTabMenu]
+  );
+
   const loadMenus = useCallback(async () => {
     if (!selectedRestaurantId) {
       setMenuItems([]);
@@ -719,42 +798,18 @@ export function TodayMenuPanel({
 
         {/* flex 行で FlatList は minWidth:0 無しだと幅を取りすぎて右の「＋」が画面外へ押し出される */}
         <View style={styles.restaurantListSlot}>
-          <ScrollView
+          <DraggableFlatList
             horizontal
+            data={restaurants}
+            keyExtractor={(r) => r.id}
+            renderItem={renderRestaurantDraggableItem}
+            onDragEnd={handleRestaurantDragEnd}
+            activationDistance={10}
             showsHorizontalScrollIndicator={false}
             style={styles.restaurantScroll}
             contentContainerStyle={styles.restaurantTabRowContent}
             keyboardShouldPersistTaps="handled"
-          >
-            {restaurants.map((item) => {
-              const selected = tab === "shops" && selectedRestaurantId === item.id;
-              return (
-                <View
-                  key={item.id}
-                  style={[styles.restaurantTabStrip, selected ? styles.restaurantTabStripOn : null]}
-                >
-                  <Pressable
-                    onPress={() => {
-                      setTab("shops");
-                      setSelectedRestaurantId(item.id);
-                    }}
-                    onLongPress={() => openRestaurantTabMenu(item)}
-                    delayLongPress={520}
-                    style={({ pressed }) => [styles.restaurantNameHit, pressed && { opacity: 0.88 }]}
-                    accessibilityLabel={item.name}
-                    accessibilityHint="長押しで名前を変更"
-                  >
-                    <Text
-                      style={[styles.restaurantNameText, selected ? styles.restaurantNameTextOn : null]}
-                      numberOfLines={1}
-                    >
-                      {item.name}
-                    </Text>
-                  </Pressable>
-                </View>
-              );
-            })}
-          </ScrollView>
+          />
         </View>
         {onOpenRestaurantAdd ? (
           <Pressable
@@ -1014,7 +1069,7 @@ const styles = StyleSheet.create({
   compositionScrollContent: {
     paddingBottom: 24,
   },
-  switchRow: { flexDirection: "row", alignItems: "stretch", gap: 4, minWidth: 0 },
+  switchRow: { flexDirection: "row", alignItems: "stretch", gap: 4, minWidth: 0, minHeight: 38 },
   /** お気に入り・成分表を店舗タブ行の左に詰めて並べる（枠ボタンは使わない） */
   leftModeTabs: {
     flexDirection: "row",
@@ -1059,7 +1114,7 @@ const styles = StyleSheet.create({
   },
   modeTabLabelOn: { color: "#e5e7eb" },
   /** 店舗タブ行が右端の「＋」を押し出さないようにする */
-  restaurantListSlot: { flex: 1, minWidth: 0, overflow: "hidden" },
+  restaurantListSlot: { flex: 1, minWidth: 0, overflow: "hidden", minHeight: 38 },
   restaurantPlusBtn: {
     width: 40,
     flexShrink: 0,
@@ -1121,7 +1176,7 @@ const styles = StyleSheet.create({
   delGoText: { color: "#fff", fontSize: 13, fontWeight: "600" },
   delHintBtn: { paddingVertical: 6, alignItems: "center" },
   delHintText: { color: "#f87171", fontSize: 11, fontWeight: "500" },
-  restaurantScroll: { flex: 1 },
+  restaurantScroll: { flex: 1, minHeight: 38 },
   /** 下線で選択表示 */
   restaurantTabRowContent: {
     paddingRight: 8,
@@ -1140,11 +1195,27 @@ const styles = StyleSheet.create({
   restaurantTabStripOn: {
     borderBottomColor: "#10b981",
   },
+  restaurantTabStripDragging: {
+    opacity: 0.92,
+  },
+  restaurantDragHandle: {
+    paddingLeft: 2,
+    paddingRight: 2,
+    justifyContent: "center",
+    alignItems: "center",
+    minWidth: 28,
+  },
+  restaurantDragHandleGlyph: {
+    color: "#6b7280",
+    fontSize: 13,
+    lineHeight: 16,
+    fontWeight: "600",
+  },
   restaurantNameHit: {
     flexShrink: 1,
     justifyContent: "center",
-    paddingRight: 8,
-    paddingLeft: 6,
+    paddingRight: 6,
+    paddingLeft: 2,
     minWidth: 0,
   },
   restaurantNameText: {

--- a/apps/mobile/components/TodayMenuPanel.tsx
+++ b/apps/mobile/components/TodayMenuPanel.tsx
@@ -15,11 +15,6 @@ import {
   TextInput,
   View,
 } from "react-native";
-import DraggableFlatList, {
-  ScaleDecorator,
-  type DragEndParams,
-  type RenderItemParams,
-} from "react-native-draggable-flatlist";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import {
   addMenuItemToFavoritesMobile,
@@ -49,7 +44,6 @@ import { RenameRestaurantModal } from "./RenameRestaurantModal";
 import { StandardFoodCompositionPanel } from "./StandardFoodCompositionPanel";
 import { ImportMenuItemsModal } from "./ImportMenuItemsModal";
 import { deleteRestaurantMobile } from "../lib/delete-restaurant-mobile";
-import { reorderRestaurantsMobile } from "../lib/reorder-restaurants-mobile";
 import { shareUtf8JsonFile } from "../lib/share-json-mobile";
 
 type BrowseTab = "favorites" | "shops" | "composition";
@@ -451,79 +445,6 @@ export function TodayMenuPanel({
     [loadFavorites]
   );
 
-  const handleRestaurantDragEnd = useCallback(
-    ({ data }: DragEndParams<RestaurantRow>) => {
-      const next = data.map((r, index) => ({ ...r, display_order: index }));
-      setRestaurants(next);
-      void (async () => {
-        const { error } = await reorderRestaurantsMobile(
-          supabase,
-          userId,
-          next.map((r) => r.id)
-        );
-        if (error) {
-          setError(error);
-          await loadRestaurants();
-        }
-      })();
-    },
-    [supabase, userId, loadRestaurants]
-  );
-
-  const renderRestaurantDraggableItem = useCallback(
-    ({ item, drag, isActive }: RenderItemParams<RestaurantRow>) => {
-      const selected = tab === "shops" && selectedRestaurantId === item.id;
-      return (
-        <ScaleDecorator>
-          <View
-            style={[
-              styles.restaurantTabStrip,
-              selected ? styles.restaurantTabStripOn : null,
-              isActive ? styles.restaurantTabStripDragging : null,
-            ]}
-          >
-            <Pressable
-              onLongPress={drag}
-              delayLongPress={220}
-              disabled={isActive}
-              style={({ pressed }) => [
-                styles.restaurantDragHandle,
-                (pressed || isActive) && { opacity: 0.78 },
-              ]}
-              accessibilityLabel={`${item.name}の表示順を変更`}
-              hitSlop={{ top: 6, bottom: 6, left: 2, right: 2 }}
-            >
-              <Text style={styles.restaurantDragHandleGlyph}>⣿</Text>
-            </Pressable>
-            <Pressable
-              onPress={() => {
-                setTab("shops");
-                setSelectedRestaurantId(item.id);
-              }}
-              onLongPress={() => openRestaurantTabMenu(item)}
-              delayLongPress={520}
-              disabled={isActive}
-              style={({ pressed }) => [styles.restaurantNameHit, pressed && { opacity: 0.88 }]}
-              accessibilityLabel={item.name}
-              accessibilityHint="長押しで名前を変更"
-            >
-              <Text
-                style={[
-                  styles.restaurantNameText,
-                  selected ? styles.restaurantNameTextOn : null,
-                ]}
-                numberOfLines={1}
-              >
-                {item.name}
-              </Text>
-            </Pressable>
-          </View>
-        </ScaleDecorator>
-      );
-    },
-    [tab, selectedRestaurantId, openRestaurantTabMenu]
-  );
-
   const loadMenus = useCallback(async () => {
     if (!selectedRestaurantId) {
       setMenuItems([]);
@@ -798,17 +719,42 @@ export function TodayMenuPanel({
 
         {/* flex 行で FlatList は minWidth:0 無しだと幅を取りすぎて右の「＋」が画面外へ押し出される */}
         <View style={styles.restaurantListSlot}>
-          <DraggableFlatList
+          <ScrollView
             horizontal
-            data={restaurants}
-            keyExtractor={(r) => r.id}
-            renderItem={renderRestaurantDraggableItem}
-            onDragEnd={handleRestaurantDragEnd}
-            activationDistance={10}
             showsHorizontalScrollIndicator={false}
             style={styles.restaurantScroll}
             contentContainerStyle={styles.restaurantTabRowContent}
-          />
+            keyboardShouldPersistTaps="handled"
+          >
+            {restaurants.map((item) => {
+              const selected = tab === "shops" && selectedRestaurantId === item.id;
+              return (
+                <View
+                  key={item.id}
+                  style={[styles.restaurantTabStrip, selected ? styles.restaurantTabStripOn : null]}
+                >
+                  <Pressable
+                    onPress={() => {
+                      setTab("shops");
+                      setSelectedRestaurantId(item.id);
+                    }}
+                    onLongPress={() => openRestaurantTabMenu(item)}
+                    delayLongPress={520}
+                    style={({ pressed }) => [styles.restaurantNameHit, pressed && { opacity: 0.88 }]}
+                    accessibilityLabel={item.name}
+                    accessibilityHint="長押しで名前を変更"
+                  >
+                    <Text
+                      style={[styles.restaurantNameText, selected ? styles.restaurantNameTextOn : null]}
+                      numberOfLines={1}
+                    >
+                      {item.name}
+                    </Text>
+                  </Pressable>
+                </View>
+              );
+            })}
+          </ScrollView>
         </View>
         {onOpenRestaurantAdd ? (
           <Pressable
@@ -1112,7 +1058,7 @@ const styles = StyleSheet.create({
     maxWidth: 76,
   },
   modeTabLabelOn: { color: "#e5e7eb" },
-  /** DraggableFlatList が親幅いっぱいに広がらないようにする */
+  /** 店舗タブ行が右端の「＋」を押し出さないようにする */
   restaurantListSlot: { flex: 1, minWidth: 0, overflow: "hidden" },
   restaurantPlusBtn: {
     width: 40,
@@ -1176,7 +1122,7 @@ const styles = StyleSheet.create({
   delHintBtn: { paddingVertical: 6, alignItems: "center" },
   delHintText: { color: "#f87171", fontSize: 11, fontWeight: "500" },
   restaurantScroll: { flex: 1 },
-  /** Web `SortableRestaurantTabs` に近い: 下線で選択、左に並べ替え用ハンドル */
+  /** 下線で選択表示 */
   restaurantTabRowContent: {
     paddingRight: 8,
     alignItems: "stretch",
@@ -1194,27 +1140,11 @@ const styles = StyleSheet.create({
   restaurantTabStripOn: {
     borderBottomColor: "#10b981",
   },
-  restaurantTabStripDragging: {
-    opacity: 0.92,
-  },
-  restaurantDragHandle: {
-    paddingLeft: 2,
-    paddingRight: 2,
-    justifyContent: "center",
-    alignItems: "center",
-    minWidth: 28,
-  },
-  restaurantDragHandleGlyph: {
-    color: "#6b7280",
-    fontSize: 13,
-    lineHeight: 16,
-    fontWeight: "600",
-  },
   restaurantNameHit: {
     flexShrink: 1,
     justifyContent: "center",
-    paddingRight: 6,
-    paddingLeft: 2,
+    paddingRight: 8,
+    paddingLeft: 6,
     minWidth: 0,
   },
   restaurantNameText: {

--- a/apps/mobile/components/TodayMenuPanel.tsx
+++ b/apps/mobile/components/TodayMenuPanel.tsx
@@ -822,23 +822,20 @@ export function TodayMenuPanel({
         ) : null}
       </View>
 
-      <TextInput
-        value={tab === "composition" ? compositionQuery : query}
-        onChangeText={tab === "composition" ? setCompositionQuery : setQuery}
-        placeholder={
-          tab === "favorites"
-            ? "お気に入りを検索"
-            : tab === "composition"
-              ? "成分表を検索（例: さけ 生）"
-              : "メニューを検索"
-        }
-        placeholderTextColor="#6b7280"
-        style={styles.search}
-      />
-
       <View style={styles.contentArea}>
         {tab === "composition" ? (
-          <View style={styles.compositionArea}>
+          <ScrollView
+            style={styles.menuScroll}
+            contentContainerStyle={styles.compositionScrollContent}
+            keyboardShouldPersistTaps="handled"
+          >
+            <TextInput
+              value={compositionQuery}
+              onChangeText={setCompositionQuery}
+              placeholder="成分表を検索（例: さけ 生）"
+              placeholderTextColor="#6b7280"
+              style={styles.search}
+            />
             <StandardFoodCompositionPanel
               supabase={supabase}
               searchQuery={compositionQuery}
@@ -846,7 +843,7 @@ export function TodayMenuPanel({
                 onPickStandardFoodForMenu?.(row, null);
               }}
             />
-          </View>
+          </ScrollView>
         ) : (
           <ScrollView
             style={styles.menuScroll}
@@ -864,6 +861,13 @@ export function TodayMenuPanel({
               ) : undefined
             }
           >
+            <TextInput
+              value={query}
+              onChangeText={setQuery}
+              placeholder={tab === "favorites" ? "お気に入りを検索" : "メニューを検索"}
+              placeholderTextColor="#6b7280"
+              style={styles.search}
+            />
             {loading ? (
               <View style={styles.center}>
                 <ActivityIndicator color="#10b981" />
@@ -1057,13 +1061,12 @@ const styles = StyleSheet.create({
     flex: 1,
     minHeight: 0,
   },
-  compositionArea: {
-    flex: 1,
-    minHeight: 0,
-  },
   menuScroll: {
     flex: 1,
     minHeight: 0,
+  },
+  compositionScrollContent: {
+    paddingBottom: 24,
   },
   switchRow: { flexDirection: "row", alignItems: "stretch", gap: 4, minWidth: 0 },
   /** お気に入り・成分表を店舗タブ行の左に詰めて並べる（枠ボタンは使わない） */

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -4,7 +4,6 @@ import {
   Alert,
   Image,
   Pressable,
-  RefreshControl,
   ScrollView,
   StyleSheet,
   Text,
@@ -792,13 +791,6 @@ export function TodayScreen() {
         </View>
 
         <View style={styles.bodyColumn}>
-        <ScrollView
-          style={styles.scroll}
-          contentContainerStyle={styles.scrollContent}
-          refreshControl={
-            <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-          }
-        >
           {loadError ? <Text style={styles.inlineError}>{loadError}</Text> : null}
           {snapshotError && !snapshotRestaurantId ? (
             <Text style={styles.inlineWarn}>
@@ -1028,27 +1020,33 @@ export function TodayScreen() {
             </View>
           </View>
 
-          <TodayMenuPanel
-            supabase={supabase}
-            userId={userId}
-            reloadNonce={dataNonce}
-            onAddToCart={addToCartFromItem}
-            onEditMenuItem={openMenuEditorEdit}
-            onOpenRestaurantAdd={() => setRestaurantAddOpen(true)}
-            onOpenMenuEditorAdd={openMenuEditorAdd}
-            selectRestaurantIdAfterAdd={selectRestaurantIdAfterAdd}
-            onSelectRestaurantIdAfterAddConsumed={onSelectRestaurantIdAfterAddConsumed}
-            macroTargets={{
-              protein_target_g: activeProfile.protein_target_g,
-              fat_target_g: activeProfile.fat_target_g,
-            }}
-            browseTabRequest={menuBrowseTabRequest}
-            onBrowseTabRequestConsumed={onBrowseTabRequestConsumed}
-            onPickStandardFoodForMenu={openMenuEditorFromStandardFood}
-            onToast={showToast}
-            onRestaurantDeleted={clearCartForRestaurant}
-          />
-        </ScrollView>
+          <View style={styles.menuPanelSlot}>
+            <TodayMenuPanel
+              supabase={supabase}
+              userId={userId}
+              reloadNonce={dataNonce}
+              onAddToCart={addToCartFromItem}
+              onEditMenuItem={openMenuEditorEdit}
+              onOpenRestaurantAdd={() => setRestaurantAddOpen(true)}
+              onOpenMenuEditorAdd={openMenuEditorAdd}
+              selectRestaurantIdAfterAdd={selectRestaurantIdAfterAdd}
+              onSelectRestaurantIdAfterAddConsumed={onSelectRestaurantIdAfterAddConsumed}
+              macroTargets={{
+                protein_target_g: activeProfile.protein_target_g,
+                fat_target_g: activeProfile.fat_target_g,
+              }}
+              browseTabRequest={menuBrowseTabRequest}
+              onBrowseTabRequestConsumed={onBrowseTabRequestConsumed}
+              onPickStandardFoodForMenu={openMenuEditorFromStandardFood}
+              onToast={showToast}
+              onRestaurantDeleted={clearCartForRestaurant}
+              refreshing={refreshing}
+              onRefresh={() => {
+                void onRefresh();
+              }}
+              menuBottomInset={cartExpanded ? 180 : 108}
+            />
+          </View>
 
         <TodayCartDock
           lines={cartLinesSorted}
@@ -1155,9 +1153,9 @@ const styles = StyleSheet.create({
     flex: 1,
     minHeight: 0,
   },
-  scroll: { flex: 1 },
-  scrollContent: {
-    paddingBottom: 32,
+  menuPanelSlot: {
+    flex: 1,
+    minHeight: 0,
   },
   centeredFill: {
     flex: 1,

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -1155,7 +1155,7 @@ const styles = StyleSheet.create({
   },
   menuPanelSlot: {
     flex: 1,
-    minHeight: 0,
+    minHeight: 220,
   },
   centeredFill: {
     flex: 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.59.0",
+  "version": "1.60.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## Summary
- mobile Today の外側 `ScrollView` を撤去し、ヘッダー/日付ナビ/フェーズ/PFC/記録パネルを固定領域に分離
- `TodayMenuPanel` を上部制御（モードタブ・店舗タブ・検索）固定 + メニュー行のみ縦スクロールに変更し、pull-to-refresh をメニュー領域に移設
- `TodayCartDock` 展開時でもメニュー末尾を操作しやすいよう、メニュー一覧の下余白を状態連動で調整

## Test plan
- [x] `npm run mobile:typecheck`
- [ ] iOS 実機/シミュレータで、上部固定領域がスクロールしないことを確認
- [ ] Android 実機/エミュレータで、メニュー一覧のみスクロールすることを確認
- [ ] 記録一覧展開時に、記録一覧の内部スクロールとメニュー一覧スクロールが競合しないことを確認
- [ ] カート展開時にメニュー末尾の操作が可能であることを確認

closes #310

Made with [Cursor](https://cursor.com)