### PR TITLE
feat: Today画面に総摂取カロリー（kcal）を表示

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 ### Changed
 
+## [1.68.0] - 2026-07-25
+
+### Added
+
+- **Today**: PFC進捗バーの右側に、その日の総摂取カロリー（kcal）を表示（Web / iOS共通）。記録済み＋カート内のPFCから算出し、整数（四捨五入）で表示する（[#342](https://github.com/kzkski/ketolog/issues/342)）。
+
 ## [1.67.0] - 2026-07-13
 
 ### Added

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -15,7 +15,12 @@ import brandHeaderImage from "../assets/brand-header.png";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { Ionicons } from "@expo/vector-icons";
 import Constants from "expo-constants";
-import { pfcGramsFromNullablePer100, sumPfc, type PfcGrams } from "@ketolog/domain/pfc";
+import {
+  pfcGramsFromNullablePer100,
+  pfcTotalKcal,
+  sumPfc,
+  type PfcGrams,
+} from "@ketolog/domain/pfc";
 import { getMealTypeForTimeZone } from "@ketolog/domain/meal-timezone";
 import type { MealType } from "@ketolog/types";
 import {
@@ -289,6 +294,7 @@ export function TodayScreen() {
 
   /** バー表示は「本日の記録」＋「カート内」を合算（カート投入で即反映） */
   const pfcBarCurrent = useMemo(() => sumPfc(consumed, cartPfcTotal), [consumed, cartPfcTotal]);
+  const totalKcal = Math.round(pfcTotalKcal(pfcBarCurrent));
 
   const mergeCartLine = useCallback(
     (line: CartLineState) => {
@@ -842,30 +848,39 @@ export function TodayScreen() {
 
           <View
             style={styles.pfcBlock}
+            accessible
             accessibilityLabel={
               cartLinesSorted.length > 0
-                ? "PFC（記録済みとカート内の合計）"
-                : "PFC（記録済み）"
+                ? `PFC（記録済みとカート内の合計）。合計摂取 ${totalKcal} kcal`
+                : `PFC（記録済み）。合計摂取 ${totalKcal} kcal`
             }
           >
-            <PfcBarRow
-              label="P"
-              current={pfcBarCurrent.p}
-              target={activeProfile.protein_target_g}
-              color={COLORS.p}
-            />
-            <PfcBarRow
-              label="F"
-              current={pfcBarCurrent.f}
-              target={activeProfile.fat_target_g}
-              color={COLORS.f}
-            />
-            <PfcBarRow
-              label="C"
-              current={pfcBarCurrent.c}
-              target={activeProfile.carbs_target_g}
-              color={COLORS.c}
-            />
+            <View style={styles.pfcRows}>
+              <PfcBarRow
+                label="P"
+                current={pfcBarCurrent.p}
+                target={activeProfile.protein_target_g}
+                color={COLORS.p}
+              />
+              <PfcBarRow
+                label="F"
+                current={pfcBarCurrent.f}
+                target={activeProfile.fat_target_g}
+                color={COLORS.f}
+              />
+              <PfcBarRow
+                label="C"
+                current={pfcBarCurrent.c}
+                target={activeProfile.carbs_target_g}
+                color={COLORS.c}
+              />
+            </View>
+            <View style={styles.kcalBox} accessible={false}>
+              <Text style={styles.kcalValue} numberOfLines={1}>
+                {totalKcal}
+              </Text>
+              <Text style={styles.kcalUnit}>kcal</Text>
+            </View>
           </View>
 
           <View style={[styles.logOuter, !showLogEntries && styles.logOuterCollapsed]}>
@@ -1298,11 +1313,18 @@ const styles = StyleSheet.create({
   phaseBtnTextOn: { color: COLORS.phaseOnText, fontSize: 11, fontWeight: "600" },
   phaseBtnTextOff: { color: COLORS.phaseOffText, fontSize: 11, fontWeight: "500" },
   pfcBlock: {
+    flexDirection: "row",
+    alignItems: "stretch",
     paddingHorizontal: 14,
     paddingVertical: 12,
     backgroundColor: COLORS.sectionBg,
     borderBottomWidth: StyleSheet.hairlineWidth,
     borderBottomColor: COLORS.headerBorder,
+    gap: 10,
+  },
+  pfcRows: {
+    flex: 1,
+    minWidth: 0,
     gap: 6,
   },
   pfcRow: {
@@ -1329,6 +1351,27 @@ const styles = StyleSheet.create({
     textAlign: "right",
     color: COLORS.text,
     fontVariant: ["tabular-nums"],
+  },
+  kcalBox: {
+    minWidth: 56,
+    alignItems: "center",
+    justifyContent: "center",
+    gap: 2,
+    paddingHorizontal: 4,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#374151",
+    backgroundColor: "rgba(31,41,55,0.6)",
+  },
+  kcalValue: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#ffffff",
+    fontVariant: ["tabular-nums"],
+  },
+  kcalUnit: {
+    fontSize: 10,
+    color: COLORS.textMuted,
   },
   logOuter: {
     marginTop: 8,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.67.0",
+  "version": "1.68.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/app/today/_components/PfcHeader.tsx
+++ b/src/app/today/_components/PfcHeader.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { AriaAttributes, ReactNode } from "react";
 import type { DietPhase, PhaseProfiles } from "@/lib/diet-phase";
+import { pfcTotalKcal } from "@ketolog/domain/pfc";
 import type { PfcGrams } from "@ketolog/types";
 import { MACRO_BAR_BG } from "@/lib/macroHighlights";
 
@@ -37,6 +38,26 @@ function PfcBarRow({
         className={`text-xs tabular-nums w-[4.75rem] sm:w-[4.5rem] text-right ${over ? "text-red-400" : "text-gray-300"}`}
       >
         {fmtMacroGrams(current)} / {target}g
+      </span>
+    </div>
+  );
+}
+
+function KcalBadge({ totalKcal }: { totalKcal: number }) {
+  return (
+    <div
+      role="group"
+      aria-label={`合計摂取 ${totalKcal} kcal`}
+      className="flex min-w-14 sm:min-w-16 shrink-0 flex-col items-center justify-center gap-0.5 rounded-lg border border-gray-700 bg-gray-800/60 px-1"
+    >
+      <span
+        aria-hidden="true"
+        className="text-sm sm:text-base font-bold text-white tabular-nums leading-none whitespace-nowrap"
+      >
+        {totalKcal}
+      </span>
+      <span aria-hidden="true" className="text-[10px] text-gray-400 leading-none">
+        kcal
       </span>
     </div>
   );
@@ -100,6 +121,7 @@ export function PfcHeader({
   appUpdateApplying,
   onApplyAppUpdate,
 }: PfcHeaderProps) {
+  const totalKcal = Math.round(pfcTotalKcal(totalConsumed));
   const changelogUrl = process.env.NEXT_PUBLIC_CHANGELOG_URL;
   const appVersion = process.env.NEXT_PUBLIC_APP_VERSION;
 
@@ -193,25 +215,30 @@ export function PfcHeader({
         </div>
       </div>
 
-      <div className="flex-none px-3 sm:px-4 py-1.5 sm:py-3 bg-gray-900 border-b border-gray-800 space-y-1 sm:space-y-1.5">
-        <PfcBarRow
-          label="P"
-          current={totalConsumed.p}
-          target={proteinTargetG}
-          color={MACRO_BAR_BG.p}
-        />
-        <PfcBarRow
-          label="F"
-          current={totalConsumed.f}
-          target={fatTargetG}
-          color={MACRO_BAR_BG.f}
-        />
-        <PfcBarRow
-          label="C"
-          current={totalConsumed.c}
-          target={carbsTargetG}
-          color={MACRO_BAR_BG.c}
-        />
+      <div className="flex-none px-3 sm:px-4 py-1.5 sm:py-3 bg-gray-900 border-b border-gray-800">
+        <div className="flex items-stretch gap-2 sm:gap-3">
+          <div className="flex-1 min-w-0 space-y-1 sm:space-y-1.5">
+            <PfcBarRow
+              label="P"
+              current={totalConsumed.p}
+              target={proteinTargetG}
+              color={MACRO_BAR_BG.p}
+            />
+            <PfcBarRow
+              label="F"
+              current={totalConsumed.f}
+              target={fatTargetG}
+              color={MACRO_BAR_BG.f}
+            />
+            <PfcBarRow
+              label="C"
+              current={totalConsumed.c}
+              target={carbsTargetG}
+              color={MACRO_BAR_BG.c}
+            />
+          </div>
+          <KcalBadge totalKcal={totalKcal} />
+        </div>
       </div>
 
       {headerHint && hintDialogOpen && (


### PR DESCRIPTION
## Summary

- Today 画面の PFC 進捗バー（P/F/C）の右側に、表示中日付の総摂取カロリーを表示する
- Web（`PfcHeader`）と iOS（`TodayScreen`）で同一レイアウト（3行の右に縦積み、行は増やさない）
- 計算は既存の `pfcTotalKcal`（P×4 / F×9 / C×4）。対象はバーと同じ「記録済み + カート」
- 表示は整数（四捨五入）+ 単位 `kcal`

closes #342

## Test plan

- [ ] 記録なし・カート空で `0` kcal と表示される
- [ ] カート追加で保存前でも kcal が増える（バーと同時）
- [ ] 記録保存後も合計として継続表示される
- [ ] 日付切替でその日の値に追随する
- [ ] 生の p/f/c から `p*4+f*9+c*4` を四捨五入した値と一致する
- [ ] PFC バーが3行のままである
- [ ] Web（デスクトップ／狭幅）と iOS（SE 幅含む）でレイアウト崩れがない
- [ ] `npm run mobile:typecheck` / domain tests が通る

Made with [Cursor](https://cursor.com)