### PR TITLE
chore: CIのnpm ciをリトライ対応

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,15 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && exit 0
+            echo "npm ci failed (attempt $i/3); retrying..."
+            rm -rf node_modules
+            sleep 5
+          done
+          echo "npm ci failed after 3 attempts"
+          exit 1
 
       - name: Run unit tests
         run: npm test

--- a/.github/workflows/mobile-ci.yml
+++ b/.github/workflows/mobile-ci.yml
@@ -29,7 +29,15 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies (workspaces)
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && exit 0
+            echo "npm ci failed (attempt $i/3); retrying..."
+            rm -rf node_modules
+            sleep 5
+          done
+          echo "npm ci failed after 3 attempts"
+          exit 1
 
       - name: Run mobile typecheck
         run: npm run mobile:typecheck

--- a/.github/workflows/mobile-ios-testflight-release.yml
+++ b/.github/workflows/mobile-ios-testflight-release.yml
@@ -39,7 +39,15 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: |
+          for i in 1 2 3; do
+            npm ci && exit 0
+            echo "npm ci failed (attempt $i/3); retrying..."
+            rm -rf node_modules
+            sleep 5
+          done
+          echo "npm ci failed after 3 attempts"
+          exit 1
 
       - name: Verify Expo auth
         run: npx --yes eas-cli whoami


### PR DESCRIPTION
## Summary
- `npm ci` 実行時に `supabase` の postinstall で発生する一時的なダウンロード/展開失敗（`incorrect header check`）の影響を緩和するため、依存インストールを最大3回まで再試行するようにしました。
- 対象は `CI` / `Mobile CI` / `Mobile iOS TestFlight Release` の3ワークフローです。
- 各リトライ前に `node_modules` を削除し、壊れた中間状態の再利用を避けます。

## Test plan
- [x] ワークフローYAML変更の差分確認
- [ ] PR上でCIが通ることを確認

## Notes
- 共有された deprecated 警告（`inflight`, `glob`, `rimraf` など）は今回の失敗原因ではなく、直接の失敗原因は Supabase CLI のアーカイブ展開失敗です。

Made with [Cursor](https://cursor.com)