### PR TITLE
fix(mobile): グループ候補と展開カートのスクロール不具合を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### Fixed
 
 - **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。
-- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。加えて `TodayScreen` 側の `menuPanelSlot` の `minHeight` を 0 にして、展開カート表示時にメニュー領域が縮まずフッターが画面外へ押し出されるレイアウトを解消した。モバイル / Web ともにカート上部の重複情報（「〜に記録」「PFC サマリ」「記録する食事」ラベル）を整理し、一覧表示領域を優先した。
+- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。加えて `TodayScreen` 側の `menuPanelSlot` の `minHeight` を 0 にして、展開カート表示時にメニュー領域が縮まずフッターが画面外へ押し出されるレイアウトを解消した。モバイル / Web ともにカート上部の重複情報（「〜に記録」「PFC サマリ」「記録する食事」ラベル）を整理し、一覧表示領域を優先した。あわせてヘッダー右上に「全削除」を追加し、カート内容を一括で空にできるようにした。
 
 ## [1.62.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### Fixed
 
 - **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。
-- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。加えて `TodayScreen` 側の `menuPanelSlot` の `minHeight` を 0 にして、展開カート表示時にメニュー領域が縮まずフッターが画面外へ押し出されるレイアウトを解消した。モバイル / Web ともにカート上部の重複情報（「〜に記録」「PFC サマリ」「記録する食事」ラベル）を整理し、一覧表示領域を優先した。あわせてヘッダー右上に「全削除」を追加し、カート内容を一括で空にできるようにした。
+- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。加えて `TodayScreen` 側の `menuPanelSlot` の `minHeight` を 0 にして、展開カート表示時にメニュー領域が縮まずフッターが画面外へ押し出されるレイアウトを解消した。モバイル / Web ともにカート上部の重複情報（「〜に記録」「PFC サマリ」「記録する食事」ラベル）を整理し、一覧表示領域を優先した。あわせてヘッダー右上に「空にする」を追加し、カート内容を一括で空にできるようにした。
 
 ## [1.62.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### Fixed
 
 - **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。
-- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。
+- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。加えて `TodayScreen` 側の `menuPanelSlot` の `minHeight` を 0 にして、展開カート表示時にメニュー領域が縮まずフッターが画面外へ押し出されるレイアウトを解消した。
 
 ## [1.62.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### Fixed
 
 - **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。
-- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。
+- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。
 
 ## [1.62.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### Fixed
 
 - **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。
-- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。加えて `TodayScreen` 側の `menuPanelSlot` の `minHeight` を 0 にして、展開カート表示時にメニュー領域が縮まずフッターが画面外へ押し出されるレイアウトを解消した。
+- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。加えて `TodayScreen` 側の `menuPanelSlot` の `minHeight` を 0 にして、展開カート表示時にメニュー領域が縮まずフッターが画面外へ押し出されるレイアウトを解消した。モバイル / Web ともにカート上部の重複情報（「〜に記録」「PFC サマリ」「記録する食事」ラベル）を整理し、一覧表示領域を優先した。
 
 ## [1.62.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,13 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.62.2] - 2026-04-27
+
+### Fixed
+
+- **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。
+- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。
+
 ## [1.62.1] - 2026-04-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 ### Fixed
 
 - **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。
-- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。
+- **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。
 
 ## [1.62.1] - 2026-04-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Fixed
 
-- **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。
+- **Mobile / Today（[#319](https://github.com/kzkski/ketolog/issues/319)）**: メニュー追加モーダルのグループ名候補を内側 `ScrollView` で縦スクロールできるようにし、候補ボックスを `overflow: hidden` でクリップしてメモ欄との重なり表示を防いだ。候補ドロップダウンの最大高さも拡張し（モバイル 280px / Web `max-h-64`）、一度に見える候補件数を増やした。
 - **Mobile / Today（[#320](https://github.com/kzkski/ketolog/issues/320)）**: 展開カートに画面高ベースの `maxHeight` を導入し、行一覧のみを `flex` + `ScrollView` でスクロールする構造へ変更。小さい画面でも下部の「記録する」ボタンへ到達しやすくした。空カート時の早期 return の後に `useMemo` を置いていたため初回投入で「Rendered more hooks than during the previous render.」になる不具合を修正した（フック呼び出し順を一定にした）。展開パネルに固定高がない状態で行一覧に `flex: 1` を使っていたため一覧の高さが 0 になり行が見えない問題を、行 `ScrollView` に画面高に応じた明示 `maxHeight` を与える形に改めた。加えて `TodayScreen` 側の `menuPanelSlot` の `minHeight` を 0 にして、展開カート表示時にメニュー領域が縮まずフッターが画面外へ押し出されるレイアウトを解消した。モバイル / Web ともにカート上部の重複情報（「〜に記録」「PFC サマリ」「記録する食事」ラベル）を整理し、一覧表示領域を優先した。あわせてヘッダー右上に「空にする」を追加し、カート内容を一括で空にできるようにした。
 
 ## [1.62.1] - 2026-04-27

--- a/apps/mobile/components/MenuItemEditorModal.tsx
+++ b/apps/mobile/components/MenuItemEditorModal.tsx
@@ -1598,7 +1598,7 @@ const styles = StyleSheet.create({
   candidateBtnText: { color: COLORS.text, fontSize: 12 },
   suggestBox: {
     marginTop: 8,
-    maxHeight: 176,
+    maxHeight: 280,
     borderWidth: 1,
     borderColor: COLORS.border,
     borderRadius: 8,
@@ -1606,7 +1606,7 @@ const styles = StyleSheet.create({
     overflow: "hidden",
   },
   suggestScroll: {
-    maxHeight: 176,
+    maxHeight: 280,
   },
   suggestRow: { paddingHorizontal: 12, paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: COLORS.border },
   suggestRowText: { color: COLORS.text, fontSize: 14 },

--- a/apps/mobile/components/MenuItemEditorModal.tsx
+++ b/apps/mobile/components/MenuItemEditorModal.tsx
@@ -1227,18 +1227,24 @@ export function MenuItemEditorModal({
                 </View>
                 {existingGroupNames.length > 0 && groupSuggestOpen ? (
                   <View style={styles.suggestBox}>
-                    {existingGroupNames.map((g) => (
-                      <Pressable
-                        key={g}
-                        onPress={() => {
-                          setGroupName(g);
-                          setGroupSuggestOpen(false);
-                        }}
-                        style={styles.suggestRow}
-                      >
-                        <Text style={styles.suggestRowText}>{g}</Text>
-                      </Pressable>
-                    ))}
+                    <ScrollView
+                      style={styles.suggestScroll}
+                      keyboardShouldPersistTaps="handled"
+                      nestedScrollEnabled
+                    >
+                      {existingGroupNames.map((g) => (
+                        <Pressable
+                          key={g}
+                          onPress={() => {
+                            setGroupName(g);
+                            setGroupSuggestOpen(false);
+                          }}
+                          style={styles.suggestRow}
+                        >
+                          <Text style={styles.suggestRowText}>{g}</Text>
+                        </Pressable>
+                      ))}
+                    </ScrollView>
                   </View>
                 ) : null}
               </View>
@@ -1597,6 +1603,10 @@ const styles = StyleSheet.create({
     borderColor: COLORS.border,
     borderRadius: 8,
     backgroundColor: "#0f172a",
+    overflow: "hidden",
+  },
+  suggestScroll: {
+    maxHeight: 176,
   },
   suggestRow: { paddingHorizontal: 12, paddingVertical: 10, borderBottomWidth: 1, borderBottomColor: COLORS.border },
   suggestRowText: { color: COLORS.text, fontSize: 14 },

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -110,6 +110,11 @@ export function TodayCartDock({
     () => Math.max(250, Math.min(420, Math.floor(windowHeight * 0.52))),
     [windowHeight]
   );
+  /** `expanded` に固定高がないと `flex:1` だけの領域は 0 高になる。行一覧は明示 maxHeight で確保する */
+  const lineListMaxHeight = useMemo(
+    () => Math.max(160, Math.min(320, Math.floor(windowHeight * 0.36))),
+    [windowHeight]
+  );
 
   if (lines.length === 0) return null;
 
@@ -164,52 +169,54 @@ export function TodayCartDock({
             })}
           </View>
 
-          <View style={styles.lineArea}>
-            <ScrollView style={styles.lineScroll} keyboardShouldPersistTaps="handled" nestedScrollEnabled>
-              {lines.map((line) => {
-                const totalGrams = line.gramsPerServing * line.count;
-                const v = pfcGramsFromNullablePer100(
-                  line.protein_per_100g,
-                  line.fat_per_100g,
-                  line.carbs_per_100g,
-                  totalGrams
-                );
-                return (
-                  <View key={line.menuItemId} style={styles.lineRow}>
-                    <View style={styles.lineBody}>
-                      <Text style={styles.lineName} numberOfLines={2}>
-                        {line.name}
-                        <Text style={styles.countGrams}>
-                          {" "}
-                          ×{line.count}（{totalGrams}g）
-                        </Text>
+          <ScrollView
+            style={[styles.lineScroll, { maxHeight: lineListMaxHeight }]}
+            keyboardShouldPersistTaps="handled"
+            nestedScrollEnabled
+          >
+            {lines.map((line) => {
+              const totalGrams = line.gramsPerServing * line.count;
+              const v = pfcGramsFromNullablePer100(
+                line.protein_per_100g,
+                line.fat_per_100g,
+                line.carbs_per_100g,
+                totalGrams
+              );
+              return (
+                <View key={line.menuItemId} style={styles.lineRow}>
+                  <View style={styles.lineBody}>
+                    <Text style={styles.lineName} numberOfLines={2}>
+                      {line.name}
+                      <Text style={styles.countGrams}>
+                        {" "}
+                        ×{line.count}（{totalGrams}g）
                       </Text>
-                      <Text style={styles.linePfc}>
-                        P{fmtMacroGrams(v.p)} F{fmtMacroGrams(v.f)} C{fmtMacroGrams(v.c)}
-                      </Text>
-                    </View>
-                    <View style={styles.gramsCol}>
-                      <Text style={styles.gramsLabel}>1回</Text>
-                      <CartGramsEditor
-                        grams={line.gramsPerServing}
-                        disabled={saving}
-                        onCommit={(n) => onUpdateGramsPerServing(line.menuItemId, n)}
-                      />
-                    </View>
-                    <Pressable
-                      onPress={() => onRemoveLine(line.menuItemId)}
-                      disabled={saving}
-                      hitSlop={8}
-                      style={({ pressed }) => [styles.removeBtn, pressed && { opacity: 0.75 }]}
-                      accessibilityLabel="カートから外す"
-                    >
-                      <Text style={styles.removeBtnText}>×</Text>
-                    </Pressable>
+                    </Text>
+                    <Text style={styles.linePfc}>
+                      P{fmtMacroGrams(v.p)} F{fmtMacroGrams(v.f)} C{fmtMacroGrams(v.c)}
+                    </Text>
                   </View>
-                );
-              })}
-            </ScrollView>
-          </View>
+                  <View style={styles.gramsCol}>
+                    <Text style={styles.gramsLabel}>1回</Text>
+                    <CartGramsEditor
+                      grams={line.gramsPerServing}
+                      disabled={saving}
+                      onCommit={(n) => onUpdateGramsPerServing(line.menuItemId, n)}
+                    />
+                  </View>
+                  <Pressable
+                    onPress={() => onRemoveLine(line.menuItemId)}
+                    disabled={saving}
+                    hitSlop={8}
+                    style={({ pressed }) => [styles.removeBtn, pressed && { opacity: 0.75 }]}
+                    accessibilityLabel="カートから外す"
+                  >
+                    <Text style={styles.removeBtnText}>×</Text>
+                  </Pressable>
+                </View>
+              );
+            })}
+          </ScrollView>
 
           <View style={styles.footerRow}>
             <Text style={styles.totalPfc} numberOfLines={2}>
@@ -297,8 +304,7 @@ const styles = StyleSheet.create({
   },
   mealChipText: { fontSize: 11, fontWeight: "700" },
   mealChipTextOff: { color: "#6b7280" },
-  lineArea: { flex: 1, minHeight: 0, marginBottom: 8 },
-  lineScroll: { flex: 1 },
+  lineScroll: { marginBottom: 8 },
   lineRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -148,7 +148,7 @@ export function TodayCartDock({
             style={({ pressed }) => [styles.clearBtn, (pressed || saving) && { opacity: 0.75 }]}
             accessibilityLabel="カートを空にする"
           >
-            <Text style={styles.clearBtnText}>空にする</Text>
+            <Text style={styles.clearBtnText}>🗑 空にする</Text>
           </Pressable>
           <Pressable
             onPress={onToggleExpanded}

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -135,17 +135,12 @@ export function TodayCartDock({
       >
         <View style={styles.headerMain}>
           <Text style={styles.headerTitle}>カート（{nItems}）</Text>
-          <Text style={styles.headerSub}>
-            {CART_MEAL_LABEL[mealType]}に記録 · P{fmtMacroGrams(cartPfc.p)} F{fmtMacroGrams(cartPfc.f)}{" "}
-            C{fmtMacroGrams(cartPfc.c)}
-          </Text>
         </View>
         <Text style={styles.chev}>{expanded ? "▼" : "▲"}</Text>
       </Pressable>
 
       {expanded ? (
         <View style={[styles.expanded, { maxHeight: expandedMaxHeight }]}>
-          <Text style={styles.mealLabel}>記録する食事</Text>
           <View style={styles.mealRow}>
             {CART_MEAL_ORDER.map((m) => {
               const on = mealType === m;
@@ -262,12 +257,6 @@ const styles = StyleSheet.create({
     fontSize: 16,
     fontWeight: "700",
   },
-  headerSub: {
-    color: "#9ca3af",
-    fontSize: 11,
-    marginTop: 3,
-    lineHeight: 15,
-  },
   chev: { color: "#6b7280", fontSize: 14, paddingLeft: 4 },
   expanded: {
     paddingHorizontal: 12,
@@ -276,18 +265,12 @@ const styles = StyleSheet.create({
     borderTopColor: "#1f2937",
     overflow: "hidden",
   },
-  mealLabel: {
-    color: "#6b7280",
-    fontSize: 10,
-    fontWeight: "600",
-    marginTop: 8,
-    marginBottom: 6,
-  },
   mealRow: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 6,
-    marginBottom: 10,
+    marginTop: 8,
+    marginBottom: 8,
   },
   mealChip: {
     flex: 1,

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -148,7 +148,7 @@ export function TodayCartDock({
             style={({ pressed }) => [styles.clearBtn, (pressed || saving) && { opacity: 0.75 }]}
             accessibilityLabel="カートを空にする"
           >
-            <Text style={styles.clearBtnText}>全削除</Text>
+            <Text style={styles.clearBtnText}>空にする</Text>
           </Pressable>
           <Pressable
             onPress={onToggleExpanded}

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ActivityIndicator,
   Pressable,
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   Text,
   TextInput,
+  useWindowDimensions,
   View,
 } from "react-native";
 import type { MealType } from "@ketolog/types";
@@ -104,10 +105,15 @@ export function TodayCartDock({
   onRemoveLine,
   onUpdateGramsPerServing,
 }: Props) {
+  const { height: windowHeight } = useWindowDimensions();
   if (lines.length === 0) return null;
 
   const nItems = lines.reduce((s, l) => s + l.count, 0);
   const shell = CART_MEAL_CHIP_ACTIVE[mealType];
+  const expandedMaxHeight = useMemo(
+    () => Math.max(250, Math.min(420, Math.floor(windowHeight * 0.52))),
+    [windowHeight]
+  );
 
   return (
     <View
@@ -132,7 +138,7 @@ export function TodayCartDock({
       </Pressable>
 
       {expanded ? (
-        <View style={styles.expanded}>
+        <View style={[styles.expanded, { maxHeight: expandedMaxHeight }]}>
           <Text style={styles.mealLabel}>記録する食事</Text>
           <View style={styles.mealRow}>
             {CART_MEAL_ORDER.map((m) => {
@@ -157,50 +163,52 @@ export function TodayCartDock({
             })}
           </View>
 
-          <ScrollView style={styles.lineScroll} keyboardShouldPersistTaps="handled" nestedScrollEnabled>
-            {lines.map((line) => {
-              const totalGrams = line.gramsPerServing * line.count;
-              const v = pfcGramsFromNullablePer100(
-                line.protein_per_100g,
-                line.fat_per_100g,
-                line.carbs_per_100g,
-                totalGrams
-              );
-              return (
-                <View key={line.menuItemId} style={styles.lineRow}>
-                  <View style={styles.lineBody}>
-                    <Text style={styles.lineName} numberOfLines={2}>
-                      {line.name}
-                      <Text style={styles.countGrams}>
-                        {" "}
-                        ×{line.count}（{totalGrams}g）
+          <View style={styles.lineArea}>
+            <ScrollView style={styles.lineScroll} keyboardShouldPersistTaps="handled" nestedScrollEnabled>
+              {lines.map((line) => {
+                const totalGrams = line.gramsPerServing * line.count;
+                const v = pfcGramsFromNullablePer100(
+                  line.protein_per_100g,
+                  line.fat_per_100g,
+                  line.carbs_per_100g,
+                  totalGrams
+                );
+                return (
+                  <View key={line.menuItemId} style={styles.lineRow}>
+                    <View style={styles.lineBody}>
+                      <Text style={styles.lineName} numberOfLines={2}>
+                        {line.name}
+                        <Text style={styles.countGrams}>
+                          {" "}
+                          ×{line.count}（{totalGrams}g）
+                        </Text>
                       </Text>
-                    </Text>
-                    <Text style={styles.linePfc}>
-                      P{fmtMacroGrams(v.p)} F{fmtMacroGrams(v.f)} C{fmtMacroGrams(v.c)}
-                    </Text>
-                  </View>
-                  <View style={styles.gramsCol}>
-                    <Text style={styles.gramsLabel}>1回</Text>
-                    <CartGramsEditor
-                      grams={line.gramsPerServing}
+                      <Text style={styles.linePfc}>
+                        P{fmtMacroGrams(v.p)} F{fmtMacroGrams(v.f)} C{fmtMacroGrams(v.c)}
+                      </Text>
+                    </View>
+                    <View style={styles.gramsCol}>
+                      <Text style={styles.gramsLabel}>1回</Text>
+                      <CartGramsEditor
+                        grams={line.gramsPerServing}
+                        disabled={saving}
+                        onCommit={(n) => onUpdateGramsPerServing(line.menuItemId, n)}
+                      />
+                    </View>
+                    <Pressable
+                      onPress={() => onRemoveLine(line.menuItemId)}
                       disabled={saving}
-                      onCommit={(n) => onUpdateGramsPerServing(line.menuItemId, n)}
-                    />
+                      hitSlop={8}
+                      style={({ pressed }) => [styles.removeBtn, pressed && { opacity: 0.75 }]}
+                      accessibilityLabel="カートから外す"
+                    >
+                      <Text style={styles.removeBtnText}>×</Text>
+                    </Pressable>
                   </View>
-                  <Pressable
-                    onPress={() => onRemoveLine(line.menuItemId)}
-                    disabled={saving}
-                    hitSlop={8}
-                    style={({ pressed }) => [styles.removeBtn, pressed && { opacity: 0.75 }]}
-                    accessibilityLabel="カートから外す"
-                  >
-                    <Text style={styles.removeBtnText}>×</Text>
-                  </Pressable>
-                </View>
-              );
-            })}
-          </ScrollView>
+                );
+              })}
+            </ScrollView>
+          </View>
 
           <View style={styles.footerRow}>
             <Text style={styles.totalPfc} numberOfLines={2}>
@@ -258,6 +266,7 @@ const styles = StyleSheet.create({
     paddingBottom: 8,
     borderTopWidth: StyleSheet.hairlineWidth,
     borderTopColor: "#1f2937",
+    overflow: "hidden",
   },
   mealLabel: {
     color: "#6b7280",
@@ -287,7 +296,8 @@ const styles = StyleSheet.create({
   },
   mealChipText: { fontSize: 11, fontWeight: "700" },
   mealChipTextOff: { color: "#6b7280" },
-  lineScroll: { maxHeight: 200, marginBottom: 8 },
+  lineArea: { flex: 1, minHeight: 0, marginBottom: 8 },
+  lineScroll: { flex: 1 },
   lineRow: {
     flexDirection: "row",
     alignItems: "center",

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -89,6 +89,7 @@ type Props = {
   onMealType: (m: MealType) => void;
   saving: boolean;
   onSave: () => void;
+  onClearAll: () => void;
   onRemoveLine: (menuItemId: string) => void;
   onUpdateGramsPerServing: (menuItemId: string, grams: number) => void;
 };
@@ -102,6 +103,7 @@ export function TodayCartDock({
   onMealType,
   saving,
   onSave,
+  onClearAll,
   onRemoveLine,
   onUpdateGramsPerServing,
 }: Props) {
@@ -129,15 +131,35 @@ export function TodayCartDock({
       ]}
       accessibilityLabel="カート"
     >
-      <Pressable
-        onPress={onToggleExpanded}
-        style={({ pressed }) => [styles.headerBar, pressed && { opacity: 0.88 }]}
-      >
-        <View style={styles.headerMain}>
-          <Text style={styles.headerTitle}>カート（{nItems}）</Text>
+      <View style={styles.headerBar}>
+        <Pressable
+          onPress={onToggleExpanded}
+          style={({ pressed }) => [styles.headerMainTap, pressed && { opacity: 0.88 }]}
+        >
+          <View style={styles.headerMain}>
+            <Text style={styles.headerTitle}>カート（{nItems}）</Text>
+          </View>
+        </Pressable>
+        <View style={styles.headerActions}>
+          <Pressable
+            onPress={onClearAll}
+            disabled={saving}
+            hitSlop={8}
+            style={({ pressed }) => [styles.clearBtn, (pressed || saving) && { opacity: 0.75 }]}
+            accessibilityLabel="カートを空にする"
+          >
+            <Text style={styles.clearBtnText}>全削除</Text>
+          </Pressable>
+          <Pressable
+            onPress={onToggleExpanded}
+            hitSlop={8}
+            style={({ pressed }) => [styles.chevBtn, pressed && { opacity: 0.75 }]}
+            accessibilityLabel={expanded ? "カートを閉じる" : "カートを開く"}
+          >
+            <Text style={styles.chev}>{expanded ? "▼" : "▲"}</Text>
+          </Pressable>
         </View>
-        <Text style={styles.chev}>{expanded ? "▼" : "▲"}</Text>
-      </Pressable>
+      </View>
 
       {expanded ? (
         <View style={[styles.expanded, { maxHeight: expandedMaxHeight }]}>
@@ -247,16 +269,29 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
-    paddingHorizontal: 14,
-    paddingVertical: 10,
+    paddingLeft: 14,
+    paddingRight: 10,
+    paddingVertical: 8,
     minHeight: 48,
   },
+  headerMainTap: { flex: 1, minWidth: 0, paddingVertical: 2 },
   headerMain: { flex: 1, minWidth: 0, paddingRight: 8 },
   headerTitle: {
     color: "#f9fafb",
     fontSize: 16,
     fontWeight: "700",
   },
+  headerActions: { flexDirection: "row", alignItems: "center", gap: 4 },
+  clearBtn: {
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#374151",
+    backgroundColor: "rgba(17, 24, 39, 0.7)",
+  },
+  clearBtnText: { color: "#d1d5db", fontSize: 11, fontWeight: "600" },
+  chevBtn: { paddingHorizontal: 6, paddingVertical: 6, borderRadius: 8 },
   chev: { color: "#6b7280", fontSize: 14, paddingLeft: 4 },
   expanded: {
     paddingHorizontal: 12,

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -107,12 +107,12 @@ export function TodayCartDock({
 }: Props) {
   const { height: windowHeight } = useWindowDimensions();
   const expandedMaxHeight = useMemo(
-    () => Math.max(250, Math.min(420, Math.floor(windowHeight * 0.52))),
+    () => Math.max(220, Math.min(360, Math.floor(windowHeight * 0.44))),
     [windowHeight]
   );
   /** `expanded` に固定高がないと `flex:1` だけの領域は 0 高になる。行一覧は明示 maxHeight で確保する */
   const lineListMaxHeight = useMemo(
-    () => Math.max(160, Math.min(320, Math.floor(windowHeight * 0.36))),
+    () => Math.max(120, Math.min(220, Math.floor(windowHeight * 0.26))),
     [windowHeight]
   );
 

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -106,14 +106,15 @@ export function TodayCartDock({
   onUpdateGramsPerServing,
 }: Props) {
   const { height: windowHeight } = useWindowDimensions();
-  if (lines.length === 0) return null;
-
-  const nItems = lines.reduce((s, l) => s + l.count, 0);
-  const shell = CART_MEAL_CHIP_ACTIVE[mealType];
   const expandedMaxHeight = useMemo(
     () => Math.max(250, Math.min(420, Math.floor(windowHeight * 0.52))),
     [windowHeight]
   );
+
+  if (lines.length === 0) return null;
+
+  const nItems = lines.reduce((s, l) => s + l.count, 0);
+  const shell = CART_MEAL_CHIP_ACTIVE[mealType];
 
   return (
     <View

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -389,6 +389,11 @@ export function TodayScreen() {
     });
   }, []);
 
+  const clearCartAll = useCallback(() => {
+    setCart(new Map());
+    setCartExpanded(false);
+  }, []);
+
   const updateCartGramsPerServing = useCallback((menuItemId: string, grams: number) => {
     setCart((prev) => {
       const next = new Map(prev);
@@ -1059,6 +1064,7 @@ export function TodayScreen() {
           onSave={() => {
             void saveCartToLog();
           }}
+          onClearAll={clearCartAll}
           onRemoveLine={removeCartLine}
           onUpdateGramsPerServing={updateCartGramsPerServing}
         />

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -1155,7 +1155,7 @@ const styles = StyleSheet.create({
   },
   menuPanelSlot: {
     flex: 1,
-    minHeight: 220,
+    minHeight: 0,
   },
   centeredFill: {
     flex: 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.62.1",
+  "version": "1.62.2",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1560,6 +1560,11 @@ export default function TodayClient({
     });
   }
 
+  function clearCartAll() {
+    setCart(new Map());
+    setCartExpanded(false);
+  }
+
   function updateGrams(itemId: string, grams: number) {
     setCart((prev) => {
       const next = new Map(prev);
@@ -1925,6 +1930,7 @@ export default function TodayClient({
           cartPfc={cartPFC}
           saving={saving}
           onSave={handleSave}
+          onClearAll={clearCartAll}
           onRemoveCartLine={removeCartLine}
         />
       </div>

--- a/src/app/today/_components/CartPanel.tsx
+++ b/src/app/today/_components/CartPanel.tsx
@@ -96,7 +96,7 @@ function CartBarHeader({
           disabled={clearingDisabled}
           className="px-2 py-1 rounded-md border border-gray-700 bg-gray-900/70 text-[11px] font-semibold text-gray-300 hover:text-white disabled:opacity-50"
         >
-          空にする
+          🗑 空にする
         </button>
         <button
           type="button"

--- a/src/app/today/_components/CartPanel.tsx
+++ b/src/app/today/_components/CartPanel.tsx
@@ -67,14 +67,10 @@ function CartBarHeader({
   cartExpanded,
   onToggle,
   cartEntryCount,
-  cartPFC,
-  mealType,
 }: {
   cartExpanded: boolean;
   onToggle: () => void;
   cartEntryCount: number;
-  cartPFC: PfcGrams;
-  mealType: MealType;
 }) {
   return (
     <button
@@ -82,24 +78,14 @@ function CartBarHeader({
       onClick={onToggle}
       className="w-full flex items-center justify-between gap-2 px-4 py-3.5 sm:py-2.5 min-h-12 sm:min-h-0 text-left"
     >
-      <div className="flex flex-col items-start min-w-0 flex-1 gap-0.5">
+      <div className="flex flex-col items-start min-w-0 flex-1">
         <span className="text-base sm:text-sm font-medium text-white">
           カート（{cartEntryCount}品）
         </span>
-        <span
-          className={`text-[11px] sm:text-xs leading-snug ${MEAL_TAB_STYLES[mealType].label}`}
-        >
-          {MEAL_LABELS[mealType]}に記録
-        </span>
       </div>
-      <div className="flex items-center gap-3 shrink-0">
-        <span className="text-sm sm:text-xs text-gray-400 tabular-nums">
-          P{fmt(cartPFC.p)} F{fmt(cartPFC.f)} C{fmt(cartPFC.c)}
-        </span>
-        <span className="text-gray-400 text-sm sm:text-xs" aria-hidden>
-          {cartExpanded ? "▼" : "▲"}
-        </span>
-      </div>
+      <span className="text-gray-400 text-sm sm:text-xs shrink-0" aria-hidden>
+        {cartExpanded ? "▼" : "▲"}
+      </span>
     </button>
   );
 }
@@ -131,7 +117,6 @@ function CartExpandedBody({
   return (
     <>
       <div className="px-3 pt-1 pb-2 border-t border-gray-800/70">
-        <p className="text-[10px] text-gray-500 mb-1.5 px-0.5">記録する食事</p>
         <div className="flex gap-1">
           {(Object.keys(MEAL_LABELS) as MealType[]).map((t) => (
             <button
@@ -249,8 +234,6 @@ export function CartPanel({
           cartExpanded={cartExpanded}
           onToggle={() => onCartExpandedChange(!cartExpanded)}
           cartEntryCount={cartEntries.length}
-          cartPFC={cartPfc}
-          mealType={mealType}
         />
       </div>
 
@@ -277,8 +260,6 @@ export function CartPanel({
               cartExpanded={cartExpanded}
               onToggle={() => onCartExpandedChange(!cartExpanded)}
               cartEntryCount={cartEntries.length}
-              cartPFC={cartPfc}
-              mealType={mealType}
             />
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               <CartExpandedBody
@@ -303,8 +284,6 @@ export function CartPanel({
           cartExpanded={cartExpanded}
           onToggle={() => onCartExpandedChange(!cartExpanded)}
           cartEntryCount={cartEntries.length}
-          cartPFC={cartPfc}
-          mealType={mealType}
         />
         {cartExpanded && (
           <CartExpandedBody

--- a/src/app/today/_components/CartPanel.tsx
+++ b/src/app/today/_components/CartPanel.tsx
@@ -96,7 +96,7 @@ function CartBarHeader({
           disabled={clearingDisabled}
           className="px-2 py-1 rounded-md border border-gray-700 bg-gray-900/70 text-[11px] font-semibold text-gray-300 hover:text-white disabled:opacity-50"
         >
-          全削除
+          空にする
         </button>
         <button
           type="button"

--- a/src/app/today/_components/CartPanel.tsx
+++ b/src/app/today/_components/CartPanel.tsx
@@ -67,26 +67,47 @@ function CartBarHeader({
   cartExpanded,
   onToggle,
   cartEntryCount,
+  onClearAll,
+  clearingDisabled,
 }: {
   cartExpanded: boolean;
   onToggle: () => void;
   cartEntryCount: number;
+  onClearAll: () => void;
+  clearingDisabled: boolean;
 }) {
   return (
-    <button
-      type="button"
-      onClick={onToggle}
-      className="w-full flex items-center justify-between gap-2 px-4 py-3.5 sm:py-2.5 min-h-12 sm:min-h-0 text-left"
-    >
+    <div className="w-full flex items-center justify-between gap-2 px-4 py-3.5 sm:py-2.5 min-h-12 sm:min-h-0">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="min-w-0 flex-1 text-left"
+      >
       <div className="flex flex-col items-start min-w-0 flex-1">
         <span className="text-base sm:text-sm font-medium text-white">
           カート（{cartEntryCount}品）
         </span>
       </div>
-      <span className="text-gray-400 text-sm sm:text-xs shrink-0" aria-hidden>
-        {cartExpanded ? "▼" : "▲"}
-      </span>
-    </button>
+      </button>
+      <div className="flex items-center gap-1.5 shrink-0">
+        <button
+          type="button"
+          onClick={onClearAll}
+          disabled={clearingDisabled}
+          className="px-2 py-1 rounded-md border border-gray-700 bg-gray-900/70 text-[11px] font-semibold text-gray-300 hover:text-white disabled:opacity-50"
+        >
+          全削除
+        </button>
+        <button
+          type="button"
+          onClick={onToggle}
+          className="text-gray-400 text-sm sm:text-xs px-1.5 py-1 rounded-md hover:bg-gray-800/70"
+          aria-label={cartExpanded ? "カートを閉じる" : "カートを開く"}
+        >
+          {cartExpanded ? "▼" : "▲"}
+        </button>
+      </div>
+    </div>
   );
 }
 
@@ -209,6 +230,7 @@ export type CartPanelProps = {
   cartPfc: PfcGrams;
   saving: boolean;
   onSave: () => void | Promise<void>;
+  onClearAll: () => void;
   onRemoveCartLine: (mapKey: string) => void;
 };
 
@@ -221,6 +243,7 @@ export function CartPanel({
   cartPfc,
   saving,
   onSave,
+  onClearAll,
   onRemoveCartLine,
 }: CartPanelProps) {
   if (cartEntries.length === 0) return null;
@@ -234,6 +257,8 @@ export function CartPanel({
           cartExpanded={cartExpanded}
           onToggle={() => onCartExpandedChange(!cartExpanded)}
           cartEntryCount={cartEntries.length}
+          onClearAll={onClearAll}
+          clearingDisabled={saving}
         />
       </div>
 
@@ -260,6 +285,8 @@ export function CartPanel({
               cartExpanded={cartExpanded}
               onToggle={() => onCartExpandedChange(!cartExpanded)}
               cartEntryCount={cartEntries.length}
+              onClearAll={onClearAll}
+              clearingDisabled={saving}
             />
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
               <CartExpandedBody
@@ -284,6 +311,8 @@ export function CartPanel({
           cartExpanded={cartExpanded}
           onToggle={() => onCartExpandedChange(!cartExpanded)}
           cartEntryCount={cartEntries.length}
+          onClearAll={onClearAll}
+          clearingDisabled={saving}
         />
         {cartExpanded && (
           <CartExpandedBody

--- a/src/app/today/_components/ItemDrawer.tsx
+++ b/src/app/today/_components/ItemDrawer.tsx
@@ -775,7 +775,7 @@ export function MenuItemDrawer({
               )}
             </div>
               {existingGroupNames.length > 0 && isGroupSuggestionsOpen && (
-                <ul className="absolute z-20 mt-1 max-h-44 w-full overflow-y-auto rounded-lg border border-gray-700 bg-gray-900/95 p-1 shadow-lg">
+                <ul className="absolute z-20 mt-1 max-h-64 w-full overflow-y-auto rounded-lg border border-gray-700 bg-gray-900/95 p-1 shadow-lg">
                   {groupSuggestions.length > 0 ? (
                     groupSuggestions.map((g) => (
                       <li key={g}>


### PR DESCRIPTION
## Summary
- `MenuItemEditorModal` のグループ名候補を内側 `ScrollView` 化し、候補ボックスに `overflow: hidden` を付けて候補表示の重なりと視認性を改善
- `TodayCartDock` の展開領域に画面高ベースの `maxHeight` を導入し、行一覧だけを `flex` + `ScrollView` でスクロールする構造に変更
- `package.json` を `1.62.2` に更新し、`CHANGELOG.md` に #319 / #320 の修正内容を追記

closes #319
closes #320

## Test plan
- [x] `npm run mobile:typecheck`
- [ ] iOS 実機/シミュレータで、グループ候補が多い状態でも候補エリア内で縦スクロールできること
- [ ] iOS 実機/シミュレータで、候補表示中にメモ欄との不自然な重なり表示が起きないこと
- [ ] 小さい画面でカートを5件以上にして展開し、行一覧スクロールと「記録する」ボタン押下が常に可能であること

Made with [Cursor](https://cursor.com)