### PR TITLE
fix: PFC 未確定入力を保存時に反映する（#329）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.64.1] - 2026-07-01
+
+### Fixed
+
+- **Web / Mobile / メニュー登録（[#329](https://github.com/kzkski/ketolog/issues/329)）**: PFC 入力で最後のフィールドを確定（フォーカス移動）せずに保存しても、入力中の栄養素値が DB に反映されるようにした。
+
 ## [1.64.0] - 2026-05-19
 
 ### Added

--- a/apps/mobile/components/MenuItemEditorModal.tsx
+++ b/apps/mobile/components/MenuItemEditorModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-native";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { manualSharedProductServingFromDefaultGrams } from "@ketolog/domain/manual-shared-product-serving";
+import { resolveNutrientStoredValue } from "@ketolog/domain/nutrient-input";
 import { pfcGramsFromNullablePer100 } from "@ketolog/domain/pfc";
 import type { MealType } from "@ketolog/types";
 import {
@@ -231,6 +232,21 @@ export function MenuItemEditorModal({
     [nutrientMode, grams]
   );
 
+  const effectiveNutrientStrings = useCallback(
+    () => ({
+      protein: resolveNutrientStoredValue(nutrientMode, grams, protein, rawP),
+      fat: resolveNutrientStoredValue(nutrientMode, grams, fat, rawF),
+      carbs: resolveNutrientStoredValue(nutrientMode, grams, carbs, rawC),
+    }),
+    [nutrientMode, grams, protein, fat, carbs, rawP, rawF, rawC]
+  );
+
+  const parsePer100g = useCallback((s: string): number | null => {
+    if (s.trim() === "") return null;
+    const v = parseFloat(s);
+    return Number.isFinite(v) ? v : null;
+  }, []);
+
   const resetAddForm = useCallback(() => {
     setName("");
     setProtein("");
@@ -399,16 +415,12 @@ export function MenuItemEditorModal({
 
   const buildMenuPayload = useCallback(() => {
     const gramsNum = parseFloat(grams) || 100;
-    const n = (s: string) => {
-      if (s.trim() === "") return null;
-      const v = parseFloat(s);
-      return Number.isFinite(v) ? v : null;
-    };
+    const n = effectiveNutrientStrings();
     return {
       name: name.trim(),
-      protein_per_100g: n(protein),
-      fat_per_100g: n(fat),
-      carbs_per_100g: n(carbs),
+      protein_per_100g: parsePer100g(n.protein),
+      fat_per_100g: parsePer100g(n.fat),
+      carbs_per_100g: parsePer100g(n.carbs),
       default_grams: gramsNum,
       rank,
       notes: notes.trim() || null,
@@ -418,9 +430,8 @@ export function MenuItemEditorModal({
     };
   }, [
     name,
-    protein,
-    fat,
-    carbs,
+    effectiveNutrientStrings,
+    parsePer100g,
     grams,
     rank,
     notes,
@@ -434,16 +445,12 @@ export function MenuItemEditorModal({
     if (!isEdit) return null;
     if (!name.trim()) return null;
     const gramsNum = parseFloat(grams) || 100;
-    const n = (s: string) => {
-      if (s.trim() === "") return null;
-      const v = parseFloat(s);
-      return Number.isFinite(v) ? v : null;
-    };
+    const n = effectiveNutrientStrings();
     return {
       name: name.trim(),
-      protein_per_100g: n(protein),
-      fat_per_100g: n(fat),
-      carbs_per_100g: n(carbs),
+      protein_per_100g: parsePer100g(n.protein),
+      fat_per_100g: parsePer100g(n.fat),
+      carbs_per_100g: parsePer100g(n.carbs),
       shared_barcode: loadedEdit?.shared_barcode ?? null,
       standard_food_code: loadedEdit?.standard_food_code ?? null,
       default_grams: gramsNum,
@@ -451,7 +458,7 @@ export function MenuItemEditorModal({
       notes: notes.trim() || null,
       group: groupName.trim() || null,
     };
-  }, [isEdit, name, protein, fat, carbs, grams, rank, notes, groupName, loadedEdit]);
+  }, [isEdit, name, effectiveNutrientStrings, parsePer100g, grams, rank, notes, groupName, loadedEdit]);
 
   const shareQrPayload = useMemo(() => {
     if (!shareQrImportItem) return null;
@@ -914,9 +921,10 @@ export function MenuItemEditorModal({
     if (!snapshotRestaurantId) return null;
     if (!name.trim()) return null;
     const gramsNum = parseFloat(grams) || 100;
-    const p100 = protein === "" ? null : parseFloat(protein);
-    const f100 = fat === "" ? null : parseFloat(fat);
-    const c100 = carbs === "" ? null : parseFloat(carbs);
+    const n = effectiveNutrientStrings();
+    const p100 = parsePer100g(n.protein);
+    const f100 = parsePer100g(n.fat);
+    const c100 = parsePer100g(n.carbs);
     const v = pfcGramsFromNullablePer100(
       p100 !== null && Number.isFinite(p100) ? p100 : null,
       f100 !== null && Number.isFinite(f100) ? f100 : null,
@@ -936,7 +944,7 @@ export function MenuItemEditorModal({
       menu_item_id: null,
       saved_at: new Date().toISOString(),
     };
-  }, [snapshotRestaurantId, name, grams, protein, fat, carbs, date, logMeal]);
+  }, [snapshotRestaurantId, name, grams, effectiveNutrientStrings, parsePer100g, date, logMeal]);
 
   const handleLogOnly = useCallback(async () => {
     const draft = buildSnapshotLogDraft();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ketolog",
-  "version": "1.55.0",
+  "version": "1.64.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ketolog",
-      "version": "1.55.0",
+      "version": "1.64.0",
       "workspaces": [
         "apps/*",
         "packages/*"
@@ -7058,9 +7058,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7073,9 +7070,6 @@
       "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7090,9 +7084,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7105,9 +7096,6 @@
       "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7122,9 +7110,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7137,9 +7122,6 @@
       "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7154,9 +7136,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7169,9 +7148,6 @@
       "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7186,9 +7162,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7201,9 +7174,6 @@
       "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7218,9 +7188,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7234,9 +7201,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7249,9 +7213,6 @@
       "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.64.0",
+  "version": "1.64.1",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -16,6 +16,7 @@
     "./menu-share-qr": "./src/menu-share-qr.ts",
     "./restaurant-json-v1": "./src/restaurant-json-v1.ts",
     "./restaurant-import": "./src/restaurant-import.ts",
-    "./insights": "./src/insights.ts"
+    "./insights": "./src/insights.ts",
+    "./nutrient-input": "./src/nutrient-input.ts"
   }
 }

--- a/packages/domain/src/nutrient-input.test.ts
+++ b/packages/domain/src/nutrient-input.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { per100gFromDisplayValue, resolveNutrientStoredValue } from "./nutrient-input";
+
+describe("per100gFromDisplayValue", () => {
+  it("1回分を 100g あたりへ換算する", () => {
+    expect(per100gFromDisplayValue("10", "200")).toBe("5");
+  });
+});
+
+describe("resolveNutrientStoredValue", () => {
+  it("raw がある per100g では raw をそのまま使う", () => {
+    expect(resolveNutrientStoredValue("per100g", "100", "", "5.2")).toBe("5.2");
+  });
+
+  it("raw がある perServing では 100g あたりへ換算する", () => {
+    expect(resolveNutrientStoredValue("perServing", "200", "", "10")).toBe("5");
+  });
+
+  it("raw がなければ stored を使う", () => {
+    expect(resolveNutrientStoredValue("per100g", "100", "3", null)).toBe("3");
+  });
+
+  it("raw が空文字でも stored より優先する", () => {
+    expect(resolveNutrientStoredValue("per100g", "100", "3", "")).toBe("");
+  });
+});

--- a/packages/domain/src/nutrient-input.ts
+++ b/packages/domain/src/nutrient-input.ts
@@ -1,0 +1,26 @@
+export type NutrientInputMode = "per100g" | "perServing";
+
+/** 1回分表示値を 100g あたりの保存用文字列へ変換する */
+export function per100gFromDisplayValue(displayValue: string, gramsStr: string): string {
+  const v = parseFloat(displayValue);
+  const g = parseFloat(gramsStr);
+  if (isNaN(v) || isNaN(g) || g === 0) return displayValue;
+  return parseFloat((v * 100 / g).toFixed(2)).toString();
+}
+
+/**
+ * 未確定の raw 入力があれば保存用の per100g 文字列へ解決する。
+ * onBlur 前に保存しても、画面上の入力値がペイロードに反映される。
+ */
+export function resolveNutrientStoredValue(
+  mode: NutrientInputMode,
+  gramsStr: string,
+  stored: string,
+  raw: string | null,
+): string {
+  if (raw !== null) {
+    const trimmed = raw.trim();
+    return mode === "per100g" ? trimmed : per100gFromDisplayValue(trimmed, gramsStr);
+  }
+  return stored;
+}

--- a/src/app/today/_components/ItemDrawer.tsx
+++ b/src/app/today/_components/ItemDrawer.tsx
@@ -10,6 +10,7 @@ import {
 } from "react";
 import type { MenuItem, Restaurant, SharedProduct } from "@/types/database";
 import type { MealType } from "@ketolog/types";
+import { resolveNutrientStoredValue } from "@ketolog/domain/nutrient-input";
 import { pfcGramsFromNullablePer100 } from "@/lib/menu-item-pfc";
 import {
   addMenuItem,
@@ -493,12 +494,27 @@ export function MenuItemDrawer({
     setIsGroupSuggestionsOpen((v) => !v);
   }
 
+  function effectiveNutrientStrings() {
+    return {
+      protein: resolveNutrientStoredValue(mode, grams, protein, rawP),
+      fat: resolveNutrientStoredValue(mode, grams, fat, rawF),
+      carbs: resolveNutrientStoredValue(mode, grams, carbs, rawC),
+    };
+  }
+
+  function parsePer100g(s: string): number | null {
+    if (s.trim() === "") return null;
+    const v = parseFloat(s);
+    return Number.isFinite(v) ? v : null;
+  }
+
   function buildMenuPayload(): MenuItemUpdate {
+    const n = effectiveNutrientStrings();
     return {
       name: name.trim(),
-      protein_per_100g: protein === "" ? null : parseFloat(protein),
-      fat_per_100g: fat === "" ? null : parseFloat(fat),
-      carbs_per_100g: carbs === "" ? null : parseFloat(carbs),
+      protein_per_100g: parsePer100g(n.protein),
+      fat_per_100g: parsePer100g(n.fat),
+      carbs_per_100g: parsePer100g(n.carbs),
       shared_barcode: sharedBarcode,
       standard_food_code: standardFoodCode,
       default_grams: parseFloat(grams) || 100,
@@ -512,9 +528,10 @@ export function MenuItemDrawer({
     if (!snapshotRestaurantId) return null;
     if (!name.trim()) return null;
     const gramsNum = parseFloat(grams) || 100;
-    const p100 = protein === "" ? null : parseFloat(protein);
-    const f100 = fat === "" ? null : parseFloat(fat);
-    const c100 = carbs === "" ? null : parseFloat(carbs);
+    const n = effectiveNutrientStrings();
+    const p100 = parsePer100g(n.protein);
+    const f100 = parsePer100g(n.fat);
+    const c100 = parsePer100g(n.carbs);
     const v = pfcGramsFromNullablePer100(
       p100 !== null && Number.isFinite(p100) ? p100 : null,
       f100 !== null && Number.isFinite(f100) ? f100 : null,
@@ -592,11 +609,12 @@ export function MenuItemDrawer({
       return;
     }
     const gramsNum = parseFloat(grams) || 100;
+    const n = effectiveNutrientStrings();
     onSnapshotCart({
       name: name.trim(),
-      protein_per_100g: protein === "" ? null : parseFloat(protein),
-      fat_per_100g: fat === "" ? null : parseFloat(fat),
-      carbs_per_100g: carbs === "" ? null : parseFloat(carbs),
+      protein_per_100g: parsePer100g(n.protein),
+      fat_per_100g: parsePer100g(n.fat),
+      carbs_per_100g: parsePer100g(n.carbs),
       grams: gramsNum,
       shared_barcode: sharedBarcode,
     });


### PR DESCRIPTION
## Summary

- PFC 入力フィールドは `onBlur` で確定する設計のため、フォーカスを移動せずに保存すると最後に入力した値（特に糖質）が DB に渡らない問題を修正した
- `@ketolog/domain/nutrient-input` に `resolveNutrientStoredValue` を追加し、保存時に未確定の `rawP` / `rawF` / `rawC` を解決してペイロードへ反映する
- Web `ItemDrawer` と Mobile `MenuItemEditorModal` のメニュー登録・スナップショット記録・カート追加の各経路に適用

## Test plan

- [x] `npm test`（`nutrient-input.test.ts` 含む 51 件成功）
- [ ] Web: メニュー追加で C を入力 → blur せず「このお店のメニューに登録」→ 再表示で C が保存されている
- [ ] Web: 同様に「カートに入れる」「今すぐ食事ログに記録」でも C が反映される
- [ ] Mobile: 同様の手順でメニュー登録・即時記録が正しい PFC になる
- [ ] 1回分モードで入力した値も保存時に 100g 換算される

closes #329

Made with [Cursor](https://cursor.com)