### PR TITLE
feat(mobile): 検索フィールドにクリアボタンを追加（#330）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 - **ドキュメント / リリース運用**: `docs/release/README.md` を v2-v3 の運用ハブとして再編し、`beta-checklist.md` / `quality-and-ci.md` に Tracking ひな形（Status/Track/Issue/Owner/DoD）を追加した。v3 向けに `docs/release/v3-native-feasibility.md` を新設し、ネイティブアプリ化の判断観点を整理した。
 - **ドキュメント / ベータ運用**: `beta-checklist.md` に Ketovisor 連携向けデータ契約（`contractVersion`・スキーマ・互換ポリシー）を追加し、`docs/release/README.md` と `ROADMAP.md` の v2 優先トラックに反映した（[#248](https://github.com/kzkski/ketolog/issues/248)）。
 
+## [1.65.0] - 2026-07-01
+
+### Added
+
+- **Mobile / Today（[#330](https://github.com/kzkski/ketolog/issues/330)）**: メニュー・お気に入り・成分表の検索フィールドに、Web と同様の一括クリア（×）ボタンを追加した。
+
 ## [1.64.0] - 2026-05-19
 
 ### Added

--- a/apps/mobile/components/MenuBrowseSearchField.tsx
+++ b/apps/mobile/components/MenuBrowseSearchField.tsx
@@ -1,0 +1,75 @@
+import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
+
+type MenuBrowseSearchFieldProps = {
+  value: string;
+  onChangeText: (text: string) => void;
+  placeholder: string;
+  accessibilityLabel?: string;
+};
+
+export function MenuBrowseSearchField({
+  value,
+  onChangeText,
+  placeholder,
+  accessibilityLabel = "検索",
+}: MenuBrowseSearchFieldProps) {
+  const showClear = value.length > 0;
+
+  return (
+    <View style={styles.row}>
+      <TextInput
+        value={value}
+        onChangeText={onChangeText}
+        placeholder={placeholder}
+        placeholderTextColor="#6b7280"
+        style={styles.input}
+        accessibilityLabel={accessibilityLabel}
+        returnKeyType="search"
+      />
+      {showClear ? (
+        <Pressable
+          onPress={() => onChangeText("")}
+          style={({ pressed }) => [styles.clearBtn, pressed && styles.clearBtnPressed]}
+          accessibilityLabel="検索をクリア"
+          hitSlop={8}
+        >
+          <Text style={styles.clearGlyph}>×</Text>
+        </Pressable>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#374151",
+    backgroundColor: "rgba(3, 7, 18, 0.8)",
+  },
+  input: {
+    flex: 1,
+    minWidth: 0,
+    color: "#e5e7eb",
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    fontSize: 14,
+  },
+  clearBtn: {
+    minWidth: 44,
+    minHeight: 44,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 10,
+  },
+  clearBtnPressed: {
+    opacity: 0.75,
+  },
+  clearGlyph: {
+    color: "#9ca3af",
+    fontSize: 20,
+    lineHeight: 22,
+    fontWeight: "300",
+  },
+});

--- a/apps/mobile/components/TodayMenuPanel.tsx
+++ b/apps/mobile/components/TodayMenuPanel.tsx
@@ -48,6 +48,7 @@ import {
 import type { StandardFoodSearchRow } from "../lib/search-standard-foods-mobile";
 import { RenameRestaurantModal } from "./RenameRestaurantModal";
 import { StandardFoodCompositionPanel } from "./StandardFoodCompositionPanel";
+import { MenuBrowseSearchField } from "./MenuBrowseSearchField";
 import { ImportMenuItemsModal } from "./ImportMenuItemsModal";
 import { deleteRestaurantMobile } from "../lib/delete-restaurant-mobile";
 import { reorderRestaurantsMobile } from "../lib/reorder-restaurants-mobile";
@@ -854,12 +855,11 @@ export function TodayMenuPanel({
             contentContainerStyle={styles.compositionScrollContent}
             keyboardShouldPersistTaps="handled"
           >
-            <TextInput
+            <MenuBrowseSearchField
               value={compositionQuery}
               onChangeText={setCompositionQuery}
               placeholder="成分表を検索（例: さけ 生）"
-              placeholderTextColor="#6b7280"
-              style={styles.search}
+              accessibilityLabel="成分表を検索"
             />
             <StandardFoodCompositionPanel
               supabase={supabase}
@@ -886,12 +886,11 @@ export function TodayMenuPanel({
               ) : undefined
             }
           >
-            <TextInput
+            <MenuBrowseSearchField
               value={query}
               onChangeText={setQuery}
               placeholder={tab === "favorites" ? "お気に入りを検索" : "メニューを検索"}
-              placeholderTextColor="#6b7280"
-              style={styles.search}
+              accessibilityLabel={tab === "favorites" ? "お気に入りを検索" : "メニューを検索"}
             />
             {loading ? (
               <View style={styles.center}>
@@ -1250,15 +1249,6 @@ const styles = StyleSheet.create({
   },
   restaurantNameTextOn: {
     color: "#f9fafb",
-  },
-  search: {
-    borderWidth: 1,
-    borderColor: "#374151",
-    borderRadius: 0,
-    color: "#e5e7eb",
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    fontSize: 14,
   },
   center: { alignItems: "center", paddingVertical: 20 },
   error: { color: "#fecaca", fontSize: 12, paddingVertical: 8 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.64.0",
+  "version": "1.65.0",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## Summary

- iOS ネイティブアプリの Today 画面で、検索文字列を一括クリアできるようにした
- `MenuBrowseSearchField` コンポーネントを新設し、メニュー・お気に入り・成分表の 3 箇所に適用
- 入力があるときだけ右側に × ボタンを表示（Web の `type="search"` クリア UI に合わせた操作感）

## Test plan

- [ ] iOS Simulator / 実機: メニュー検索に文字入力 → × タップで空になり一覧が全件表示に戻る
- [ ] お気に入りタブ・成分表タブでも同様
- [ ] クリア後に再入力・スクロールが問題ない
- [ ] Android でも表示・操作に問題ない

closes #330

Made with [Cursor](https://cursor.com)