### PR TITLE
fix(mobile): メニュー行の重量反映・キーボード閉じ・新規メニュー後の一覧更新

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.62.3] - 2026-04-28
+
+### Fixed
+
+- **Mobile / Today（[#323](https://github.com/kzkski/ketolog/issues/323)）**: メニュー行で重量を編集したまま「+」でカート投入すると、未 blur のためデフォルト重量しか渡らなかった問題を修正（入力文字列を確定してから投入し、Web の `MenuItemRow` と同趣旨にした）。投入後は `Keyboard.dismiss()` でソフトキーボードを閉じ、カート操作しやすくした。新規メニュー保存後に `reloadNonce` で店舗の `menu_items` を再取得するようし、タブを行き来しなくても一覧が更新されるようにした。
+
 ## [1.62.2] - 2026-04-27
 
 ### Fixed

--- a/apps/mobile/components/TodayMenuPanel.tsx
+++ b/apps/mobile/components/TodayMenuPanel.tsx
@@ -6,6 +6,7 @@ import {
   ActionSheetIOS,
   ActivityIndicator,
   Alert,
+  Keyboard,
   Platform,
   Pressable,
   RefreshControl,
@@ -195,6 +196,12 @@ function fmtPfc(n: number) {
   return n < 10 ? n.toFixed(1) : String(Math.round(n));
 }
 
+/** メニュー行の g 入力・onBlur・「+」で共通（カンマ除去・正の有限値のみ） */
+function parseMenuLineGrams(raw: string): number | null {
+  const n = Number.parseFloat(raw.replace(/,/g, ""));
+  return Number.isFinite(n) && n > 0 ? n : null;
+}
+
 function MenuLineRow({
   item,
   starred,
@@ -240,6 +247,23 @@ function MenuLineRow({
           macroTargets
         )
       : { highlightP: false, highlightF: false };
+
+  const handleAddToCart = () => {
+    let resolved = grams;
+    if (editing) {
+      const n = parseMenuLineGrams(gramsStr);
+      if (n != null) {
+        resolved = n;
+        setGrams(n);
+        setGramsStr(String(n));
+      } else {
+        setGramsStr(String(grams));
+      }
+    }
+    setEditing(false);
+    onAdd(resolved);
+    Keyboard.dismiss();
+  };
 
   return (
     <View style={styles.row}>
@@ -298,8 +322,8 @@ function MenuLineRow({
           value={gramsStr}
           onChangeText={setGramsStr}
           onBlur={() => {
-            const n = Number.parseFloat(gramsStr.replace(/,/g, ""));
-            if (Number.isFinite(n) && n > 0) {
+            const n = parseMenuLineGrams(gramsStr);
+            if (n != null) {
               setGrams(n);
               setGramsStr(String(n));
             } else {
@@ -316,7 +340,7 @@ function MenuLineRow({
           <Text style={styles.gramsTapText}>{grams}g</Text>
         </Pressable>
       )}
-      <Pressable onPress={() => onAdd(grams)} style={styles.plusBtn}>
+      <Pressable onPress={handleAddToCart} style={styles.plusBtn}>
         <Text style={styles.plusBtnText}>+</Text>
       </Pressable>
     </View>
@@ -560,7 +584,7 @@ export function TodayMenuPanel({
 
   useEffect(() => {
     void loadMenus();
-  }, [loadMenus]);
+  }, [loadMenus, reloadNonce]);
 
   useEffect(() => {
     if (!selectRestaurantIdAfterAdd) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.62.2",
+  "version": "1.62.3",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## 概要

[#323](https://github.com/kzkski/ketolog/issues/323) 対応。モバイル「今日」のメニュー行で、Web と揃った操作性・データ反映にする。

## 変更内容

- **`MenuLineRow`（`TodayMenuPanel.tsx`）**: 重量編集中に「+」を押したとき、`onBlur` 前でも `gramsStr` をパースしてカートへ渡す。`parseMenuLineGrams` で `onBlur` と同じ検証を共通化。投入後は `setEditing(false)` と `Keyboard.dismiss()` でソフトキーボードを閉じる。
- **店舗メニュー一覧の再取得**: `loadMenus` 実行用の `useEffect` の依存に `reloadNonce` を追加（`loadMenus` の `useCallback` 本体には含めず、exhaustive-deps の「不要な依存」警告を避ける）。`TodayScreen` の `dataNonce` 更新時（メニュー保存後・プルリフレッシュ等）に `menu_items` が取り直される。

## リリース

- `package.json` を **1.62.3**（パッチ）に更新
- `CHANGELOG.md` に `## [1.62.3]` を追加

closes #323

Made with [Cursor](https://cursor.com)