### PR TITLE
feat: カート内の1回あたりg編集（Web・モバイル）とTodayのキーボード回避

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 ### Changed
 
 - **ドキュメント / アーキテクチャ**: Web の食事ログ（楽観 UI・ロールバック）とモバイル（接続時は DB 反映待ち、オフラインは outbox 再送）の対比を `docs/architecture/food-log-sync.md` に整理し、主要実装箇所へ短い案内コメントを追加した（[#304](https://github.com/kzkski/ketolog/issues/304)）。
-
 - **ドキュメント / Native PoC**: `docs/release/v3-native-feasibility.md` に #272 向けの実証 KPI（体感速度・操作完了率・クラッシュ・開発効率）と固定計測手順、暫定評価、Go/No-Go の記録枠を追加した。
 - **ドキュメント / Native PoC**: 実証完了に伴い Go を **継続** とし、**デスクトップは Web（ネイティブ対象外）・モバイルは Expo ネイティブ前提**の製品方針を `v3-native-feasibility.md` に追記した（[#263](https://github.com/kzkski/ketolog/issues/263) / [#272](https://github.com/kzkski/ketolog/issues/272)）。
 - **ドキュメント / 開発運用**: `CONTRIBUTING.md` と `docs/release/README.md` に Issue ラベル運用の最小ルール（`platform` / `type` / `priority` の必須系統、`epic:*` / `track:*` の推奨運用）を追加した（[#274](https://github.com/kzkski/ketolog/issues/274)）。
@@ -21,6 +20,13 @@
 - **ドキュメント**: `ROADMAP.md` を公開向けのマイルストーン構成（v1/v2/v3）へ再編し、市場調査は公開サマリー中心に整理した。詳細な戦略レポートは公開リポジトリ管理の対象外にした。
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
+
+## [1.63.0] - 2026-04-28
+
+### Added
+
+- **Web / Today（[#325](https://github.com/kzkski/ketolog/issues/325)）**: カート展開一覧から「1回あたり」のグラム数を変更できるようにした（±1・±5 と数値入力）。スナップショット行も同様に更新できるよう `TodayClient` のカート更新を拡張した。
+- **Mobile / Today（[#325](https://github.com/kzkski/ketolog/issues/325)）**: カート内の g はインライン入力ではなく、タップで開くボトムシートで ±1・±5・数値入力・確定できるようにした。Today 画面に `KeyboardAvoidingView` を入れ、メニューなどの入力時にソフトキーボードで下部が隠れにくくした。
 
 ## [1.62.3] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 ### Changed
 
+- **Web / Today**: カート内の 1 回あたり g 編集を、横並びの ± ボタン群ではなく `type="number"`（`min` / `step`）の入力とブラウザのスピナーに整理した（モバイルの専用シートは変更なし）。
+
 - **ドキュメント / アーキテクチャ**: Web の食事ログ（楽観 UI・ロールバック）とモバイル（接続時は DB 反映待ち、オフラインは outbox 再送）の対比を `docs/architecture/food-log-sync.md` に整理し、主要実装箇所へ短い案内コメントを追加した（[#304](https://github.com/kzkski/ketolog/issues/304)）。
 - **ドキュメント / Native PoC**: `docs/release/v3-native-feasibility.md` に #272 向けの実証 KPI（体感速度・操作完了率・クラッシュ・開発効率）と固定計測手順、暫定評価、Go/No-Go の記録枠を追加した。
 - **ドキュメント / Native PoC**: 実証完了に伴い Go を **継続** とし、**デスクトップは Web（ネイティブ対象外）・モバイルは Expo ネイティブ前提**の製品方針を `v3-native-feasibility.md` に追記した（[#263](https://github.com/kzkski/ketolog/issues/263) / [#272](https://github.com/kzkski/ketolog/issues/272)）。

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import {
   ActivityIndicator,
+  Keyboard,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -9,6 +13,7 @@ import {
   useWindowDimensions,
   View,
 } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { MealType } from "@ketolog/types";
 import { pfcGramsFromNullablePer100, type PfcGrams } from "@ketolog/domain/pfc";
 
@@ -48,38 +53,6 @@ function fmtMacroGrams(n: number) {
   return n < 10 ? n.toFixed(1) : String(Math.round(n));
 }
 
-function CartGramsEditor({
-  grams,
-  disabled,
-  onCommit,
-}: {
-  grams: number;
-  disabled: boolean;
-  onCommit: (n: number) => void;
-}) {
-  const [local, setLocal] = useState(String(grams));
-  useEffect(() => {
-    setLocal(String(grams));
-  }, [grams]);
-  return (
-    <TextInput
-      value={local}
-      onChangeText={setLocal}
-      onBlur={() => {
-        const n = Number.parseFloat(local.replace(/,/g, ""));
-        if (Number.isFinite(n) && n > 0) {
-          onCommit(n);
-        } else {
-          setLocal(String(grams));
-        }
-      }}
-      keyboardType="decimal-pad"
-      editable={!disabled}
-      style={styles.gramsInput}
-    />
-  );
-}
-
 type Props = {
   lines: CartLineState[];
   expanded: boolean;
@@ -107,7 +80,50 @@ export function TodayCartDock({
   onRemoveLine,
   onUpdateGramsPerServing,
 }: Props) {
+  const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
+  const [gramsSheetForId, setGramsSheetForId] = useState<string | null>(null);
+  const [sheetDraft, setSheetDraft] = useState("");
+
+  const sheetLine = useMemo(
+    () => (gramsSheetForId ? lines.find((l) => l.menuItemId === gramsSheetForId) : undefined),
+    [gramsSheetForId, lines]
+  );
+
+  /** カートから該当行が消えたらモーダルを閉じる（状態リセットは次に開くときに上書き） */
+  const gramsSheetVisible =
+    gramsSheetForId != null && lines.some((l) => l.menuItemId === gramsSheetForId);
+
+  function openGramsSheet(menuItemId: string) {
+    if (saving) return;
+    const line = lines.find((l) => l.menuItemId === menuItemId);
+    setSheetDraft(line ? String(line.gramsPerServing) : "");
+    setGramsSheetForId(menuItemId);
+  }
+
+  function closeGramsSheet() {
+    Keyboard.dismiss();
+    setGramsSheetForId(null);
+  }
+
+  function applySheetDelta(delta: number) {
+    const v = Number.parseFloat(sheetDraft.replace(/,/g, ""));
+    const base = Number.isFinite(v) && v > 0 ? v : 1;
+    setSheetDraft(String(Math.max(1, base + delta)));
+  }
+
+  function commitGramsSheet() {
+    if (!gramsSheetForId || saving) return;
+    const n = Number.parseFloat(sheetDraft.replace(/,/g, ""));
+    if (!Number.isFinite(n) || n <= 0) {
+      if (sheetLine) setSheetDraft(String(sheetLine.gramsPerServing));
+      return;
+    }
+    onUpdateGramsPerServing(gramsSheetForId, n);
+    Keyboard.dismiss();
+    setGramsSheetForId(null);
+  }
+
   const expandedMaxHeight = useMemo(
     () => Math.max(220, Math.min(360, Math.floor(windowHeight * 0.44))),
     [windowHeight]
@@ -124,7 +140,119 @@ export function TodayCartDock({
   const shell = CART_MEAL_CHIP_ACTIVE[mealType];
 
   return (
-    <View
+    <>
+      <Modal
+        visible={gramsSheetVisible}
+        transparent
+        animationType="fade"
+        onRequestClose={closeGramsSheet}
+      >
+        <View style={styles.modalOuter}>
+          <Pressable
+            style={styles.modalBackdrop}
+            onPress={closeGramsSheet}
+            accessibilityLabel="閉じる"
+          />
+          <KeyboardAvoidingView
+            behavior={Platform.OS === "ios" ? "padding" : "height"}
+            keyboardVerticalOffset={0}
+            style={styles.modalKav}
+          >
+          <View
+            style={[
+              styles.gramsSheet,
+              { paddingBottom: Math.max(insets.bottom, 12) + 8 },
+            ]}
+          >
+            <Text style={styles.gramsSheetTitle} numberOfLines={2}>
+              {sheetLine?.name ?? ""}
+            </Text>
+            <Text style={styles.gramsSheetSubtitle}>1回あたり（g）</Text>
+            <View style={styles.gramsStepRow}>
+              <Pressable
+                onPress={() => applySheetDelta(-5)}
+                disabled={saving}
+                style={({ pressed }) => [
+                  styles.stepBtn,
+                  pressed && { opacity: 0.85 },
+                  saving && { opacity: 0.45 },
+                ]}
+              >
+                <Text style={styles.stepBtnText}>−5</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => applySheetDelta(-1)}
+                disabled={saving}
+                style={({ pressed }) => [
+                  styles.stepBtn,
+                  pressed && { opacity: 0.85 },
+                  saving && { opacity: 0.45 },
+                ]}
+              >
+                <Text style={styles.stepBtnText}>−</Text>
+              </Pressable>
+              <TextInput
+                value={sheetDraft}
+                onChangeText={setSheetDraft}
+                keyboardType="decimal-pad"
+                editable={!saving}
+                selectTextOnFocus
+                style={styles.gramsSheetInput}
+                accessibilityLabel="1回あたりのグラム数"
+              />
+              <Pressable
+                onPress={() => applySheetDelta(1)}
+                disabled={saving}
+                style={({ pressed }) => [
+                  styles.stepBtn,
+                  pressed && { opacity: 0.85 },
+                  saving && { opacity: 0.45 },
+                ]}
+              >
+                <Text style={styles.stepBtnText}>+</Text>
+              </Pressable>
+              <Pressable
+                onPress={() => applySheetDelta(5)}
+                disabled={saving}
+                style={({ pressed }) => [
+                  styles.stepBtn,
+                  pressed && { opacity: 0.85 },
+                  saving && { opacity: 0.45 },
+                ]}
+              >
+                <Text style={styles.stepBtnText}>+5</Text>
+              </Pressable>
+            </View>
+            <View style={styles.gramsSheetActions}>
+              <Pressable
+                onPress={closeGramsSheet}
+                disabled={saving}
+                style={({ pressed }) => [
+                  styles.cancelBtn,
+                  pressed && { opacity: 0.88 },
+                  saving && { opacity: 0.45 },
+                ]}
+              >
+                <Text style={styles.cancelBtnText}>キャンセル</Text>
+              </Pressable>
+              <Pressable
+                onPress={commitGramsSheet}
+                disabled={saving}
+                style={({ pressed }) => [
+                  styles.confirmBtn,
+                  pressed && { opacity: 0.92 },
+                  saving && { opacity: 0.45 },
+                ]}
+              >
+                <Text style={styles.confirmBtnText}>確定</Text>
+              </Pressable>
+            </View>
+          </View>
+          </KeyboardAvoidingView>
+        </View>
+      </Modal>
+
+      <View
       style={[
         styles.shell,
         { borderTopColor: shell.border, backgroundColor: "rgba(15, 23, 42, 0.98)" },
@@ -213,14 +341,19 @@ export function TodayCartDock({
                       P{fmtMacroGrams(v.p)} F{fmtMacroGrams(v.f)} C{fmtMacroGrams(v.c)}
                     </Text>
                   </View>
-                  <View style={styles.gramsCol}>
+                  <Pressable
+                    onPress={() => openGramsSheet(line.menuItemId)}
+                    disabled={saving}
+                    style={({ pressed }) => [
+                      styles.gramsCol,
+                      pressed && { opacity: 0.88 },
+                      saving && { opacity: 0.45 },
+                    ]}
+                    accessibilityLabel="1回あたりのグラムを編集"
+                  >
                     <Text style={styles.gramsLabel}>1回</Text>
-                    <CartGramsEditor
-                      grams={line.gramsPerServing}
-                      disabled={saving}
-                      onCommit={(n) => onUpdateGramsPerServing(line.menuItemId, n)}
-                    />
-                  </View>
+                    <Text style={styles.gramsTapValue}>{fmtMacroGrams(line.gramsPerServing)}g</Text>
+                  </Pressable>
                   <Pressable
                     onPress={() => onRemoveLine(line.menuItemId)}
                     disabled={saving}
@@ -256,6 +389,7 @@ export function TodayCartDock({
         </View>
       ) : null}
     </View>
+    </>
   );
 }
 
@@ -341,19 +475,110 @@ const styles = StyleSheet.create({
     marginTop: 4,
     fontVariant: ["tabular-nums"],
   },
-  gramsCol: { alignItems: "center", width: 52 },
+  gramsCol: { alignItems: "center", justifyContent: "center", width: 56, minHeight: 44 },
   gramsLabel: { color: "#6b7280", fontSize: 9, marginBottom: 2 },
-  gramsInput: {
-    width: 50,
+  gramsTapValue: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+  modalOuter: {
+    flex: 1,
+    justifyContent: "flex-end",
+  },
+  modalBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.55)",
+  },
+  modalKav: {
+    width: "100%",
+  },
+  gramsSheet: {
+    backgroundColor: "#111827",
+    borderTopLeftRadius: 16,
+    borderTopRightRadius: 16,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderColor: "#374151",
+  },
+  gramsSheetTitle: {
+    color: "#f9fafb",
+    fontSize: 16,
+    fontWeight: "700",
+    marginBottom: 4,
+  },
+  gramsSheetSubtitle: {
+    color: "#9ca3af",
+    fontSize: 12,
+    marginBottom: 12,
+  },
+  gramsStepRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    flexWrap: "wrap",
+    gap: 8,
+    marginBottom: 16,
+  },
+  stepBtn: {
+    minWidth: 44,
+    minHeight: 44,
+    paddingHorizontal: 10,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#4b5563",
+    backgroundColor: "#1f2937",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  stepBtnText: {
+    color: "#e5e7eb",
+    fontSize: 16,
+    fontWeight: "700",
+  },
+  gramsSheetInput: {
+    minWidth: 72,
     textAlign: "center",
     color: "#fff",
-    fontSize: 13,
-    fontWeight: "600",
-    paddingVertical: 6,
-    borderRadius: 8,
+    fontSize: 18,
+    fontWeight: "700",
+    paddingVertical: 10,
+    paddingHorizontal: 8,
+    borderRadius: 10,
     borderWidth: 1,
-    borderColor: "#10b981",
-    backgroundColor: "#111827",
+    borderColor: "#059669",
+    backgroundColor: "#0f172a",
+    fontVariant: ["tabular-nums"],
+  },
+  gramsSheetActions: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 12,
+  },
+  cancelBtn: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 10,
+  },
+  cancelBtnText: {
+    color: "#9ca3af",
+    fontSize: 16,
+    fontWeight: "600",
+  },
+  confirmBtn: {
+    paddingVertical: 12,
+    paddingHorizontal: 22,
+    borderRadius: 10,
+    backgroundColor: "#059669",
+    minWidth: 100,
+    alignItems: "center",
+  },
+  confirmBtnText: {
+    color: "#fff",
+    fontSize: 16,
+    fontWeight: "700",
   },
   removeBtn: {
     width: 40,

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -3,6 +3,8 @@ import {
   ActivityIndicator,
   Alert,
   Image,
+  KeyboardAvoidingView,
+  Platform,
   Pressable,
   ScrollView,
   StyleSheet,
@@ -717,6 +719,11 @@ export function TodayScreen() {
 
   return (
     <SafeAreaView style={styles.safe} edges={["top", "left", "right", "bottom"]}>
+      <KeyboardAvoidingView
+        style={styles.kavRoot}
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        keyboardVerticalOffset={0}
+      >
       <View style={styles.root}>
         <View style={styles.topHeader}>
           <View style={styles.brandBlock}>
@@ -1070,6 +1077,7 @@ export function TodayScreen() {
         />
         </View>
       </View>
+      </KeyboardAvoidingView>
 
       <FoodLogEntryModal
         visible={entryModalOpen}
@@ -1151,6 +1159,9 @@ const styles = StyleSheet.create({
   safe: {
     flex: 1,
     backgroundColor: COLORS.bg,
+  },
+  kavRoot: {
+    flex: 1,
   },
   root: {
     flex: 1,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.62.3",
+  "version": "1.63.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -1565,14 +1565,24 @@ export default function TodayClient({
     setCartExpanded(false);
   }
 
-  function updateGrams(itemId: string, grams: number) {
+  /** カート行キー（メニューは `item.id`、スナップショットは `cartKey`）で 1回あたり g を更新 */
+  function updateCartGramsPerServing(lineKey: string, grams: number) {
+    if (!Number.isFinite(grams) || grams <= 0) return;
     setCart((prev) => {
       const next = new Map(prev);
-      const existing = next.get(itemId);
-      if (!existing || existing.kind !== "menu") return prev;
-      next.set(itemId, { ...existing, gramsPerServing: grams });
+      const existing = next.get(lineKey);
+      if (!existing) return prev;
+      if (existing.kind === "menu") {
+        next.set(lineKey, { ...existing, gramsPerServing: grams });
+      } else if (existing.kind === "snapshot") {
+        next.set(lineKey, { ...existing, gramsPerServing: grams });
+      }
       return next;
     });
+  }
+
+  function updateGrams(itemId: string, grams: number) {
+    updateCartGramsPerServing(itemId, grams);
   }
 
   // ── メニューアイテム保存後 ──────────────────────────────────────────────────
@@ -1932,6 +1942,7 @@ export default function TodayClient({
           onSave={handleSave}
           onClearAll={clearCartAll}
           onRemoveCartLine={removeCartLine}
+          onUpdateGramsPerServing={updateCartGramsPerServing}
         />
       </div>
 

--- a/src/app/today/_components/CartPanel.tsx
+++ b/src/app/today/_components/CartPanel.tsx
@@ -64,7 +64,7 @@ function pfcFromPer100(
   };
 }
 
-/** カート行の「1回あたり g」（±・直接入力。メニュー行の g 編集と同趣旨） */
+/** カート行の「1回あたり g」— 数値入力とブラウザ標準の step スピナー（1g 単位）に任せる */
 function CartLineGramsEditor({
   gramsPerServing,
   disabled,
@@ -79,11 +79,6 @@ function CartLineGramsEditor({
     setDraft(String(gramsPerServing));
   }, [gramsPerServing]);
 
-  function applyDelta(delta: number) {
-    const next = Math.max(1, gramsPerServing + delta);
-    onCommit(next);
-  }
-
   function commitDraft() {
     const n = Number.parseFloat(draft.replace(/,/g, ""));
     if (Number.isFinite(n) && n > 0) {
@@ -93,60 +88,29 @@ function CartLineGramsEditor({
     }
   }
 
-  const btnClass =
-    "min-h-9 min-w-9 sm:min-h-8 sm:min-w-8 flex items-center justify-center rounded-lg border border-gray-600 bg-gray-800 text-gray-200 text-xs font-semibold disabled:opacity-40 touch-manipulation shrink-0";
-
   return (
     <div className="flex flex-col items-end gap-0.5 shrink-0">
       <span className="text-[9px] text-gray-500 leading-none">1回</span>
-      <div className="flex items-center gap-0.5 flex-wrap justify-end">
-        <button
-          type="button"
-          className={btnClass}
-          disabled={disabled || gramsPerServing <= 1}
-          onClick={() => applyDelta(-5)}
-          aria-label="5グラム減らす"
-        >
-          −5
-        </button>
-        <button
-          type="button"
-          className={btnClass}
-          disabled={disabled || gramsPerServing <= 1}
-          onClick={() => applyDelta(-1)}
-          aria-label="1グラム減らす"
-        >
-          −
-        </button>
-        <input
-          type="number"
-          value={draft}
-          disabled={disabled}
-          onChange={(e) => setDraft(e.target.value)}
-          onBlur={commitDraft}
-          onKeyDown={(e) => e.key === "Enter" && commitDraft()}
-          className="w-[3.25rem] sm:w-14 text-center text-xs sm:text-sm bg-gray-800 border border-emerald-600/80 rounded px-0.5 py-1 text-white tabular-nums shrink-0"
-          aria-label="1回あたりのグラム数"
-        />
-        <button
-          type="button"
-          className={btnClass}
-          disabled={disabled}
-          onClick={() => applyDelta(1)}
-          aria-label="1グラム増やす"
-        >
-          +
-        </button>
-        <button
-          type="button"
-          className={btnClass}
-          disabled={disabled}
-          onClick={() => applyDelta(5)}
-          aria-label="5グラム増やす"
-        >
-          +5
-        </button>
-      </div>
+      <input
+        type="number"
+        min={1}
+        step={1}
+        value={draft}
+        disabled={disabled}
+        onChange={(e) => {
+          const v = e.target.value;
+          setDraft(v);
+          if (v === "") return;
+          const n = Number.parseFloat(v);
+          if (Number.isFinite(n) && n > 0) {
+            onCommit(n);
+          }
+        }}
+        onBlur={commitDraft}
+        onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
+        className="w-[3.75rem] sm:w-16 text-center text-xs sm:text-sm bg-gray-800 border border-emerald-600/80 rounded px-0.5 py-1 text-white tabular-nums shrink-0"
+        aria-label="1回あたりのグラム数"
+      />
     </div>
   );
 }

--- a/src/app/today/_components/CartPanel.tsx
+++ b/src/app/today/_components/CartPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import type { MenuItem } from "@/types/database";
 import type { MealType, PfcGrams } from "@ketolog/types";
-import { MEAL_LABELS, MEAL_TAB_STYLES } from "@/lib/constants/meal";
+import { MEAL_LABELS } from "@/lib/constants/meal";
 
 /** カート内「記録する食事」セグメントの選択中スタイル（タブと同色） */
 const MEAL_CART_SEGMENT_ACTIVE: Record<MealType, string> = {
@@ -63,6 +64,93 @@ function pfcFromPer100(
   };
 }
 
+/** カート行の「1回あたり g」（±・直接入力。メニュー行の g 編集と同趣旨） */
+function CartLineGramsEditor({
+  gramsPerServing,
+  disabled,
+  onCommit,
+}: {
+  gramsPerServing: number;
+  disabled: boolean;
+  onCommit: (n: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(gramsPerServing));
+  useEffect(() => {
+    setDraft(String(gramsPerServing));
+  }, [gramsPerServing]);
+
+  function applyDelta(delta: number) {
+    const next = Math.max(1, gramsPerServing + delta);
+    onCommit(next);
+  }
+
+  function commitDraft() {
+    const n = Number.parseFloat(draft.replace(/,/g, ""));
+    if (Number.isFinite(n) && n > 0) {
+      onCommit(n);
+    } else {
+      setDraft(String(gramsPerServing));
+    }
+  }
+
+  const btnClass =
+    "min-h-9 min-w-9 sm:min-h-8 sm:min-w-8 flex items-center justify-center rounded-lg border border-gray-600 bg-gray-800 text-gray-200 text-xs font-semibold disabled:opacity-40 touch-manipulation shrink-0";
+
+  return (
+    <div className="flex flex-col items-end gap-0.5 shrink-0">
+      <span className="text-[9px] text-gray-500 leading-none">1回</span>
+      <div className="flex items-center gap-0.5 flex-wrap justify-end">
+        <button
+          type="button"
+          className={btnClass}
+          disabled={disabled || gramsPerServing <= 1}
+          onClick={() => applyDelta(-5)}
+          aria-label="5グラム減らす"
+        >
+          −5
+        </button>
+        <button
+          type="button"
+          className={btnClass}
+          disabled={disabled || gramsPerServing <= 1}
+          onClick={() => applyDelta(-1)}
+          aria-label="1グラム減らす"
+        >
+          −
+        </button>
+        <input
+          type="number"
+          value={draft}
+          disabled={disabled}
+          onChange={(e) => setDraft(e.target.value)}
+          onBlur={commitDraft}
+          onKeyDown={(e) => e.key === "Enter" && commitDraft()}
+          className="w-[3.25rem] sm:w-14 text-center text-xs sm:text-sm bg-gray-800 border border-emerald-600/80 rounded px-0.5 py-1 text-white tabular-nums shrink-0"
+          aria-label="1回あたりのグラム数"
+        />
+        <button
+          type="button"
+          className={btnClass}
+          disabled={disabled}
+          onClick={() => applyDelta(1)}
+          aria-label="1グラム増やす"
+        >
+          +
+        </button>
+        <button
+          type="button"
+          className={btnClass}
+          disabled={disabled}
+          onClick={() => applyDelta(5)}
+          aria-label="5グラム増やす"
+        >
+          +5
+        </button>
+      </div>
+    </div>
+  );
+}
+
 function CartBarHeader({
   cartExpanded,
   onToggle,
@@ -117,6 +205,7 @@ function CartExpandedBody({
   cartEntries,
   cartPFC,
   removeCartLine,
+  onUpdateGramsPerServing,
   onSave,
   saving,
   layout = "inline",
@@ -126,6 +215,7 @@ function CartExpandedBody({
   cartEntries: CartEntry[];
   cartPFC: PfcGrams;
   removeCartLine: (key: string) => void;
+  onUpdateGramsPerServing: (lineKey: string, grams: number) => void;
   onSave: () => void | Promise<void>;
   saving: boolean;
   /** モバイルのオーバーレイでは一覧を縦に伸ばす */
@@ -178,9 +268,9 @@ function CartExpandedBody({
           return (
             <div
               key={lineKey}
-              className="flex items-center gap-2 px-4 py-1.5 border-b border-gray-800/50"
+              className="flex flex-wrap items-center gap-x-2 gap-y-2 px-4 py-1.5 border-b border-gray-800/50"
             >
-              <span className="text-sm text-gray-200 truncate flex-1 min-w-0">
+              <span className="text-sm text-gray-200 truncate flex-1 min-w-[10rem]">
                 {title}
                 {snapshotTag}
                 <span className="text-gray-500 ml-1 text-xs whitespace-nowrap">
@@ -190,6 +280,11 @@ function CartExpandedBody({
               <span className="text-xs text-gray-400 shrink-0 tabular-nums">
                 P{fmt(v.p)} F{fmt(v.f)} C{fmt(v.c)}
               </span>
+              <CartLineGramsEditor
+                gramsPerServing={entry.gramsPerServing}
+                disabled={saving}
+                onCommit={(g) => onUpdateGramsPerServing(lineKey, g)}
+              />
               <button
                 type="button"
                 aria-label="カートから外す"
@@ -232,6 +327,7 @@ export type CartPanelProps = {
   onSave: () => void | Promise<void>;
   onClearAll: () => void;
   onRemoveCartLine: (mapKey: string) => void;
+  onUpdateGramsPerServing: (lineKey: string, grams: number) => void;
 };
 
 export function CartPanel({
@@ -245,6 +341,7 @@ export function CartPanel({
   onSave,
   onClearAll,
   onRemoveCartLine,
+  onUpdateGramsPerServing,
 }: CartPanelProps) {
   if (cartEntries.length === 0) return null;
 
@@ -296,6 +393,7 @@ export function CartPanel({
                 cartEntries={cartEntries}
                 cartPFC={cartPfc}
                 removeCartLine={onRemoveCartLine}
+                onUpdateGramsPerServing={onUpdateGramsPerServing}
                 onSave={onSave}
                 saving={saving}
               />
@@ -321,6 +419,7 @@ export function CartPanel({
             cartEntries={cartEntries}
             cartPFC={cartPfc}
             removeCartLine={onRemoveCartLine}
+            onUpdateGramsPerServing={onUpdateGramsPerServing}
             onSave={onSave}
             saving={saving}
           />


### PR DESCRIPTION
## 概要
- **Web**: `CartPanel` の各行に「1回あたり」g の ±1・±5 と数値入力を追加。`TodayClient` に `updateCartGramsPerServing` を導入し、メニュー行・スナップショット行の両方で `gramsPerServing` を更新可能にした。
- **Mobile**: カートのインライン `TextInput` をやめ、`gramsTapValue` タップでボトムシート（±・数値・確定／キャンセル）。カートが空で行が消えた場合はモーダルを閉じる。
- **Mobile Today**: メインコンテンツを `KeyboardAvoidingView` で包み、キーボード表示時にレイアウトが押し上がりやすくした。

## Issue
closes #325

## チェック
- [x] `npm run build`
- [x] `npm --prefix apps/mobile run typecheck`

Made with [Cursor](https://cursor.com)