### PR TITLE
fix(db): daily_log ビューの security_invoker 化と権限最小化

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **DB / daily_log**: `public.daily_log` ビューを `security_invoker` に変更し、`anon` の過剰 GRANT を剥奪、`authenticated` は SELECT のみに制限した。SECURITY DEFINER による RLS バイパス（他ユーザーの日次集計が見える問題）を解消（[MyVitalRelay#14](https://github.com/kzkski/MyVitalRelay/issues/14)）。
+
 ### Changed
 
 ## [1.65.0] - 2026-07-01

--- a/supabase/migrations/20260710120000_fix_daily_log_security_invoker.sql
+++ b/supabase/migrations/20260710120000_fix_daily_log_security_invoker.sql
@@ -1,0 +1,14 @@
+-- daily_log ビューを security_invoker にし、権限を最小化する。
+-- Issue: kzkski/MyVitalRelay#14
+-- 本番では security_invoker のみ先行適用済み。本 migration で権限整理も含めて再現可能にする。
+
+ALTER VIEW public.daily_log SET (security_invoker = true);
+
+COMMENT ON VIEW public.daily_log IS
+  '日次集計ビュー（food_log / body_composition / sleep / activity）。security_invoker=true で基底テーブル RLS 準拠。';
+
+REVOKE ALL ON public.daily_log FROM anon;
+REVOKE ALL ON public.daily_log FROM PUBLIC;
+
+REVOKE ALL ON public.daily_log FROM authenticated;
+GRANT SELECT ON public.daily_log TO authenticated;


### PR DESCRIPTION
## Summary

- `public.daily_log` を `security_invoker = true` に設定（SECURITY DEFINER による RLS バイパスを解消）
- `anon` / `PUBLIC` から過剰 GRANT を REVOKE
- `authenticated` は SELECT のみ GRANT

MyVitalRelay [#14](https://github.com/kzkski/MyVitalRelay/issues/14) 対応。

## 本番適用状況

本 PR の migration は **本番 DB に適用済み**（Supabase MCP 経由）。ローカル再現性のためリポジトリに追加。

## Test plan

- [x] `security_invoker=true` 確認
- [x] `security_definer_view` Linter ERROR 解消
- [x] 回帰テスト: `count(*)=212`, `count(distinct user_id)=1`
- [x] RLS 分離: kazuki@ 212行、kyoko@ 0行
- [x] `anon` 権限なし、`authenticated` SELECT のみ


Made with [Cursor](https://cursor.com)