### PR TITLE
feat: 分析画面に食事タイプフィルタを追加（Web/Mobile）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.62.0] - 2026-04-26
+
+### Added
+
+- **Web / Mobile / 分析（[#314](https://github.com/kzkski/ketolog/issues/314)）**: 分析画面に「すべて・朝食・昼食・夕食・間食」の食事タイプフィルタを追加し、選択タイプだけで平均PFC・日次推移・日別一覧・Top10を再集計できるようにした。期間JSONのエクスポート/共有にも選択中 `mealTypes` を含め、Webとモバイルで同じ条件を再現できるようにした。
+
 ## [1.61.0] - 2026-04-26
 
 ### Changed

--- a/apps/mobile/lib/fetch-insights-food-log-mobile.ts
+++ b/apps/mobile/lib/fetch-insights-food-log-mobile.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { InsightFoodLogEntry } from "@ketolog/domain/insights";
+import type { MealType } from "@ketolog/types";
 
 const INSIGHTS_PAGE_SIZE = 1000;
 
@@ -7,13 +8,14 @@ export async function fetchInsightsFoodLogForDateRange(
   supabase: SupabaseClient,
   userId: string,
   start: string,
-  end: string
+  end: string,
+  mealTypes?: MealType[]
 ): Promise<{ entries: InsightFoodLogEntry[]; error: string | null }> {
   const entries: InsightFoodLogEntry[] = [];
   let offset = 0;
 
   for (;;) {
-    const { data, error } = await supabase
+    let query = supabase
       .from("food_log")
       .select(
         "id, date, meal_type, eaten_at, item_name, grams, protein_g, fat_g, carbs_g, source, menu_item_id, created_at"
@@ -25,6 +27,10 @@ export async function fetchInsightsFoodLogForDateRange(
       .order("eaten_at", { ascending: true })
       .order("created_at", { ascending: true })
       .range(offset, offset + INSIGHTS_PAGE_SIZE - 1);
+    if (mealTypes && mealTypes.length > 0) {
+      query = query.in("meal_type", mealTypes);
+    }
+    const { data, error } = await query;
 
     if (error) return { entries: [], error: error.message };
 

--- a/apps/mobile/screens/InsightsScreen.tsx
+++ b/apps/mobile/screens/InsightsScreen.tsx
@@ -228,7 +228,6 @@ export function InsightsScreen() {
             <Text style={styles.closeBtnText}>閉じる</Text>
           </Pressable>
         </View>
-        <Text style={styles.sub}>JST の日付で集計します</Text>
       </View>
 
       {outboxLoaded && outboxHasUnsent ? (
@@ -546,7 +545,6 @@ const styles = StyleSheet.create({
     backgroundColor: COLORS.btnBg,
   },
   closeBtnText: { color: COLORS.text, fontSize: 13, fontWeight: "600" },
-  sub: { color: COLORS.muted, fontSize: 11, marginTop: 6 },
   outboxBanner: {
     flexDirection: "row",
     alignItems: "flex-start",

--- a/apps/mobile/screens/InsightsScreen.tsx
+++ b/apps/mobile/screens/InsightsScreen.tsx
@@ -44,10 +44,12 @@ const MEAL_LABEL_FULL: Record<MealType, string> = {
   dinner: "夕食",
   snack: "間食",
 };
+const MEAL_TYPES: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
 
 const CUSTOM_RANGE_MAX_DAYS = 90;
 
 type Preset = "7d" | "30d" | "custom";
+type MealFilter = MealType | "all";
 
 function fmtNum(v: number): string {
   return v.toFixed(1);
@@ -80,6 +82,7 @@ export function InsightsScreen() {
   const preset7 = useMemo(() => getPresetRange(today, 7), [today]);
 
   const [preset, setPreset] = useState<Preset>("7d");
+  const [mealFilter, setMealFilter] = useState<MealFilter>("all");
   const [start, setStart] = useState(preset7.start);
   const [end, setEnd] = useState(preset7.end);
   const [entries, setEntries] = useState<InsightFoodLogEntry[]>([]);
@@ -91,15 +94,22 @@ export function InsightsScreen() {
   const [outboxHasUnsent, setOutboxHasUnsent] = useState(false);
 
   const loadRange = useCallback(
-    async (nextStart: string, nextEnd: string, nextPreset: Preset) => {
+    async (
+      nextStart: string,
+      nextEnd: string,
+      nextPreset: Preset,
+      nextMealFilter: MealFilter = mealFilter
+    ) => {
       if (!userId) return;
       setLoading(true);
       setError(null);
+      const mealTypes = nextMealFilter === "all" ? undefined : [nextMealFilter];
       const result = await fetchInsightsFoodLogForDateRange(
         supabase,
         userId,
         nextStart,
-        nextEnd
+        nextEnd,
+        mealTypes
       );
       setLoading(false);
       if (result.error) {
@@ -107,12 +117,13 @@ export function InsightsScreen() {
         return;
       }
       setPreset(nextPreset);
+      setMealFilter(nextMealFilter);
       setStart(nextStart);
       setEnd(nextEnd);
       setEntries(result.entries);
       setExpanded(new Set());
     },
-    [supabase, userId]
+    [supabase, userId, mealFilter]
   );
 
   useEffect(() => {
@@ -130,13 +141,6 @@ export function InsightsScreen() {
     setOutboxLoaded(true);
   }, [userId]);
 
-  useEffect(() => {
-    if (!userId) {
-      setOutboxLoaded(false);
-      setOutboxHasUnsent(false);
-    }
-  }, [userId]);
-
   useFocusEffect(
     useCallback(() => {
       if (!userId) return;
@@ -145,8 +149,11 @@ export function InsightsScreen() {
   );
 
   const insight = useMemo(
-    () => buildInsights(entries, start, end),
-    [entries, start, end]
+    () =>
+      buildInsights(entries, start, end, {
+        mealTypes: mealFilter === "all" ? undefined : [mealFilter],
+      }),
+    [entries, start, end, mealFilter]
   );
   const avgTotal =
     insight.summary.avgProtein + insight.summary.avgFat + insight.summary.avgCarbs;
@@ -167,7 +174,12 @@ export function InsightsScreen() {
     const payload = {
       kind: "ketolog_insights_export",
       version: 1,
-      period: { start, end, preset },
+      period: {
+        start,
+        end,
+        preset,
+        mealTypes: mealFilter === "all" ? [...MEAL_TYPES] : [mealFilter],
+      },
       exportedAt: new Date().toISOString(),
       entries,
     };
@@ -279,6 +291,53 @@ export function InsightsScreen() {
           </View>
           <Text style={styles.hint}>カスタムは最大{CUSTOM_RANGE_MAX_DAYS}日</Text>
           {shareErr ? <Text style={styles.errSmall}>{shareErr}</Text> : null}
+          <View style={styles.mealFilterRow}>
+            <Pressable
+              onPress={() => {
+                void loadRange(start, end, preset, "all");
+              }}
+              disabled={loading}
+              style={({ pressed }) => [
+                styles.mealFilterBtn,
+                mealFilter === "all" && styles.mealFilterBtnOn,
+                pressed && { opacity: 0.85 },
+                loading && { opacity: 0.5 },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.mealFilterBtnText,
+                  mealFilter === "all" && styles.mealFilterBtnTextOn,
+                ]}
+              >
+                すべて
+              </Text>
+            </Pressable>
+            {MEAL_TYPES.map((mealType) => (
+              <Pressable
+                key={mealType}
+                onPress={() => {
+                  void loadRange(start, end, preset, mealType);
+                }}
+                disabled={loading}
+                style={({ pressed }) => [
+                  styles.mealFilterBtn,
+                  mealFilter === mealType && styles.mealFilterBtnOn,
+                  pressed && { opacity: 0.85 },
+                  loading && { opacity: 0.5 },
+                ]}
+              >
+                <Text
+                  style={[
+                    styles.mealFilterBtnText,
+                    mealFilter === mealType && styles.mealFilterBtnTextOn,
+                  ]}
+                >
+                  {MEAL_LABEL_FULL[mealType]}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
 
           <View style={styles.dateRow}>
             <View style={styles.dateField}>
@@ -530,6 +589,27 @@ const styles = StyleSheet.create({
   },
   shareBtnText: { color: COLORS.text, fontSize: 13, fontWeight: "600" },
   hint: { color: COLORS.muted, fontSize: 10, marginTop: 8 },
+  mealFilterRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+    marginTop: 10,
+    alignItems: "center",
+  },
+  mealFilterBtn: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: COLORS.btnBg,
+  },
+  mealFilterBtnOn: {
+    borderColor: COLORS.accent,
+    backgroundColor: COLORS.accent,
+  },
+  mealFilterBtnText: { color: COLORS.text, fontSize: 12, fontWeight: "600" },
+  mealFilterBtnTextOn: { color: "#fff" },
   errSmall: { color: COLORS.err, fontSize: 11, marginTop: 6 },
   dateRow: { flexDirection: "row", gap: 8, marginTop: 12, alignItems: "flex-end" },
   dateField: { flex: 1, minWidth: 0 },

--- a/apps/mobile/screens/InsightsScreen.tsx
+++ b/apps/mobile/screens/InsightsScreen.tsx
@@ -45,6 +45,12 @@ const MEAL_LABEL_FULL: Record<MealType, string> = {
   snack: "間食",
 };
 const MEAL_TYPES: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
+const MEAL_FILTER_ON: Record<MealType, { borderColor: string; backgroundColor: string }> = {
+  breakfast: { borderColor: "#fb7185", backgroundColor: "rgba(244, 63, 94, 0.22)" },
+  lunch: { borderColor: "#38bdf8", backgroundColor: "rgba(14, 165, 233, 0.22)" },
+  dinner: { borderColor: "#a78bfa", backgroundColor: "rgba(139, 92, 246, 0.22)" },
+  snack: { borderColor: "#2dd4bf", backgroundColor: "rgba(20, 184, 166, 0.22)" },
+};
 
 const CUSTOM_RANGE_MAX_DAYS = 90;
 
@@ -322,7 +328,7 @@ export function InsightsScreen() {
                 disabled={loading}
                 style={({ pressed }) => [
                   styles.mealFilterBtn,
-                  mealFilter === mealType && styles.mealFilterBtnOn,
+                  mealFilter === mealType && MEAL_FILTER_ON[mealType],
                   pressed && { opacity: 0.85 },
                   loading && { opacity: 0.5 },
                 ]}
@@ -330,7 +336,7 @@ export function InsightsScreen() {
                 <Text
                   style={[
                     styles.mealFilterBtnText,
-                    mealFilter === mealType && styles.mealFilterBtnTextOn,
+                    mealFilter === mealType && { color: MEAL_FILTER_ON[mealType].borderColor },
                   ]}
                 >
                   {MEAL_LABEL_FULL[mealType]}
@@ -591,18 +597,21 @@ const styles = StyleSheet.create({
   hint: { color: COLORS.muted, fontSize: 10, marginTop: 8 },
   mealFilterRow: {
     flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 8,
+    flexWrap: "nowrap",
+    gap: 6,
     marginTop: 10,
     alignItems: "center",
   },
   mealFilterBtn: {
-    paddingHorizontal: 10,
+    flex: 1,
+    minWidth: 0,
+    paddingHorizontal: 6,
     paddingVertical: 6,
-    borderRadius: 999,
+    borderRadius: 8,
     borderWidth: 1,
     borderColor: COLORS.border,
     backgroundColor: COLORS.btnBg,
+    alignItems: "center",
   },
   mealFilterBtnOn: {
     borderColor: COLORS.accent,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.61.0",
+  "version": "1.62.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/src/insights.test.ts
+++ b/packages/domain/src/insights.test.ts
@@ -54,4 +54,49 @@ describe("buildInsights", () => {
     expect(insight.chart).toHaveLength(1);
     expect(insight.chart[0]!.protein).toBeCloseTo(15);
   });
+
+  it("filters entries by selected meal types", () => {
+    const insight = buildInsights(
+      [
+        {
+          id: "1",
+          date: "2026-04-20",
+          meal_type: "breakfast",
+          eaten_at: "2026-04-20T08:00:00Z",
+          item_name: "ヨーグルト",
+          grams: 100,
+          protein_g: 4,
+          fat_g: 3,
+          carbs_g: 6,
+          source: "manual",
+          menu_item_id: null,
+          created_at: "2026-04-20T08:00:01Z",
+        },
+        {
+          id: "2",
+          date: "2026-04-20",
+          meal_type: "dinner",
+          eaten_at: "2026-04-20T18:00:00Z",
+          item_name: "鶏むね肉",
+          grams: 150,
+          protein_g: 30,
+          fat_g: 4,
+          carbs_g: 0,
+          source: "manual",
+          menu_item_id: null,
+          created_at: "2026-04-20T18:00:01Z",
+        },
+      ],
+      "2026-04-20",
+      "2026-04-20",
+      { mealTypes: ["breakfast"] }
+    );
+    expect(insight.summary.avgProtein).toBeCloseTo(4);
+    expect(insight.summary.avgFat).toBeCloseTo(3);
+    expect(insight.summary.avgCarbs).toBeCloseTo(6);
+    expect(insight.daily[0]!.entries).toHaveLength(1);
+    expect(insight.daily[0]!.entries[0]!.meal_type).toBe("breakfast");
+    expect(insight.top10).toHaveLength(1);
+    expect(insight.top10[0]!.label).toBe("ヨーグルト");
+  });
 });

--- a/packages/domain/src/insights.ts
+++ b/packages/domain/src/insights.ts
@@ -1,5 +1,6 @@
 import { addDaysJst, eachDate, toJstDateString } from "./date";
 import { sumPfc } from "./pfc";
+import type { MealType } from "@ketolog/types";
 
 export { addDaysJst };
 
@@ -54,7 +55,8 @@ function toNum(v: number | null): number {
 export function buildInsights(
   entries: InsightFoodLogEntry[],
   start: string,
-  end: string
+  end: string,
+  options?: { mealTypes?: MealType[] }
 ): {
   daily: DailyInsight[];
   summary: { avgProtein: number; avgFat: number; avgCarbs: number };
@@ -62,12 +64,16 @@ export function buildInsights(
   chart: Array<{ date: string; protein: number; fat: number; carbs: number }>;
 } {
   const days = eachDate(start, end);
+  const mealTypeSet =
+    options?.mealTypes && options.mealTypes.length > 0 ? new Set(options.mealTypes) : null;
+  const filteredEntries =
+    mealTypeSet == null ? entries : entries.filter((entry) => mealTypeSet.has(entry.meal_type as MealType));
   const byDate = new Map<string, DailyInsight>();
   for (const day of days) {
     byDate.set(day, { date: day, protein: 0, fat: 0, carbs: 0, entries: [] });
   }
 
-  for (const entry of entries) {
+  for (const entry of filteredEntries) {
     const bucket = byDate.get(entry.date);
     if (!bucket) continue;
     const merged = sumPfc(
@@ -101,7 +107,7 @@ export function buildInsights(
   const sumCarbs = periodTotals.c;
 
   const topMap = new Map<string, TopItem>();
-  for (const entry of entries) {
+  for (const entry of filteredEntries) {
     const key = entry.menu_item_id
       ? `menu:${entry.menu_item_id}`
       : `name:${normalizeName(entry.item_name)}`;

--- a/src/app/insights/InsightsClient.tsx
+++ b/src/app/insights/InsightsClient.tsx
@@ -10,7 +10,7 @@ import {
   type InsightFoodLogEntry,
 } from "@/lib/insights";
 import { getInsightsFoodLogForDateRange } from "./actions";
-import { MEAL_LABELS } from "@/lib/constants/meal";
+import { MEAL_LABELS, MEAL_TYPES } from "@/lib/constants/meal";
 import type { MealType } from "@ketolog/types";
 
 const InsightsChart = dynamic(() => import("./InsightsChart"), {
@@ -21,6 +21,7 @@ const InsightsChart = dynamic(() => import("./InsightsChart"), {
 const CUSTOM_RANGE_MAX_DAYS = 90;
 
 type Preset = "7d" | "30d" | "custom";
+type MealFilter = MealType | "all";
 
 function fmtNum(v: number): string {
   return v.toFixed(1);
@@ -55,20 +56,34 @@ export default function InsightsClient({
   const [start, setStart] = useState(preset7.start);
   const [end, setEnd] = useState(preset7.end);
   const [entries, setEntries] = useState(initialEntries);
+  const [mealFilter, setMealFilter] = useState<MealFilter>("all");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const selectedMealTypes = useMemo(
+    () => (mealFilter === "all" ? undefined : [mealFilter]),
+    [mealFilter]
+  );
 
-  const insight = useMemo(() => buildInsights(entries, start, end), [entries, start, end]);
+  const insight = useMemo(
+    () => buildInsights(entries, start, end, { mealTypes: selectedMealTypes }),
+    [entries, start, end, selectedMealTypes]
+  );
   const avgTotal = insight.summary.avgProtein + insight.summary.avgFat + insight.summary.avgCarbs;
   const avgProteinPct = avgTotal > 0 ? (insight.summary.avgProtein / avgTotal) * 100 : 0;
   const avgFatPct = avgTotal > 0 ? (insight.summary.avgFat / avgTotal) * 100 : 0;
   const avgCarbsPct = avgTotal > 0 ? (insight.summary.avgCarbs / avgTotal) * 100 : 0;
 
-  async function loadRange(nextStart: string, nextEnd: string, nextPreset: Preset) {
+  async function loadRange(
+    nextStart: string,
+    nextEnd: string,
+    nextPreset: Preset,
+    nextMealFilter: MealFilter = mealFilter
+  ) {
     setLoading(true);
     setError(null);
-    const result = await getInsightsFoodLogForDateRange(nextStart, nextEnd);
+    const mealTypes = nextMealFilter === "all" ? undefined : [nextMealFilter];
+    const result = await getInsightsFoodLogForDateRange(nextStart, nextEnd, mealTypes);
     setLoading(false);
     if (result.error) {
       setError(result.error);
@@ -77,6 +92,7 @@ export default function InsightsClient({
     setPreset(nextPreset);
     setStart(nextStart);
     setEnd(nextEnd);
+    setMealFilter(nextMealFilter);
     setEntries(result.entries);
     setExpanded(new Set());
   }
@@ -102,7 +118,7 @@ export default function InsightsClient({
     const payload = {
       kind: "ketolog_insights_export",
       version: 1,
-      period: { start, end, preset },
+      period: { start, end, preset, mealTypes: selectedMealTypes ?? [...MEAL_TYPES] },
       exportedAt: new Date().toISOString(),
       entries,
     };
@@ -166,6 +182,35 @@ export default function InsightsClient({
             >
               DL
             </button>
+          </div>
+          <div className="flex min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto [-webkit-overflow-scrolling:touch] sm:flex-wrap sm:overflow-visible">
+            <button
+              type="button"
+              onClick={() => void loadRange(start, end, preset, "all")}
+              disabled={loading}
+              className={`shrink-0 rounded-lg border px-2.5 py-1.5 text-xs transition-colors sm:px-3 sm:py-2 sm:text-sm ${
+                mealFilter === "all"
+                  ? "border-emerald-500 bg-emerald-600 text-white"
+                  : "border-gray-700 bg-gray-800 text-gray-200 hover:bg-gray-700"
+              }`}
+            >
+              すべて
+            </button>
+            {MEAL_TYPES.map((mealType) => (
+              <button
+                key={mealType}
+                type="button"
+                onClick={() => void loadRange(start, end, preset, mealType)}
+                disabled={loading}
+                className={`shrink-0 rounded-lg border px-2.5 py-1.5 text-xs transition-colors sm:px-3 sm:py-2 sm:text-sm ${
+                  mealFilter === mealType
+                    ? "border-emerald-500 bg-emerald-600 text-white"
+                    : "border-gray-700 bg-gray-800 text-gray-200 hover:bg-gray-700"
+                }`}
+              >
+                {MEAL_LABELS[mealType]}
+              </button>
+            ))}
           </div>
 
           <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_minmax(0,1fr)_auto] items-end gap-2">

--- a/src/app/insights/InsightsClient.tsx
+++ b/src/app/insights/InsightsClient.tsx
@@ -10,7 +10,7 @@ import {
   type InsightFoodLogEntry,
 } from "@/lib/insights";
 import { getInsightsFoodLogForDateRange } from "./actions";
-import { MEAL_LABELS, MEAL_TYPES } from "@/lib/constants/meal";
+import { MEAL_LABELS, MEAL_TAB_STYLES, MEAL_TYPES } from "@/lib/constants/meal";
 import type { MealType } from "@ketolog/types";
 
 const InsightsChart = dynamic(() => import("./InsightsChart"), {
@@ -42,6 +42,21 @@ function jstDateLabel(date: string): string {
 
 function toIsoNow() {
   return new Date().toISOString().replace(/[:.]/g, "-");
+}
+
+function mealFilterButtonClass(mealFilter: MealFilter, target: MealFilter): string {
+  const base =
+    "w-full rounded-lg border px-1 py-1.5 text-center text-[11px] font-medium transition-colors sm:px-2 sm:py-2 sm:text-sm";
+  if (target === "all") {
+    return mealFilter === "all"
+      ? `${base} border-emerald-500 bg-emerald-600 text-white`
+      : `${base} border-gray-700 bg-gray-800 text-gray-200 hover:bg-gray-700`;
+  }
+  if (mealFilter === target) {
+    const style = MEAL_TAB_STYLES[target];
+    return `${base} ${style.row} ${style.label}`;
+  }
+  return `${base} border-gray-700 bg-gray-800 text-gray-200 hover:bg-gray-700`;
 }
 
 export default function InsightsClient({
@@ -183,16 +198,12 @@ export default function InsightsClient({
               DL
             </button>
           </div>
-          <div className="flex min-w-0 flex-nowrap items-center gap-1.5 overflow-x-auto [-webkit-overflow-scrolling:touch] sm:flex-wrap sm:overflow-visible">
+          <div className="grid grid-cols-5 gap-1.5 sm:gap-2">
             <button
               type="button"
               onClick={() => void loadRange(start, end, preset, "all")}
               disabled={loading}
-              className={`shrink-0 rounded-lg border px-2.5 py-1.5 text-xs transition-colors sm:px-3 sm:py-2 sm:text-sm ${
-                mealFilter === "all"
-                  ? "border-emerald-500 bg-emerald-600 text-white"
-                  : "border-gray-700 bg-gray-800 text-gray-200 hover:bg-gray-700"
-              }`}
+              className={mealFilterButtonClass(mealFilter, "all")}
             >
               すべて
             </button>
@@ -202,11 +213,7 @@ export default function InsightsClient({
                 type="button"
                 onClick={() => void loadRange(start, end, preset, mealType)}
                 disabled={loading}
-                className={`shrink-0 rounded-lg border px-2.5 py-1.5 text-xs transition-colors sm:px-3 sm:py-2 sm:text-sm ${
-                  mealFilter === mealType
-                    ? "border-emerald-500 bg-emerald-600 text-white"
-                    : "border-gray-700 bg-gray-800 text-gray-200 hover:bg-gray-700"
-                }`}
+                className={mealFilterButtonClass(mealFilter, mealType)}
               >
                 {MEAL_LABELS[mealType]}
               </button>

--- a/src/app/insights/actions.ts
+++ b/src/app/insights/actions.ts
@@ -2,12 +2,14 @@
 
 import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import type { InsightFoodLogEntry } from "@/lib/insights";
+import type { MealType } from "@ketolog/types";
 
 const INSIGHTS_PAGE_SIZE = 1000;
 
 export async function getInsightsFoodLogForDateRange(
   start: string,
-  end: string
+  end: string,
+  mealTypes?: MealType[]
 ): Promise<{ entries: InsightFoodLogEntry[]; error: string | null }> {
   const { supabase, user } = await getSupabaseAuthForRequest();
   if (!user) return { entries: [], error: "認証が必要です" };
@@ -16,7 +18,7 @@ export async function getInsightsFoodLogForDateRange(
   let offset = 0;
 
   for (;;) {
-    const { data, error } = await supabase
+    let query = supabase
       .from("food_log")
       .select(
         "id, date, meal_type, eaten_at, item_name, grams, protein_g, fat_g, carbs_g, source, menu_item_id, created_at"
@@ -28,6 +30,10 @@ export async function getInsightsFoodLogForDateRange(
       .order("eaten_at", { ascending: true })
       .order("created_at", { ascending: true })
       .range(offset, offset + INSIGHTS_PAGE_SIZE - 1);
+    if (mealTypes && mealTypes.length > 0) {
+      query = query.in("meal_type", mealTypes);
+    }
+    const { data, error } = await query;
 
     if (error) return { entries: [], error: error.message };
 


### PR DESCRIPTION
## Summary
- 分析画面（Web/Mobile）に「すべて・朝食・昼食・夕食・間食」フィルタを追加し、期間（7日/30日/カスタム）と組み合わせて再集計できるようにしました。
- `food_log` 取得クエリに `meal_type` 条件を追加し、選択タイプのみをDB側で抽出するようにしました。
- 共有ドメイン `buildInsights` に `mealTypes` オプションを追加し、平均PFC・日次推移・日別一覧・Top10 を同一条件で集計するよう統一しました。
- 期間JSONのエクスポート/共有に選択中 `mealTypes` を含め、条件再現性を上げました。
- `packages/domain/src/insights.test.ts` に meal filter のユニットテストを追加しました。
- `CHANGELOG.md` を更新し、`package.json` を `1.62.0` に更新しました。

## Test plan
- [x] `npm run lint -- "packages/domain/src/insights.ts" "packages/domain/src/insights.test.ts" "src/app/insights/actions.ts" "src/app/insights/InsightsClient.tsx" "apps/mobile/lib/fetch-insights-food-log-mobile.ts" "apps/mobile/screens/InsightsScreen.tsx"`
- [x] `npm run test`
- [ ] Web `/insights` で食事タイプ切替時に平均PFC・日次推移・日別一覧・Top10が同時更新されることを手動確認
- [ ] Mobile 分析画面で同様に同時更新されることを手動確認
- [ ] 期間JSON（DL/共有）に `mealTypes` が含まれることを手動確認

closes #314

Made with [Cursor](https://cursor.com)