### PR TITLE
feat: メニュー編集でバーコード表示と未登録時スキャン登録を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.61.0] - 2026-04-26
+
+### Changed
+
+- **Web / Mobile / Today（[#312](https://github.com/kzkski/ketolog/issues/312)）**: メニュー編集にバーコード表示を追加し、既存バーコードがあるメニューは表示専用（再スキャン不可）にした。バーコード未登録のメニューだけ編集画面からカメラ起動で初回登録でき、編集時はQR読み取りを無効化した。保存時の重複バーコードエラー文言も Web / iOS で統一した。
+
 ## [1.60.0] - 2026-04-25
 
 ### Changed

--- a/apps/mobile/components/MenuBarcodeSection.tsx
+++ b/apps/mobile/components/MenuBarcodeSection.tsx
@@ -13,6 +13,9 @@ const COLORS = {
 export type MenuBarcodeSectionProps = {
   cameraOn: boolean;
   onToggleCamera: () => void;
+  scanDisabled?: boolean;
+  scanDisabledReason?: string;
+  acceptQr?: boolean;
   scanLoading: boolean;
   scanError: string | null;
   cameraResult: { barcode: string; product_name: string } | null;
@@ -29,6 +32,9 @@ export type MenuBarcodeSectionProps = {
 export function MenuBarcodeSection({
   cameraOn,
   onToggleCamera,
+  scanDisabled = false,
+  scanDisabledReason,
+  acceptQr = true,
   scanLoading,
   scanError,
   cameraResult,
@@ -62,6 +68,7 @@ export function MenuBarcodeSection({
       onToggleCamera();
       return;
     }
+    if (scanDisabled) return;
     if (!permission?.granted) {
       const res = await requestPermission();
       if (!res.granted) {
@@ -71,13 +78,21 @@ export function MenuBarcodeSection({
     }
     handledRef.current = null;
     onToggleCamera();
-  }, [cameraOn, onToggleCamera, onRuntimeError, permission?.granted, requestPermission]);
+  }, [cameraOn, onToggleCamera, onRuntimeError, permission?.granted, requestPermission, scanDisabled]);
 
   return (
     <View style={styles.wrap}>
-      <Pressable onPress={() => void toggle()} style={styles.scanBtn}>
+      <Pressable
+        onPress={() => void toggle()}
+        disabled={scanDisabled}
+        style={[styles.scanBtn, scanDisabled && styles.scanBtnDisabled]}
+      >
         <Text style={styles.scanBtnText}>
-          {cameraOn ? "■ 読み取りを停止" : "|||  バーコード / QR を読み取り"}
+          {cameraOn
+            ? "■ 読み取りを停止"
+            : acceptQr
+              ? "|||  バーコード / QR を読み取り"
+              : "|||  バーコードを読み取り"}
         </Text>
       </Pressable>
 
@@ -86,7 +101,9 @@ export function MenuBarcodeSection({
           style={styles.camera}
           facing="back"
           barcodeScannerSettings={{
-            barcodeTypes: ["qr", "ean13", "ean8", "upc_a", "upc_e"],
+            barcodeTypes: acceptQr
+              ? ["qr", "ean13", "ean8", "upc_a", "upc_e"]
+              : ["ean13", "ean8", "upc_a", "upc_e"],
           }}
           onBarcodeScanned={({ data }) => {
             void handleBarcode(data);
@@ -112,8 +129,11 @@ export function MenuBarcodeSection({
         </Text>
       ) : null}
       {servingHint ? <Text style={styles.amberSm}>{servingHint}</Text> : null}
+      {scanDisabled && scanDisabledReason ? <Text style={styles.footnote}>{scanDisabledReason}</Text> : null}
       <Text style={styles.footnote}>
-        市販品バーコードは Open Food Facts (ODbL) を参照します。Ketolog のメニュー共有 QR も読み取れます。
+        {acceptQr
+          ? "市販品バーコードは Open Food Facts (ODbL) を参照します。Ketolog のメニュー共有 QR も読み取れます。"
+          : "市販品バーコードは Open Food Facts (ODbL) を参照します。"}
       </Text>
       {onOpenStandardFoodSearch ? (
         <Pressable onPress={onOpenStandardFoodSearch} style={styles.secondaryBtn}>
@@ -134,6 +154,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderColor: COLORS.border,
     alignItems: "center",
+  },
+  scanBtnDisabled: {
+    opacity: 0.55,
   },
   scanBtnText: { color: COLORS.text, fontSize: 14, fontWeight: "600" },
   camera: {

--- a/apps/mobile/components/MenuItemEditorModal.tsx
+++ b/apps/mobile/components/MenuItemEditorModal.tsx
@@ -152,7 +152,6 @@ export function MenuItemEditorModal({
   onRequestOpenStandardFoodComposition,
 }: Props) {
   const isEdit = state?.kind === "edit";
-  const hasLockedSharedBarcode = isEdit && Boolean(loadedEdit?.shared_barcode);
 
   const [name, setName] = useState("");
   const [protein, setProtein] = useState("");
@@ -178,6 +177,7 @@ export function MenuItemEditorModal({
   const [groupSuggestOpen, setGroupSuggestOpen] = useState(false);
 
   const [loadedEdit, setLoadedEdit] = useState<MenuRow | null>(null);
+  const hasLockedSharedBarcode = isEdit && Boolean(loadedEdit?.shared_barcode);
   const [editLoading, setEditLoading] = useState(false);
 
   const [formError, setFormError] = useState<string | null>(null);

--- a/apps/mobile/components/MenuItemEditorModal.tsx
+++ b/apps/mobile/components/MenuItemEditorModal.tsx
@@ -69,6 +69,17 @@ const COLORS = {
   danger: "#ef4444",
 };
 
+function mapMenuItemSaveError(message: string | null | undefined): string | null {
+  if (!message) return null;
+  if (
+    message.includes("menu_item_barcode_exists") ||
+    message.includes("menu_items_user_id_restaurant_id_shared_barcode_key")
+  ) {
+    return "このお店に同じバーコードのメニューがあります";
+  }
+  return message;
+}
+
 function to100g(val: string, gramsStr: string): string {
   const v = parseFloat(val);
   const g = parseFloat(gramsStr);
@@ -141,6 +152,7 @@ export function MenuItemEditorModal({
   onRequestOpenStandardFoodComposition,
 }: Props) {
   const isEdit = state?.kind === "edit";
+  const hasLockedSharedBarcode = isEdit && Boolean(loadedEdit?.shared_barcode);
 
   const [name, setName] = useState("");
   const [protein, setProtein] = useState("");
@@ -368,6 +380,16 @@ export function MenuItemEditorModal({
       setRawF(null);
       setRawC(null);
       setLogMeal(mealTypeForLog);
+      setSharedBarcode(row.shared_barcode ?? null);
+      setStandardFoodCode(row.standard_food_code ?? null);
+      setScanError(null);
+      setScanLoading(false);
+      setCameraOn(false);
+      setCameraResult(null);
+      setManualSharedProductPending(false);
+      setLastLookup(null);
+      setServingHint(null);
+      setMenuQrImportDone(null);
     })();
     return () => {
       cancelled = true;
@@ -390,8 +412,8 @@ export function MenuItemEditorModal({
       rank,
       notes: notes.trim() || null,
       group_name: groupName.trim() || null,
-      shared_barcode: isEdit ? (loadedEdit?.shared_barcode ?? null) : sharedBarcode,
-      standard_food_code: isEdit ? (loadedEdit?.standard_food_code ?? null) : standardFoodCode,
+      shared_barcode: sharedBarcode,
+      standard_food_code: standardFoodCode,
     };
   }, [
     name,
@@ -402,8 +424,6 @@ export function MenuItemEditorModal({
     rank,
     notes,
     groupName,
-    loadedEdit,
-    isEdit,
     sharedBarcode,
     standardFoodCode,
   ]);
@@ -556,6 +576,11 @@ export function MenuItemEditorModal({
         return;
       }
       if (trimmed.startsWith("{")) {
+        if (isEdit) {
+          setScanLoading(false);
+          setScanError("メニュー編集ではQR読み取りは利用できません。バーコードのみ読み取れます。");
+          return;
+        }
         const parsed = parseMenuSharePayload(trimmed);
         if (!parsed.ok) {
           setScanLoading(false);
@@ -581,6 +606,7 @@ export function MenuItemEditorModal({
     [
       applyImportRestaurantItemToForm,
       canRegisterMenu,
+      isEdit,
       lookupOffProductBarcode,
       registerRestaurants.length,
     ]
@@ -628,7 +654,7 @@ export function MenuItemEditorModal({
         "user_id",
         userId
       );
-      return { error: error?.message ?? null };
+      return { error: mapMenuItemSaveError(error?.message) ?? null };
     },
     [supabase, userId]
   );
@@ -768,8 +794,9 @@ export function MenuItemEditorModal({
 
     setBusy(false);
     if (error) {
-      setFormError(error.message);
-      onToast(`メニュー登録に失敗しました: ${error.message}`);
+      const mapped = mapMenuItemSaveError(error.message) ?? error.message;
+      setFormError(mapped);
+      onToast(`メニュー登録に失敗しました: ${mapped}`);
       return;
     }
     onToast("メニューに登録しました");
@@ -942,16 +969,33 @@ export function MenuItemEditorModal({
                 />
               </View>
 
-              {!isEdit ? (
+              <View style={styles.barcodeSection}>
+                <Text style={styles.label}>バーコード</Text>
+                {sharedBarcode ? (
+                  <Text style={styles.barcodeValue}>{sharedBarcode}</Text>
+                ) : (
+                  <Text style={styles.hint}>未登録</Text>
+                )}
                 <MenuBarcodeSection
                   cameraOn={cameraOn}
                   onToggleCamera={() => {
+                    if (hasLockedSharedBarcode) {
+                      setScanError("このメニューはバーコード登録済みのため、編集画面では再登録できません。");
+                      return;
+                    }
                     setScanError(null);
                     setCameraResult(null);
                     setServingHint(null);
                     setMenuQrImportDone(null);
                     setCameraOn((v) => !v);
                   }}
+                  scanDisabled={hasLockedSharedBarcode}
+                  scanDisabledReason={
+                    hasLockedSharedBarcode
+                      ? "このメニューはバーコード登録済みのため、再登録はできません。"
+                      : undefined
+                  }
+                  acceptQr={!isEdit}
                   scanLoading={scanLoading}
                   scanError={scanError}
                   cameraResult={
@@ -967,7 +1011,7 @@ export function MenuItemEditorModal({
                   onRuntimeError={(message) => setScanError(message)}
                   onCameraClosed={() => setCameraOn(false)}
                   onOpenStandardFoodSearch={
-                    onRequestOpenStandardFoodComposition
+                    !isEdit && onRequestOpenStandardFoodComposition
                       ? () => {
                           if (registerRestaurants.length === 0) {
                             setFormError("先にお店を追加してください。");
@@ -979,7 +1023,7 @@ export function MenuItemEditorModal({
                       : undefined
                   }
                 />
-              ) : null}
+              </View>
 
               <View style={styles.field}>
                 <View style={styles.gramsModeRow}>
@@ -1339,6 +1383,19 @@ const styles = StyleSheet.create({
   },
   scrollPad: { paddingBottom: 32 },
   field: { marginBottom: 14 },
+  barcodeSection: { marginBottom: 14 },
+  barcodeValue: {
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    borderRadius: 8,
+    backgroundColor: "#0f172a",
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    color: COLORS.text,
+    fontSize: 14,
+    fontVariant: ["tabular-nums"],
+  },
   label: {
     color: COLORS.textMuted,
     fontSize: 12,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.60.0",
+  "version": "1.61.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/app/today/_components/BarcodeScanner.tsx
+++ b/src/app/today/_components/BarcodeScanner.tsx
@@ -8,6 +8,9 @@ export type BarcodeScannerProps = {
   cameraSupported: boolean;
   cameraOn: boolean;
   onToggleScan: () => void;
+  scanDisabled?: boolean;
+  scanDisabledReason?: string;
+  acceptQr?: boolean;
   scanLoading: boolean;
   scanError: string | null;
   cameraResult: SharedProduct | null;
@@ -25,6 +28,9 @@ export function BarcodeScanner({
   cameraSupported,
   cameraOn,
   onToggleScan,
+  scanDisabled = false,
+  scanDisabledReason,
+  acceptQr = true,
   scanLoading,
   scanError,
   cameraResult,
@@ -111,7 +117,9 @@ export function BarcodeScanner({
           let detector: InstanceType<BarcodeDetectorCtor>;
           try {
             detector = new Detector({
-              formats: ["qr_code", "ean_13", "ean_8", "upc_a", "upc_e"],
+              formats: acceptQr
+                ? ["qr_code", "ean_13", "ean_8", "upc_a", "upc_e"]
+                : ["ean_13", "ean_8", "upc_a", "upc_e"],
             });
           } catch {
             detector = new Detector();
@@ -146,11 +154,11 @@ export function BarcodeScanner({
           }
           const hints = new Map<DecodeHintType, BarcodeFormat[]>();
           hints.set(DecodeHintType.POSSIBLE_FORMATS, [
-            BarcodeFormat.QR_CODE,
             BarcodeFormat.EAN_13,
             BarcodeFormat.EAN_8,
             BarcodeFormat.UPC_A,
             BarcodeFormat.UPC_E,
+            ...(acceptQr ? [BarcodeFormat.QR_CODE] : []),
           ]);
           const reader = new BrowserMultiFormatReader(hints);
           const controls = reader.scan(video, (result, _err, ctrls) => {
@@ -178,17 +186,25 @@ export function BarcodeScanner({
       stopZxing = null;
       if (stream) stream.getTracks().forEach((t) => t.stop());
     };
-  }, [cameraOn, cameraSupported, onDecoded, onRuntimeError, onCameraClosed]);
+  }, [cameraOn, cameraSupported, onDecoded, onRuntimeError, onCameraClosed, acceptQr]);
 
   return (
     <div className="space-y-2">
       <button
         type="button"
         onClick={onToggleScan}
-        className="w-full py-2.5 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm rounded-lg transition-colors inline-flex items-center justify-center gap-2"
+        disabled={scanDisabled}
+        title={scanDisabled ? scanDisabledReason : undefined}
+        className="w-full py-2.5 bg-gray-800 hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-55 text-gray-200 text-sm rounded-lg transition-colors inline-flex items-center justify-center gap-2"
       >
         <span aria-hidden="true">{cameraOn ? "■" : "|||:"}</span>
-        <span>{cameraOn ? "読み取りを停止" : "バーコード / QR を読み取り"}</span>
+        <span>
+          {cameraOn
+            ? "読み取りを停止"
+            : acceptQr
+              ? "バーコード / QR を読み取り"
+              : "バーコードを読み取り"}
+        </span>
       </button>
       {cameraOn && (
         <video
@@ -215,8 +231,13 @@ export function BarcodeScanner({
         </p>
       )}
       {servingHint && <p className="text-xs text-amber-300">{servingHint}</p>}
+      {scanDisabled && scanDisabledReason && (
+        <p className="text-xs text-gray-500">{scanDisabledReason}</p>
+      )}
       <p className="text-[11px] text-gray-500">
-        市販品バーコードは Open Food Facts (ODbL) を参照します。Ketolog のメニュー共有 QR も読み取れます。
+        {acceptQr
+          ? "市販品バーコードは Open Food Facts (ODbL) を参照します。Ketolog のメニュー共有 QR も読み取れます。"
+          : "市販品バーコードは Open Food Facts (ODbL) を参照します。"}
       </p>
       {onOpenStandardFoodSearch && (
         <button

--- a/src/app/today/_components/ItemDrawer.tsx
+++ b/src/app/today/_components/ItemDrawer.tsx
@@ -183,6 +183,7 @@ export function MenuItemDrawer({
   const groupSuggestionTriggerRef = useRef<"pointer" | "keyboard" | "unknown">("unknown");
   const notesTextareaRef = useRef<HTMLTextAreaElement>(null);
   const [isGroupSuggestionsOpen, setIsGroupSuggestionsOpen] = useState(false);
+  const hasLockedSharedBarcode = isEdit && Boolean(existing?.shared_barcode);
   const cameraSupported =
     typeof window !== "undefined" &&
     Boolean(navigator.mediaDevices?.getUserMedia) &&
@@ -390,6 +391,12 @@ export function MenuItemDrawer({
         return;
       }
       if (trimmed.startsWith("{")) {
+        if (isEdit) {
+          setCameraOn(false);
+          setScanLoading(false);
+          setScanError("メニュー編集ではQR読み取りは利用できません。バーコードのみ読み取れます。");
+          return;
+        }
         const parsed = parseMenuSharePayload(trimmed);
         if (!parsed.ok) {
           setCameraOn(false);
@@ -413,7 +420,7 @@ export function MenuItemDrawer({
       }
       await lookupOffProductBarcode(trimmed);
     },
-    [canRegisterMenu, registerDisabledReason, applyImportRestaurantItemToForm, lookupOffProductBarcode]
+    [isEdit, canRegisterMenu, registerDisabledReason, applyImportRestaurantItemToForm, lookupOffProductBarcode]
   );
 
   const closeBarcodeCamera = useCallback(() => {
@@ -425,6 +432,10 @@ export function MenuItemDrawer({
   }, []);
 
   const toggleBarcodeScan = useCallback(() => {
+    if (hasLockedSharedBarcode) {
+      setScanError("このメニューはバーコード登録済みのため、編集画面では再登録できません。");
+      return;
+    }
     if (!cameraOn && !cameraSupported) {
       setScanError(
         "この環境ではカメラを利用できません。HTTPS で開いているか、ブラウザのカメラ権限を確認してください。"
@@ -436,7 +447,7 @@ export function MenuItemDrawer({
     setServingHint(null);
     setMenuQrImportDone(null);
     setCameraOn((v) => !v);
-  }, [cameraOn, cameraSupported]);
+  }, [cameraOn, cameraSupported, hasLockedSharedBarcode]);
 
   useEffect(() => {
     if (isEdit) return;
@@ -641,11 +652,26 @@ export function MenuItemDrawer({
             />
           </div>
 
-          {!isEdit && (
+          <div className="space-y-2 rounded-lg border border-gray-800 bg-gray-950/40 px-3 py-3">
+            <p className="text-xs text-gray-400">バーコード</p>
+            {sharedBarcode ? (
+              <p className="rounded-md border border-gray-700 bg-gray-900 px-2 py-1.5 font-mono text-sm text-gray-100">
+                {sharedBarcode}
+              </p>
+            ) : (
+              <p className="text-xs text-gray-500">未登録</p>
+            )}
             <BarcodeScanner
               cameraSupported={cameraSupported}
               cameraOn={cameraOn}
               onToggleScan={toggleBarcodeScan}
+              scanDisabled={hasLockedSharedBarcode}
+              scanDisabledReason={
+                hasLockedSharedBarcode
+                  ? "このメニューはバーコード登録済みのため、再登録はできません。"
+                  : undefined
+              }
+              acceptQr={!isEdit}
               scanLoading={scanLoading}
               scanError={scanError}
               cameraResult={cameraResult}
@@ -656,9 +682,9 @@ export function MenuItemDrawer({
               onDecoded={handleDecodedScan}
               onRuntimeError={reportBarcodeRuntimeError}
               onCameraClosed={closeBarcodeCamera}
-              onOpenStandardFoodSearch={onOpenStandardFoodSearch}
+              onOpenStandardFoodSearch={!isEdit ? onOpenStandardFoodSearch : undefined}
             />
-          )}
+          </div>
 
           <div>
             <label className="block text-xs text-gray-400 mb-1">1回の量（g）</label>

--- a/src/app/today/actions/menu-item.ts
+++ b/src/app/today/actions/menu-item.ts
@@ -30,6 +30,17 @@ function isMissingColumnError(error: { message?: string } | null | undefined): b
   return msg.includes("column") && msg.includes("does not exist");
 }
 
+function mapMenuItemSaveError(message: string | null | undefined): string | null {
+  if (!message) return null;
+  if (
+    message.includes("menu_item_barcode_exists") ||
+    message.includes("menu_items_user_id_restaurant_id_shared_barcode_key")
+  ) {
+    return "このお店に同じバーコードのメニューがあります";
+  }
+  return message;
+}
+
 export type BarcodeLookupResult = {
   status: "ok" | "not_found" | "error";
   product: SharedProduct | null;
@@ -416,7 +427,7 @@ export async function updateMenuItem(
     .select()
     .single();
 
-  if (error) return { data: null, error: error.message };
+  if (error) return { data: null, error: mapMenuItemSaveError(error.message) ?? "保存に失敗しました" };
   return { data: row as MenuItem, error: null };
 }
 
@@ -447,7 +458,7 @@ export async function addMenuItem(
     .select()
     .single();
 
-  if (error) return { data: null, error: error.message };
+  if (error) return { data: null, error: mapMenuItemSaveError(error.message) ?? "追加に失敗しました" };
   return { data: row as MenuItem, error: null };
 }
 


### PR DESCRIPTION
## Summary
- Web/iOS のメニュー編集画面にバーコードセクションを追加し、既存バーコードがある場合は表示専用（再スキャン不可）に変更
- バーコード未登録のメニューだけ編集画面からカメラ起動で初回登録できるようにし、編集時のQR読み取りは無効化
- 保存時の重複バーコードエラーメッセージを Web/iOS で統一し、CHANGELOG とバージョンを更新

## Test plan
- [x] `npx eslint "src/app/today/_components/ItemDrawer.tsx" "src/app/today/_components/BarcodeScanner.tsx" "apps/mobile/components/MenuItemEditorModal.tsx" "apps/mobile/components/MenuBarcodeSection.tsx" "src/app/today/actions/menu-item.ts"`
- [ ] Web で既存バーコードありメニューを開き、バーコード表示とスキャン不可を確認
- [ ] Web でバーコード未登録メニューを開き、編集画面からバーコード登録して保存できることを確認
- [ ] Web で編集画面中にQRを読ませた際に拒否メッセージが表示されることを確認
- [ ] iOS で既存バーコードありメニューを開き、バーコード表示とスキャン不可を確認
- [ ] iOS でバーコード未登録メニューを開き、編集画面からバーコード登録して保存できることを確認
- [ ] iOS で編集画面中にQRを読ませた際に拒否メッセージが表示されることを確認

closes #312

Made with [Cursor](https://cursor.com)