### PR TITLE
fix: shared_products serving と手動バーコードの編集保存（#317 #318）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.62.1] - 2026-04-27
+
+### Fixed
+
+- **Web / Mobile / 共有商品（[#317](https://github.com/kzkski/ketolog/issues/317) / [#318](https://github.com/kzkski/ketolog/issues/318)）**: Open Food Facts の `fields` に `serving_size` を含め、`shared_products` の serving 列に反映されるようにした。手動登録（OFF 未ヒット）ではフォームの「1回の量 (g)」を `shared_products` の serving へ引き渡す。既存メニュー編集で同条件下にバーコードを付けて保存するとき、先に `shared_products` を作ってから `menu_items` を更新する RPC を追加し、外部キー違反で失敗しなくした。
+
 ## [1.62.0] - 2026-04-26
 
 ### Added

--- a/apps/mobile/components/MenuItemEditorModal.tsx
+++ b/apps/mobile/components/MenuItemEditorModal.tsx
@@ -12,6 +12,7 @@ import {
   View,
 } from "react-native";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { manualSharedProductServingFromDefaultGrams } from "@ketolog/domain/manual-shared-product-serving";
 import { pfcGramsFromNullablePer100 } from "@ketolog/domain/pfc";
 import type { MealType } from "@ketolog/types";
 import {
@@ -677,6 +678,96 @@ export function MenuItemEditorModal({
     }
 
     if (state.kind === "edit") {
+      if (manualSharedProductPending && sharedBarcode) {
+        const trimmedName = data.name.trim();
+        if (!trimmedName) {
+          setBusy(false);
+          setFormError("名前を入力してください");
+          return;
+        }
+        if (data.standard_food_code) {
+          setBusy(false);
+          setFormError("標準成分表とバーコードの同時指定はできません");
+          return;
+        }
+        const rankVal = data.rank;
+        if (!Number.isFinite(rankVal) || rankVal < 1 || rankVal > 4) {
+          setBusy(false);
+          setFormError("ランクの値が不正です");
+          return;
+        }
+        const { data: current, error: fetchErr } = await supabase
+          .from("menu_items")
+          .select("restaurant_id, group_name, group_order")
+          .eq("id", state.menuItemId)
+          .eq("user_id", userId)
+          .maybeSingle();
+        if (fetchErr || !current) {
+          setBusy(false);
+          const err = fetchErr?.message ?? "メニューが見つかりません";
+          setFormError(err);
+          onToast(`保存に失敗しました: ${err}`);
+          return;
+        }
+        const prevGroupName =
+          current.group_name == null ? null : String(current.group_name).trim() || null;
+        const nextGroupName = data.group_name?.trim() || null;
+        const groupOrder =
+          prevGroupName === nextGroupName
+            ? (typeof current.group_order === "number" ? current.group_order : 0)
+            : await resolveMenuItemGroupOrder(
+                supabase,
+                userId,
+                current.restaurant_id as string,
+                nextGroupName
+              );
+        const notesRpc = data.notes?.trim() || MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES;
+        const serving = manualSharedProductServingFromDefaultGrams(data.default_grams);
+        const { error: rpcError } = await supabase.rpc(
+          "update_menu_item_with_manual_shared_product",
+          {
+            p_menu_item_id: state.menuItemId,
+            p_barcode: sharedBarcode,
+            p_shared_product_name: trimmedName,
+            p_shared_brand: null,
+            p_shared_protein: data.protein_per_100g,
+            p_shared_fat: data.fat_per_100g,
+            p_shared_carbs: data.carbs_per_100g,
+            p_shared_serving_size: serving.serving_size,
+            p_shared_serving_size_grams: serving.serving_size_grams,
+            p_menu_name: trimmedName,
+            p_menu_protein: data.protein_per_100g,
+            p_menu_fat: data.fat_per_100g,
+            p_menu_carbs: data.carbs_per_100g,
+            p_default_grams: data.default_grams,
+            p_rank: rankVal,
+            p_notes: notesRpc,
+            p_group_name: nextGroupName,
+            p_group_order: groupOrder,
+          }
+        );
+        setBusy(false);
+        if (rpcError) {
+          const msg = rpcError.message ?? "";
+          if (msg.includes("menu_item_barcode_exists")) {
+            setFormError("このお店に同じバーコードのメニューがあります");
+            onToast("このお店に同じバーコードのメニューがあります");
+            return;
+          }
+          if (msg.includes("menu not found")) {
+            setFormError("メニューが見つかりません");
+            return;
+          }
+          setFormError(msg);
+          onToast(`保存に失敗しました: ${msg}`);
+          return;
+        }
+        onToast("保存しました");
+        onClose();
+        await onSaved();
+        return;
+      }
+
       const { error } = await applyMenuUpdate(state.menuItemId, data);
       setBusy(false);
       if (error) {
@@ -727,6 +818,7 @@ export function MenuItemEditorModal({
         return;
       }
       const notesRpc = data.notes?.trim() || MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES;
+      const addServing = manualSharedProductServingFromDefaultGrams(data.default_grams);
       const { data: menuId, error: rpcError } = await supabase.rpc(
         "add_menu_item_with_manual_shared_product",
         {
@@ -737,8 +829,8 @@ export function MenuItemEditorModal({
           p_shared_protein: data.protein_per_100g,
           p_shared_fat: data.fat_per_100g,
           p_shared_carbs: data.carbs_per_100g,
-          p_shared_serving_size: null,
-          p_shared_serving_size_grams: null,
+          p_shared_serving_size: addServing.serving_size,
+          p_shared_serving_size_grams: addServing.serving_size_grams,
           p_menu_name: trimmedName,
           p_menu_protein: data.protein_per_100g,
           p_menu_fat: data.fat_per_100g,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.62.0",
+  "version": "1.62.1",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -11,6 +11,7 @@
     "./meal-timezone": "./src/meal-timezone.ts",
     "./open-food-facts": "./src/open-food-facts.ts",
     "./shared-product-source": "./src/shared-product-source.ts",
+    "./manual-shared-product-serving": "./src/manual-shared-product-serving.ts",
     "./standard-food-meta": "./src/standard-food-meta.ts",
     "./menu-share-qr": "./src/menu-share-qr.ts",
     "./restaurant-json-v1": "./src/restaurant-json-v1.ts",

--- a/packages/domain/src/manual-shared-product-serving.test.ts
+++ b/packages/domain/src/manual-shared-product-serving.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { manualSharedProductServingFromDefaultGrams } from "./manual-shared-product-serving";
+
+describe("manualSharedProductServingFromDefaultGrams", () => {
+  it("maps positive grams to label and numeric grams", () => {
+    expect(manualSharedProductServingFromDefaultGrams(150)).toEqual({
+      serving_size: "150g",
+      serving_size_grams: 150,
+    });
+  });
+
+  it("returns nulls for non-positive or non-finite", () => {
+    expect(manualSharedProductServingFromDefaultGrams(0)).toEqual({
+      serving_size: null,
+      serving_size_grams: null,
+    });
+    expect(manualSharedProductServingFromDefaultGrams(NaN)).toEqual({
+      serving_size: null,
+      serving_size_grams: null,
+    });
+  });
+});

--- a/packages/domain/src/manual-shared-product-serving.ts
+++ b/packages/domain/src/manual-shared-product-serving.ts
@@ -1,0 +1,13 @@
+/**
+ * 手動 shared_products 行: メニュー「1回の量 (g)」を serving 列へ反映（Issue #317）。
+ */
+export function manualSharedProductServingFromDefaultGrams(defaultGrams: number): {
+  serving_size: string | null;
+  serving_size_grams: number | null;
+} {
+  if (!Number.isFinite(defaultGrams) || defaultGrams <= 0) {
+    return { serving_size: null, serving_size_grams: null };
+  }
+  const label = defaultGrams % 1 === 0 ? String(defaultGrams) : String(defaultGrams);
+  return { serving_size: `${label}g`, serving_size_grams: defaultGrams };
+}

--- a/packages/domain/src/open-food-facts.test.ts
+++ b/packages/domain/src/open-food-facts.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { normalizeBarcode } from "./open-food-facts";
+import { describe, expect, it, vi } from "vitest";
+import { fetchOpenFoodFactsProduct, normalizeBarcode } from "./open-food-facts";
 
 describe("normalizeBarcode", () => {
   it("strips non-digits", () => {
@@ -8,5 +8,44 @@ describe("normalizeBarcode", () => {
 
   it("returns empty when no digits", () => {
     expect(normalizeBarcode("abc")).toBe("");
+  });
+});
+
+describe("fetchOpenFoodFactsProduct", () => {
+  it("requests serving_size in fields and maps nutriments + serving to product", async () => {
+    const mockJson = {
+      status: 1,
+      product: {
+        product_name:  "Protein bar",
+        brands:        "B",
+        serving_size:  "30 g",
+        nutriments:    {
+          proteins_100g:        20,
+          fat_100g:              10,
+          carbohydrates_100g:   15,
+        },
+      },
+    };
+    const fetchImpl = vi.fn((input: RequestInfo | URL) => {
+      const reqUrl = String(input);
+      expect(reqUrl).toContain("serving_size");
+      expect(reqUrl).toContain("4000000000");
+      return Promise.resolve({
+        ok:   true,
+        json: () => Promise.resolve(mockJson),
+      } as Response);
+    });
+    vi.stubGlobal("fetch", fetchImpl);
+
+    try {
+      const p = await fetchOpenFoodFactsProduct("4000000000", { userAgent: "Ketolog/test" });
+      expect(p).not.toBeNull();
+      expect(p!.product_name).toBe("Protein bar");
+      expect(p!.serving_size).toBe("30 g");
+      expect(p!.serving_size_grams).toBe(30);
+      expect(p!.protein_per_100g).toBe(20);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 });

--- a/packages/domain/src/open-food-facts.ts
+++ b/packages/domain/src/open-food-facts.ts
@@ -45,7 +45,7 @@ export async function fetchOpenFoodFactsProduct(
   options?: { apiBase?: string; userAgent?: string }
 ): Promise<OpenFoodFactsProduct | null> {
   const base = (options?.apiBase ?? DEFAULT_OFF_API_BASE).replace(/\/$/, "");
-  const url = `${base}/api/v2/product/${barcode}.json?fields=code,product_name,brands,nutriments`;
+  const url = `${base}/api/v2/product/${barcode}.json?fields=code,product_name,brands,nutriments,serving_size`;
   const res = await fetch(url, {
     method: "GET",
     headers: { "User-Agent": options?.userAgent ?? getDefaultOffUserAgent("dev") },

--- a/src/app/today/_components/ItemDrawer.tsx
+++ b/src/app/today/_components/ItemDrawer.tsx
@@ -17,6 +17,7 @@ import {
   deleteMenuItem,
   lookupSharedProductByBarcode,
   updateMenuItem,
+  updateMenuItemWithManualSharedProduct,
   type MenuItemUpdate,
 } from "../actions/menu-item";
 import { saveMealToLog, type SaveItem } from "../actions/food-log";
@@ -537,7 +538,10 @@ export function MenuItemDrawer({
     const data = buildMenuPayload();
 
     if (isEdit && existing) {
-      const result = await updateMenuItem(existing.id, data);
+      const result =
+        manualSharedProductPending && sharedBarcode
+          ? await updateMenuItemWithManualSharedProduct(existing.id, sharedBarcode, data)
+          : await updateMenuItem(existing.id, data);
       if (result.error || !result.data) {
         setError(result.error ?? "保存に失敗しました");
         setSaving(false);

--- a/src/app/today/actions/menu-item.ts
+++ b/src/app/today/actions/menu-item.ts
@@ -9,6 +9,7 @@ import {
   normalizeBarcode,
 } from "@ketolog/domain/open-food-facts";
 import { STANDARD_FOOD_SEARCH_PAGE_SIZE } from "@ketolog/domain/standard-food-meta";
+import { manualSharedProductServingFromDefaultGrams } from "@ketolog/domain/manual-shared-product-serving";
 import {
   MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES,
   SHARED_PRODUCT_SOURCE_MANUAL_ENTRY,
@@ -266,6 +267,7 @@ export async function addMenuItemWithManualSharedProduct(
   );
 
   const notes = data.notes?.trim() || MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES;
+  const serving = manualSharedProductServingFromDefaultGrams(data.default_grams);
 
   const { data: menuId, error: rpcError } = await supabase.rpc(
     "add_menu_item_with_manual_shared_product",
@@ -277,8 +279,8 @@ export async function addMenuItemWithManualSharedProduct(
       p_shared_protein: data.protein_per_100g,
       p_shared_fat: data.fat_per_100g,
       p_shared_carbs: data.carbs_per_100g,
-      p_shared_serving_size: null,
-      p_shared_serving_size_grams: null,
+      p_shared_serving_size: serving.serving_size,
+      p_shared_serving_size_grams: serving.serving_size_grams,
       p_menu_name: trimmedName,
       p_menu_protein: data.protein_per_100g,
       p_menu_fat: data.fat_per_100g,
@@ -313,6 +315,109 @@ export async function addMenuItemWithManualSharedProduct(
 
   if (fetchErr || !row) {
     return { data: null, error: fetchErr?.message ?? "メニューの取得に失敗しました" };
+  }
+  return { data: row as MenuItem, error: null };
+}
+
+/**
+ * 既存メニューに OFF 未ヒットのバーコードを手入力で付与するとき、
+ * `shared_products` を先に作ってから `menu_items` を更新（Issue #318）。
+ */
+export async function updateMenuItemWithManualSharedProduct(
+  menuItemId: string,
+  barcodeRaw: string,
+  data: MenuItemUpdate
+): Promise<{ data: MenuItem | null; error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { data: null, error: "認証が必要です" };
+
+  const barcode = normalizeBarcode(barcodeRaw);
+  if (!barcode) return { data: null, error: "バーコードが不正です" };
+
+  const trimmedName = data.name.trim();
+  if (!trimmedName) return { data: null, error: "名前を入力してください" };
+
+  if (data.standard_food_code) {
+    return { data: null, error: "標準成分表とバーコードの同時指定はできません" };
+  }
+
+  const rank = data.rank;
+  if (!Number.isFinite(rank) || rank < 1 || rank > 4) {
+    return { data: null, error: "ランクの値が不正です" };
+  }
+
+  const { data: current, error: fetchErr } = await supabase
+    .from("menu_items")
+    .select("restaurant_id, group_name, group_order")
+    .eq("id", menuItemId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (fetchErr || !current) {
+    return { data: null, error: fetchErr?.message ?? "メニューが見つかりません" };
+  }
+
+  const prevGroupName = current.group_name?.trim() || null;
+  const nextGroupName = data.group_name?.trim() || null;
+  const groupOrder =
+    prevGroupName === nextGroupName
+      ? (typeof current.group_order === "number" ? current.group_order : 0)
+      : await resolveMenuItemGroupOrder(
+          supabase,
+          user.id,
+          current.restaurant_id as string,
+          nextGroupName
+        );
+
+  const notes = data.notes?.trim() || MANUAL_SHARED_PRODUCT_DEFAULT_MENU_NOTES;
+  const serving = manualSharedProductServingFromDefaultGrams(data.default_grams);
+
+  const { data: outId, error: rpcError } = await supabase.rpc(
+    "update_menu_item_with_manual_shared_product",
+    {
+      p_menu_item_id: menuItemId,
+      p_barcode: barcode,
+      p_shared_product_name: trimmedName,
+      p_shared_brand: null,
+      p_shared_protein: data.protein_per_100g,
+      p_shared_fat: data.fat_per_100g,
+      p_shared_carbs: data.carbs_per_100g,
+      p_shared_serving_size: serving.serving_size,
+      p_shared_serving_size_grams: serving.serving_size_grams,
+      p_menu_name: trimmedName,
+      p_menu_protein: data.protein_per_100g,
+      p_menu_fat: data.fat_per_100g,
+      p_menu_carbs: data.carbs_per_100g,
+      p_default_grams: data.default_grams,
+      p_rank: rank,
+      p_notes: notes,
+      p_group_name: nextGroupName,
+      p_group_order: groupOrder,
+    }
+  );
+
+  if (rpcError) {
+    const msg = rpcError.message ?? "";
+    if (msg.includes("menu_item_barcode_exists")) {
+      return { data: null, error: "このお店に同じバーコードのメニューがあります" };
+    }
+    if (msg.includes("menu not found") || msg.includes("restaurant not found")) {
+      return { data: null, error: "メニューが見つかりません" };
+    }
+    return { data: null, error: msg };
+  }
+
+  if (!outId) return { data: null, error: "保存に失敗しました" };
+
+  const { data: row, error: afterErr } = await supabase
+    .from("menu_items")
+    .select("*")
+    .eq("id", menuItemId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (afterErr || !row) {
+    return { data: null, error: afterErr?.message ?? "メニューの取得に失敗しました" };
   }
   return { data: row as MenuItem, error: null };
 }

--- a/supabase/migrations/20260427120000_update_menu_item_manual_shared_product_rpc.sql
+++ b/supabase/migrations/20260427120000_update_menu_item_manual_shared_product_rpc.sql
@@ -1,0 +1,129 @@
+-- Issue #318: existing menu edit with OFF-miss + manual shared product (FK menu_items → shared_products).
+
+CREATE OR REPLACE FUNCTION public.update_menu_item_with_manual_shared_product(
+  p_menu_item_id uuid,
+  p_barcode text,
+  p_shared_product_name text,
+  p_shared_brand text,
+  p_shared_protein numeric,
+  p_shared_fat numeric,
+  p_shared_carbs numeric,
+  p_shared_serving_size text,
+  p_shared_serving_size_grams numeric,
+  p_menu_name text,
+  p_menu_protein numeric,
+  p_menu_fat numeric,
+  p_menu_carbs numeric,
+  p_default_grams numeric,
+  p_rank smallint,
+  p_notes text,
+  p_group_name text,
+  p_group_order integer
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $fn$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_restaurant_id uuid;
+BEGIN
+  IF v_uid IS NULL THEN
+    RAISE EXCEPTION 'update_menu_item_manual_shared: not authenticated';
+  END IF;
+
+  IF p_menu_item_id IS NULL THEN
+    RAISE EXCEPTION 'update_menu_item_manual_shared: missing menu item';
+  END IF;
+
+  SELECT mi.restaurant_id
+  INTO v_restaurant_id
+  FROM public.menu_items mi
+  WHERE mi.id = p_menu_item_id AND mi.user_id = v_uid
+  FOR UPDATE;
+
+  IF v_restaurant_id IS NULL THEN
+    RAISE EXCEPTION 'update_menu_item_manual_shared: menu not found';
+  END IF;
+
+  IF p_barcode IS NULL OR btrim(p_barcode) = '' THEN
+    RAISE EXCEPTION 'update_menu_item_manual_shared: invalid barcode';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.menu_items mi
+    WHERE mi.user_id = v_uid
+      AND mi.restaurant_id = v_restaurant_id
+      AND mi.shared_barcode = btrim(p_barcode)
+      AND mi.id <> p_menu_item_id
+  ) THEN
+    RAISE EXCEPTION 'update_menu_item_manual_shared: menu_item_barcode_exists';
+  END IF;
+
+  INSERT INTO public.shared_products (
+    barcode,
+    product_name,
+    brand,
+    protein_per_100g,
+    fat_per_100g,
+    carbs_per_100g,
+    serving_size,
+    serving_size_grams,
+    source,
+    raw_json,
+    last_checked_at,
+    created_by,
+    created_at,
+    updated_at
+  )
+  VALUES (
+    btrim(p_barcode),
+    p_shared_product_name,
+    NULLIF(btrim(COALESCE(p_shared_brand, '')), ''),
+    p_shared_protein,
+    p_shared_fat,
+    p_shared_carbs,
+    NULLIF(btrim(COALESCE(p_shared_serving_size, '')), ''),
+    p_shared_serving_size_grams,
+    'manual_entry',
+    NULL,
+    now(),
+    v_uid,
+    now(),
+    now(),
+    now()
+  )
+  ON CONFLICT (barcode) DO NOTHING;
+
+  UPDATE public.menu_items
+  SET
+    name = p_menu_name,
+    protein_per_100g = p_menu_protein,
+    fat_per_100g = p_menu_fat,
+    carbs_per_100g = p_menu_carbs,
+    default_grams = p_default_grams,
+    rank = p_rank,
+    notes = p_notes,
+    group_name = NULLIF(btrim(COALESCE(p_group_name, '')), ''),
+    group_order = p_group_order,
+    shared_barcode = btrim(p_barcode),
+    standard_food_code = NULL
+  WHERE id = p_menu_item_id
+    AND user_id = v_uid;
+
+  RETURN p_menu_item_id;
+END;
+$fn$;
+
+COMMENT ON FUNCTION public.update_menu_item_with_manual_shared_product IS
+  'Issue #318: OFF 未ヒットの手動登録で既存 menu_items を更新する前に shared_products 行を確保（同一トランザクション）。';
+
+REVOKE ALL ON FUNCTION public.update_menu_item_with_manual_shared_product(
+  uuid, text, text, text, numeric, numeric, numeric, text, numeric,
+  text, numeric, numeric, numeric, numeric, smallint, text, text, integer
+) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.update_menu_item_with_manual_shared_product(
+  uuid, text, text, text, numeric, numeric, numeric, text, numeric,
+  text, numeric, numeric, numeric, numeric, smallint, text, text, integer
+) TO authenticated;


### PR DESCRIPTION
## 概要

- **#317**: Open Food Facts の `fields` に `serving_size` を含め、`fetchOpenFoodFactsProduct` で serving を埋める。手動登録（OFF 未ヒット）ではフォームの「1回の量 (g)」を RPC 経由で `shared_products` の serving 列へ渡す（`@ketolog/domain/manual-shared-product-serving`）。
- **#318**: 既存メニュー編集で `manualSharedProductPending` かつバーコードありのとき、`update_menu_item_with_manual_shared_product` RPC で `shared_products` を先に作成してから `menu_items` を更新（Web: `updateMenuItemWithManualSharedProduct`、Mobile: 同 RPC）。

## 確認

- `npm test`
- `npm run build`
- `npm run mobile:typecheck`

## デプロイ注意

Supabase にマイグレーション `20260427120000_update_menu_item_manual_shared_product_rpc.sql` の適用が必要です。

closes #317
closes #318

Made with [Cursor](https://cursor.com)