### PR TITLE
feat: 分析画面のPFC比率をカロリー比／重量比で切り替え

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,6 @@
 
 ## [Unreleased]
 
-### Added
-
-- **Web / Mobile 分析（[#327](https://github.com/kzkski/ketolog/issues/327)）**: 平均PFCバランスと日次一覧の比率バーを、**カロリー比**（P4・F9・C4 kcal/g）と**重量比**で切り替え可能にした（デフォルトはカロリー比）。選択は端末に保存される。カロリー比時は平均の合計 kcal/日を表示する。
-
 ### Changed
 
 - **Web / Today**: カート内の 1 回あたり g 編集を、横並びの ± ボタン群ではなく `type="number"`（`min` / `step`）の入力とブラウザのスピナーに整理した（モバイルの専用シートは変更なし）。
@@ -26,6 +22,12 @@
 - **ドキュメント**: `ROADMAP.md` を公開向けのマイルストーン構成（v1/v2/v3）へ再編し、市場調査は公開サマリー中心に整理した。詳細な戦略レポートは公開リポジトリ管理の対象外にした。
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
+
+## [1.64.0] - 2026-05-19
+
+### Added
+
+- **Web / Mobile 分析（[#327](https://github.com/kzkski/ketolog/issues/327)）**: 平均PFCバランスと日次一覧の比率バーを、**カロリー比**（P4・F9・C4 kcal/g）と**重量比**で切り替え可能にした（デフォルトはカロリー比）。選択は端末に保存される。カロリー比時は平均の合計 kcal/日を表示する。
 
 ## [1.63.0] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Web / Mobile 分析（[#327](https://github.com/kzkski/ketolog/issues/327)）**: 平均PFCバランスと日次一覧の比率バーを、**カロリー比**（P4・F9・C4 kcal/g）と**重量比**で切り替え可能にした（デフォルトはカロリー比）。選択は端末に保存される。カロリー比時は平均の合計 kcal/日を表示する。
+
 ### Changed
 
 - **Web / Today**: カート内の 1 回あたり g 編集を、横並びの ± ボタン群ではなく `type="number"`（`min` / `step`）の入力とブラウザのスピナーに整理した（モバイルの専用シートは変更なし）。

--- a/apps/mobile/lib/insights-pfc-ratio-storage.ts
+++ b/apps/mobile/lib/insights-pfc-ratio-storage.ts
@@ -1,0 +1,29 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { PfcRatioBasis } from "@ketolog/domain/pfc";
+
+/** Web `src/lib/insights-pfc-ratio-storage.ts` と同一キー */
+const STORAGE_KEY = "ketolog.insightsPfcRatioBasis.v1";
+
+const DEFAULT_BASIS: PfcRatioBasis = "kcal";
+
+function parseBasis(raw: string | null): PfcRatioBasis {
+  if (raw === "kcal" || raw === "gram") return raw;
+  return DEFAULT_BASIS;
+}
+
+export async function readInsightsPfcRatioBasisNative(): Promise<PfcRatioBasis> {
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    return parseBasis(raw);
+  } catch {
+    return DEFAULT_BASIS;
+  }
+}
+
+export async function writeInsightsPfcRatioBasisNative(basis: PfcRatioBasis): Promise<void> {
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, basis);
+  } catch {
+    /* quota 等 */
+  }
+}

--- a/apps/mobile/screens/InsightsScreen.tsx
+++ b/apps/mobile/screens/InsightsScreen.tsx
@@ -20,6 +20,16 @@ import {
   getTodayJstDate,
   type InsightFoodLogEntry,
 } from "@ketolog/domain/insights";
+import {
+  pfcRatioPercents,
+  pfcTotalKcal,
+  type PfcGrams,
+  type PfcRatioBasis,
+} from "@ketolog/domain/pfc";
+import {
+  readInsightsPfcRatioBasisNative,
+  writeInsightsPfcRatioBasisNative,
+} from "../lib/insights-pfc-ratio-storage";
 import { useAuthSessionContext } from "../contexts/AuthSessionContext";
 import { loadFoodLogOutbox } from "../lib/food-log-outbox";
 import { getSupabase } from "../lib/supabase";
@@ -61,9 +71,12 @@ function fmtNum(v: number): string {
   return v.toFixed(1);
 }
 
-function ratioFlex(total: number, part: number): { flex: number } {
-  if (total <= 0) return { flex: 0 };
-  return { flex: Math.max(0, Math.min(1, part / total)) };
+function toPfcGrams(protein: number, fat: number, carbs: number): PfcGrams {
+  return { p: protein, f: fat, c: carbs };
+}
+
+function ratioFlexFromPercents(pct: number): { flex: number } {
+  return { flex: Math.max(0, pct / 100) };
 }
 
 function jstDateLabel(date: string): string {
@@ -98,6 +111,7 @@ export function InsightsScreen() {
   const [shareErr, setShareErr] = useState<string | null>(null);
   const [outboxLoaded, setOutboxLoaded] = useState(false);
   const [outboxHasUnsent, setOutboxHasUnsent] = useState(false);
+  const [ratioBasis, setRatioBasis] = useState<PfcRatioBasis>("kcal");
 
   const loadRange = useCallback(
     async (
@@ -154,6 +168,15 @@ export function InsightsScreen() {
     }, [userId, refreshOutbox])
   );
 
+  useEffect(() => {
+    void readInsightsPfcRatioBasisNative().then(setRatioBasis);
+  }, []);
+
+  function selectRatioBasis(next: PfcRatioBasis) {
+    setRatioBasis(next);
+    void writeInsightsPfcRatioBasisNative(next);
+  }
+
   const insight = useMemo(
     () =>
       buildInsights(entries, start, end, {
@@ -161,11 +184,20 @@ export function InsightsScreen() {
       }),
     [entries, start, end, mealFilter]
   );
-  const avgTotal =
-    insight.summary.avgProtein + insight.summary.avgFat + insight.summary.avgCarbs;
-  const avgProteinPct = avgTotal > 0 ? (insight.summary.avgProtein / avgTotal) * 100 : 0;
-  const avgFatPct = avgTotal > 0 ? (insight.summary.avgFat / avgTotal) * 100 : 0;
-  const avgCarbsPct = avgTotal > 0 ? (insight.summary.avgCarbs / avgTotal) * 100 : 0;
+  const avgGrams = useMemo(
+    () =>
+      toPfcGrams(
+        insight.summary.avgProtein,
+        insight.summary.avgFat,
+        insight.summary.avgCarbs
+      ),
+    [insight.summary.avgProtein, insight.summary.avgFat, insight.summary.avgCarbs]
+  );
+  const avgRatioPct = useMemo(
+    () => pfcRatioPercents(avgGrams, ratioBasis),
+    [avgGrams, ratioBasis]
+  );
+  const avgDailyKcal = useMemo(() => pfcTotalKcal(avgGrams), [avgGrams]);
 
   function validateCustomRange(nextStart: string, nextEnd: string): string | null {
     if (nextStart > nextEnd) return "開始日は終了日以前にしてください。";
@@ -398,34 +430,92 @@ export function InsightsScreen() {
         </View>
 
         <View style={styles.card}>
-          <Text style={styles.cardTitle}>平均PFCバランス</Text>
+          <View style={styles.cardTitleRow}>
+            <Text style={styles.cardTitle}>平均PFCバランス</Text>
+            <View style={styles.ratioBasisGroup} accessibilityRole="tablist">
+              <Pressable
+                onPress={() => selectRatioBasis("kcal")}
+                style={[styles.ratioBasisBtn, ratioBasis === "kcal" && styles.ratioBasisBtnOn]}
+                accessibilityRole="tab"
+                accessibilityState={{ selected: ratioBasis === "kcal" }}
+              >
+                <Text
+                  style={[
+                    styles.ratioBasisBtnText,
+                    ratioBasis === "kcal" && styles.ratioBasisBtnTextOn,
+                  ]}
+                >
+                  カロリー比
+                </Text>
+              </Pressable>
+              <Pressable
+                onPress={() => selectRatioBasis("gram")}
+                style={[styles.ratioBasisBtn, ratioBasis === "gram" && styles.ratioBasisBtnOn]}
+                accessibilityRole="tab"
+                accessibilityState={{ selected: ratioBasis === "gram" }}
+              >
+                <Text
+                  style={[
+                    styles.ratioBasisBtnText,
+                    ratioBasis === "gram" && styles.ratioBasisBtnTextOn,
+                  ]}
+                >
+                  重量比
+                </Text>
+              </Pressable>
+            </View>
+          </View>
+          {ratioBasis === "kcal" ? (
+            <Text style={styles.avgKcalLine}>
+              平均 {fmtNum(avgDailyKcal)} kcal/日
+              <Text style={styles.avgKcalHint}> · P4・F9・C4 kcal/g</Text>
+            </Text>
+          ) : null}
           <View style={styles.avgGrid}>
             <View style={styles.avgCell}>
               <Text style={styles.avgCap}>たんぱく質 (P)</Text>
               <Text style={[styles.avgVal, { color: "#93c5fd" }]}>
                 {fmtNum(insight.summary.avgProtein)} g
               </Text>
-              <Text style={styles.avgPct}>{fmtNum(avgProteinPct)}%</Text>
+              <Text style={styles.avgPct}>{fmtNum(avgRatioPct.p)}%</Text>
             </View>
             <View style={styles.avgCell}>
               <Text style={styles.avgCap}>脂質 (F)</Text>
               <Text style={[styles.avgVal, { color: "#fde047" }]}>
                 {fmtNum(insight.summary.avgFat)} g
               </Text>
-              <Text style={styles.avgPct}>{fmtNum(avgFatPct)}%</Text>
+              <Text style={styles.avgPct}>{fmtNum(avgRatioPct.f)}%</Text>
             </View>
             <View style={styles.avgCell}>
               <Text style={styles.avgCap}>糖質 (C)</Text>
               <Text style={[styles.avgVal, { color: "#6ee7b7" }]}>
                 {fmtNum(insight.summary.avgCarbs)} g
               </Text>
-              <Text style={styles.avgPct}>{fmtNum(avgCarbsPct)}%</Text>
+              <Text style={styles.avgPct}>{fmtNum(avgRatioPct.c)}%</Text>
             </View>
           </View>
           <View style={styles.ratioBar}>
-            <View style={[styles.ratioSeg, { backgroundColor: "#60a5fa" }, ratioFlex(avgTotal, insight.summary.avgProtein)]} />
-            <View style={[styles.ratioSeg, { backgroundColor: "#facc15" }, ratioFlex(avgTotal, insight.summary.avgFat)]} />
-            <View style={[styles.ratioSeg, { backgroundColor: "#34d399" }, ratioFlex(avgTotal, insight.summary.avgCarbs)]} />
+            <View
+              style={[
+                styles.ratioSeg,
+                { backgroundColor: "#60a5fa" },
+                ratioFlexFromPercents(avgRatioPct.p),
+              ]}
+            />
+            <View
+              style={[
+                styles.ratioSeg,
+                { backgroundColor: "#facc15" },
+                ratioFlexFromPercents(avgRatioPct.f),
+              ]}
+            />
+            <View
+              style={[
+                styles.ratioSeg,
+                { backgroundColor: "#34d399" },
+                ratioFlexFromPercents(avgRatioPct.c),
+              ]}
+            />
           </View>
         </View>
 
@@ -438,7 +528,8 @@ export function InsightsScreen() {
           <Text style={styles.cardTitle}>日ごとの食事一覧</Text>
           {insight.daily.map((day) => {
             const isOpen = expanded.has(day.date);
-            const total = day.protein + day.fat + day.carbs;
+            const dayGrams = toPfcGrams(day.protein, day.fat, day.carbs);
+            const dayRatioPct = pfcRatioPercents(dayGrams, ratioBasis);
             return (
               <View key={day.date} style={styles.dayBlock}>
                 <Pressable onPress={() => toggleDate(day.date)} style={styles.dayHeader}>
@@ -452,9 +543,27 @@ export function InsightsScreen() {
                       <Text style={[styles.dayPfc, { color: "#6ee7b7" }]}>{fmtNum(day.carbs)}</Text>
                     </View>
                     <View style={styles.ratioBar}>
-                      <View style={[styles.ratioSeg, { backgroundColor: "#60a5fa" }, ratioFlex(total, day.protein)]} />
-                      <View style={[styles.ratioSeg, { backgroundColor: "#facc15" }, ratioFlex(total, day.fat)]} />
-                      <View style={[styles.ratioSeg, { backgroundColor: "#34d399" }, ratioFlex(total, day.carbs)]} />
+                      <View
+                        style={[
+                          styles.ratioSeg,
+                          { backgroundColor: "#60a5fa" },
+                          ratioFlexFromPercents(dayRatioPct.p),
+                        ]}
+                      />
+                      <View
+                        style={[
+                          styles.ratioSeg,
+                          { backgroundColor: "#facc15" },
+                          ratioFlexFromPercents(dayRatioPct.f),
+                        ]}
+                      />
+                      <View
+                        style={[
+                          styles.ratioSeg,
+                          { backgroundColor: "#34d399" },
+                          ratioFlexFromPercents(dayRatioPct.c),
+                        ]}
+                      />
                     </View>
                   </View>
                   <Text style={styles.dayCount}>{day.entries.length} 件</Text>
@@ -570,7 +679,32 @@ const styles = StyleSheet.create({
     padding: 12,
     marginBottom: 12,
   },
-  cardTitle: { color: COLORS.text, fontSize: 14, fontWeight: "600", marginBottom: 10 },
+  cardTitle: { color: COLORS.text, fontSize: 14, fontWeight: "600" },
+  cardTitleRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    gap: 8,
+    marginBottom: 10,
+  },
+  ratioBasisGroup: {
+    flexDirection: "row",
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: COLORS.border,
+    backgroundColor: "#0a0f1a",
+    padding: 2,
+  },
+  ratioBasisBtn: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 6,
+  },
+  ratioBasisBtnOn: { backgroundColor: COLORS.accent },
+  ratioBasisBtnText: { color: COLORS.muted, fontSize: 10, fontWeight: "600" },
+  ratioBasisBtnTextOn: { color: "#fff" },
+  avgKcalLine: { color: COLORS.muted, fontSize: 11, marginBottom: 8 },
+  avgKcalHint: { color: "#6b7280" },
   presetRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" },
   presetBtn: {
     paddingHorizontal: 12,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.63.0",
+  "version": "1.64.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/src/pfc.test.ts
+++ b/packages/domain/src/pfc.test.ts
@@ -1,5 +1,35 @@
 import { describe, expect, it } from "vitest";
-import { sumPfc } from "./pfc";
+import { pfcRatioPercents, pfcTotalKcal, sumPfc } from "./pfc";
+
+describe("pfcRatioPercents", () => {
+  const sample = { p: 15, f: 7, c: 1 };
+
+  it("重量比はグラム重量の割合", () => {
+    const r = pfcRatioPercents(sample, "gram");
+    expect(r.p).toBeCloseTo((15 / 23) * 100);
+    expect(r.f).toBeCloseTo((7 / 23) * 100);
+    expect(r.c).toBeCloseTo((1 / 23) * 100);
+    expect(r.p + r.f + r.c).toBeCloseTo(100);
+  });
+
+  it("カロリー比は 4–9–4 基準", () => {
+    const r = pfcRatioPercents(sample, "kcal");
+    expect(r.p).toBeCloseTo((60 / 127) * 100);
+    expect(r.f).toBeCloseTo((63 / 127) * 100);
+    expect(r.c).toBeCloseTo((4 / 127) * 100);
+    expect(r.p + r.f + r.c).toBeCloseTo(100);
+  });
+
+  it("全 0 のとき 0%", () => {
+    expect(pfcRatioPercents({ p: 0, f: 0, c: 0 }, "kcal")).toEqual({ p: 0, f: 0, c: 0 });
+  });
+});
+
+describe("pfcTotalKcal", () => {
+  it("4P+9F+4C", () => {
+    expect(pfcTotalKcal({ p: 15, f: 7, c: 1 })).toBe(127);
+  });
+});
 
 describe("sumPfc", () => {
   it("空ならゼロ", () => {

--- a/packages/domain/src/pfc.ts
+++ b/packages/domain/src/pfc.ts
@@ -34,3 +34,53 @@ export function pfcGramsFromNullablePer100(
     c: ((carbsPer100 ?? 0) * grams) / 100,
   };
 }
+
+/** 表示栄養の一般的な PFC 換算（kcal/g） */
+export const KCAL_PER_G_PROTEIN = 4;
+export const KCAL_PER_G_FAT = 9;
+export const KCAL_PER_G_CARBS = 4;
+
+export type PfcRatioBasis = "kcal" | "gram";
+
+export type PfcRatioPercents = {
+  p: number;
+  f: number;
+  c: number;
+};
+
+/** 各マクロの kcal 内訳（キーは gram と同じ p/f/c）。 */
+export function pfcKcal(grams: PfcGrams): PfcGrams {
+  return {
+    p: grams.p * KCAL_PER_G_PROTEIN,
+    f: grams.f * KCAL_PER_G_FAT,
+    c: grams.c * KCAL_PER_G_CARBS,
+  };
+}
+
+export function pfcTotalKcal(grams: PfcGrams): number {
+  const k = pfcKcal(grams);
+  return k.p + k.f + k.c;
+}
+
+/** 重量比またはカロリー比（4–9–4）の P/F/C 比率（%）。合計 0 のときはすべて 0。 */
+export function pfcRatioPercents(grams: PfcGrams, basis: PfcRatioBasis): PfcRatioPercents {
+  const weights = basis === "gram" ? grams : pfcKcal(grams);
+  const total = weights.p + weights.f + weights.c;
+  if (total <= 0) return { p: 0, f: 0, c: 0 };
+  return {
+    p: (weights.p / total) * 100,
+    f: (weights.f / total) * 100,
+    c: (weights.c / total) * 100,
+  };
+}
+
+/** 比率バー用の flex 比（合計 0 のときはすべて 0）。 */
+export function pfcRatioFlex(grams: PfcGrams, basis: PfcRatioBasis): PfcRatioPercents {
+  const pct = pfcRatioPercents(grams, basis);
+  const scale = 100;
+  return {
+    p: pct.p / scale,
+    f: pct.f / scale,
+    c: pct.c / scale,
+  };
+}

--- a/src/app/insights/InsightsClient.tsx
+++ b/src/app/insights/InsightsClient.tsx
@@ -1,14 +1,24 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
 import Link from "next/link";
+import {
+  pfcRatioPercents,
+  pfcTotalKcal,
+  type PfcGrams,
+  type PfcRatioBasis,
+} from "@ketolog/domain/pfc";
 import {
   addDaysJst,
   buildInsights,
   getPresetRange,
   type InsightFoodLogEntry,
 } from "@/lib/insights";
+import {
+  readInsightsPfcRatioBasis,
+  writeInsightsPfcRatioBasis,
+} from "@/lib/insights-pfc-ratio-storage";
 import { getInsightsFoodLogForDateRange } from "./actions";
 import { MEAL_LABELS, MEAL_TAB_STYLES, MEAL_TYPES } from "@/lib/constants/meal";
 import type { MealType } from "@ketolog/types";
@@ -27,9 +37,18 @@ function fmtNum(v: number): string {
   return v.toFixed(1);
 }
 
-function ratioStyle(total: number, part: number): { width: string } {
-  if (total <= 0) return { width: "0%" };
-  return { width: `${Math.max(0, Math.min(100, (part / total) * 100))}%` };
+function ratioStyleFromPercents(pct: number): { width: string } {
+  return { width: `${Math.max(0, Math.min(100, pct))}%` };
+}
+
+function toPfcGrams(protein: number, fat: number, carbs: number): PfcGrams {
+  return { p: protein, f: fat, c: carbs };
+}
+
+function ratioBasisButtonClass(active: boolean): string {
+  return `rounded-md px-2 py-1 text-[10px] font-medium transition-colors sm:text-[11px] ${
+    active ? "bg-emerald-600 text-white" : "bg-gray-800 text-gray-300 hover:bg-gray-700"
+  }`;
 }
 
 function jstDateLabel(date: string): string {
@@ -75,6 +94,17 @@ export default function InsightsClient({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [ratioBasis, setRatioBasis] = useState<PfcRatioBasis>("kcal");
+
+  useEffect(() => {
+    setRatioBasis(readInsightsPfcRatioBasis());
+  }, []);
+
+  function selectRatioBasis(next: PfcRatioBasis) {
+    setRatioBasis(next);
+    writeInsightsPfcRatioBasis(next);
+  }
+
   const selectedMealTypes = useMemo(
     () => (mealFilter === "all" ? undefined : [mealFilter]),
     [mealFilter]
@@ -84,10 +114,20 @@ export default function InsightsClient({
     () => buildInsights(entries, start, end, { mealTypes: selectedMealTypes }),
     [entries, start, end, selectedMealTypes]
   );
-  const avgTotal = insight.summary.avgProtein + insight.summary.avgFat + insight.summary.avgCarbs;
-  const avgProteinPct = avgTotal > 0 ? (insight.summary.avgProtein / avgTotal) * 100 : 0;
-  const avgFatPct = avgTotal > 0 ? (insight.summary.avgFat / avgTotal) * 100 : 0;
-  const avgCarbsPct = avgTotal > 0 ? (insight.summary.avgCarbs / avgTotal) * 100 : 0;
+  const avgGrams = useMemo(
+    () =>
+      toPfcGrams(
+        insight.summary.avgProtein,
+        insight.summary.avgFat,
+        insight.summary.avgCarbs
+      ),
+    [insight.summary.avgProtein, insight.summary.avgFat, insight.summary.avgCarbs]
+  );
+  const avgRatioPct = useMemo(
+    () => pfcRatioPercents(avgGrams, ratioBasis),
+    [avgGrams, ratioBasis]
+  );
+  const avgDailyKcal = useMemo(() => pfcTotalKcal(avgGrams), [avgGrams]);
 
   async function loadRange(
     nextStart: string,
@@ -262,29 +302,59 @@ export default function InsightsClient({
         </div>
 
         <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3">
-          <h2 className="mb-2 text-sm font-medium text-white">平均PFCバランス</h2>
+          <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
+            <h2 className="text-sm font-medium text-white">平均PFCバランス</h2>
+            <div
+              className="flex shrink-0 rounded-lg border border-gray-800 bg-gray-950/80 p-0.5"
+              role="group"
+              aria-label="PFC比率の表示基準"
+            >
+              <button
+                type="button"
+                onClick={() => selectRatioBasis("kcal")}
+                className={ratioBasisButtonClass(ratioBasis === "kcal")}
+                aria-pressed={ratioBasis === "kcal"}
+              >
+                カロリー比
+              </button>
+              <button
+                type="button"
+                onClick={() => selectRatioBasis("gram")}
+                className={ratioBasisButtonClass(ratioBasis === "gram")}
+                aria-pressed={ratioBasis === "gram"}
+              >
+                重量比
+              </button>
+            </div>
+          </div>
+          {ratioBasis === "kcal" ? (
+            <p className="mb-2 text-[11px] text-gray-400">
+              平均 {fmtNum(avgDailyKcal)} kcal/日
+              <span className="text-gray-500"> · P4・F9・C4 kcal/g</span>
+            </p>
+          ) : null}
           <div className="grid grid-cols-3 gap-2 text-center">
             <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
               <p className="text-[11px] text-gray-400">たんぱく質 (P)</p>
               <p className="text-sm font-semibold text-blue-300">{fmtNum(insight.summary.avgProtein)} g</p>
-              <p className="text-[11px] text-blue-200/90">{fmtNum(avgProteinPct)}%</p>
+              <p className="text-[11px] text-blue-200/90">{fmtNum(avgRatioPct.p)}%</p>
             </div>
             <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
               <p className="text-[11px] text-gray-400">脂質 (F)</p>
               <p className="text-sm font-semibold text-yellow-300">{fmtNum(insight.summary.avgFat)} g</p>
-              <p className="text-[11px] text-yellow-200/90">{fmtNum(avgFatPct)}%</p>
+              <p className="text-[11px] text-yellow-200/90">{fmtNum(avgRatioPct.f)}%</p>
             </div>
             <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
               <p className="text-[11px] text-gray-400">糖質 (C)</p>
               <p className="text-sm font-semibold text-emerald-300">{fmtNum(insight.summary.avgCarbs)} g</p>
-              <p className="text-[11px] text-emerald-200/90">{fmtNum(avgCarbsPct)}%</p>
+              <p className="text-[11px] text-emerald-200/90">{fmtNum(avgRatioPct.c)}%</p>
             </div>
           </div>
           <div className="mt-2 h-2 w-full overflow-hidden rounded bg-gray-800">
             <div className="flex h-full w-full">
-              <div className="bg-blue-400" style={ratioStyle(avgTotal, insight.summary.avgProtein)} />
-              <div className="bg-yellow-400" style={ratioStyle(avgTotal, insight.summary.avgFat)} />
-              <div className="bg-emerald-400" style={ratioStyle(avgTotal, insight.summary.avgCarbs)} />
+              <div className="bg-blue-400" style={ratioStyleFromPercents(avgRatioPct.p)} />
+              <div className="bg-yellow-400" style={ratioStyleFromPercents(avgRatioPct.f)} />
+              <div className="bg-emerald-400" style={ratioStyleFromPercents(avgRatioPct.c)} />
             </div>
           </div>
         </div>
@@ -298,7 +368,8 @@ export default function InsightsClient({
           <h2 className="text-sm font-medium text-white">日ごとの食事一覧</h2>
           {insight.daily.map((day) => {
             const isOpen = expanded.has(day.date);
-            const total = day.protein + day.fat + day.carbs;
+            const dayGrams = toPfcGrams(day.protein, day.fat, day.carbs);
+            const dayRatioPct = pfcRatioPercents(dayGrams, ratioBasis);
             return (
               <div key={day.date} className="rounded-lg border border-gray-800 bg-gray-950/60">
                 <button
@@ -317,9 +388,9 @@ export default function InsightsClient({
                     </div>
                     <div className="mt-1.5 h-2 w-full overflow-hidden rounded bg-gray-800">
                       <div className="flex h-full w-full">
-                        <div className="bg-blue-400" style={ratioStyle(total, day.protein)} />
-                        <div className="bg-yellow-400" style={ratioStyle(total, day.fat)} />
-                        <div className="bg-emerald-400" style={ratioStyle(total, day.carbs)} />
+                        <div className="bg-blue-400" style={ratioStyleFromPercents(dayRatioPct.p)} />
+                        <div className="bg-yellow-400" style={ratioStyleFromPercents(dayRatioPct.f)} />
+                        <div className="bg-emerald-400" style={ratioStyleFromPercents(dayRatioPct.c)} />
                       </div>
                     </div>
                   </div>

--- a/src/lib/insights-pfc-ratio-storage.ts
+++ b/src/lib/insights-pfc-ratio-storage.ts
@@ -1,0 +1,30 @@
+import type { PfcRatioBasis } from "@ketolog/domain/pfc";
+
+/** Web / Mobile で同一キー（`apps/mobile/lib/insights-pfc-ratio-storage.ts`） */
+export const INSIGHTS_PFC_RATIO_BASIS_STORAGE_KEY = "ketolog.insightsPfcRatioBasis.v1";
+
+const DEFAULT_BASIS: PfcRatioBasis = "kcal";
+
+function parseBasis(raw: string | null): PfcRatioBasis {
+  if (raw === "kcal" || raw === "gram") return raw;
+  return DEFAULT_BASIS;
+}
+
+/** SSR 時はデフォルト（カロリー比）を返す。 */
+export function readInsightsPfcRatioBasis(): PfcRatioBasis {
+  if (typeof window === "undefined") return DEFAULT_BASIS;
+  try {
+    return parseBasis(window.localStorage.getItem(INSIGHTS_PFC_RATIO_BASIS_STORAGE_KEY));
+  } catch {
+    return DEFAULT_BASIS;
+  }
+}
+
+export function writeInsightsPfcRatioBasis(basis: PfcRatioBasis): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(INSIGHTS_PFC_RATIO_BASIS_STORAGE_KEY, basis);
+  } catch {
+    /* quota 等 */
+  }
+}


### PR DESCRIPTION
## Summary

- 分析画面（Web / iOS）の PFC 比率（% 表示・カラーバー）を **カロリー比**（P4・F9・C4 kcal/g）と **重量比** で切り替え可能にした。デフォルトはカロリー比
- 平均PFCバランスと日次一覧の比率バーを同一トグルで連動。カロリー比時は **平均 kcal/日** を表示
- 選択は `localStorage`（Web）/ `AsyncStorage`（iOS）に永続化
- `@ketolog/domain/pfc` に `pfcRatioPercents` / `pfcTotalKcal` 等を追加し、Vitest で検証

closes #327

## Test plan

- [ ] 初回表示（storage なし）でカロリー比が選択され、脂質 % が重量比より高く表示される
- [ ] 重量比に切り替えると従来どおりグラム重量比になる
- [ ] 平均カードと日次一覧バーが同じモードで連動する
- [ ] カロリー比時に平均 kcal/日 が表示される
- [ ] リロード／アプリ再起動後も選択が保持される
- [ ] Web / iOS で同じ期間データなら同じ比率になる
- [ ] `npm test`（domain の pfc テスト）が通る


Made with [Cursor](https://cursor.com)