### PR TITLE
feat: カート行の簡素化と g 編集の統一「半分」ショートカット

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@
 
 ### Changed
 
+## [1.69.0] - 2026-07-25
+
+### Added
+
+- **Today / カート**: カート行を「名前 / PFC / 回数 / g / 削除」に整理し、g の横に統一デザインの `½`（分量を半分にする）ショートカットを追加。記録済みの g 編集（Web / Mobile）にも同じボタンを置いた（[#345](https://github.com/kzkski/ketolog/issues/345)）。
+
+### Changed
+
+- **Today / カート**: 名前横の `×回数（合計g）` 表示をやめ、回数は独立ステッパー（数字タップで 0.5 ↔ 1）で操作する（[#345](https://github.com/kzkski/ketolog/issues/345)）。
+
 ## [1.68.0] - 2026-07-25
 
 ### Added

--- a/apps/mobile/components/FoodLogEntryModal.tsx
+++ b/apps/mobile/components/FoodLogEntryModal.tsx
@@ -13,6 +13,7 @@ import {
 } from "react-native";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { pfcGramsFromNullablePer100 } from "@ketolog/domain/pfc";
+import { formatGramsShort } from "@ketolog/domain/cart-serving";
 import type { MealType } from "@ketolog/types";
 
 import type { MenuPrefill } from "../lib/menu-prefill";
@@ -23,6 +24,7 @@ import {
   type FoodLogOutboxDraft,
 } from "../lib/food-log-outbox";
 import { getIsOnline, isTransientNetworkError } from "../lib/network";
+import { HalfGramsButton } from "./HalfGramsButton";
 
 const MEALS: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
 
@@ -302,6 +304,12 @@ export function FoodLogEntryModal({
     void runSaveEdit();
   }, [runSaveEdit]);
 
+  const gramsDraftNum = Number.parseFloat(gramsStr.replace(/,/g, ""));
+  const gramsForHalve =
+    Number.isFinite(gramsDraftNum) && gramsDraftNum > 0
+      ? gramsDraftNum
+      : entry?.grams ?? 100;
+
   return (
     <Modal
       visible={visible}
@@ -399,6 +407,12 @@ export function FoodLogEntryModal({
                     </Pressable>
                   ))}
                 </ScrollView>
+                <HalfGramsButton
+                  value={gramsForHalve}
+                  disabled={busy}
+                  size="compact"
+                  onHalve={(next) => setGramsStr(formatGramsShort(next))}
+                />
                 <TextInput
                   value={gramsStr}
                   onChangeText={setGramsStr}

--- a/apps/mobile/components/HalfGramsButton.tsx
+++ b/apps/mobile/components/HalfGramsButton.tsx
@@ -1,0 +1,90 @@
+import { Pressable, StyleSheet, Text } from "react-native";
+import {
+  canHalveGrams,
+  HALF_GRAMS_ARIA_LABEL,
+  HALF_GRAMS_HINT,
+  HALF_GRAMS_LABEL,
+  HALF_GRAMS_LABEL_FULL,
+  halveGrams,
+} from "@ketolog/domain/cart-serving";
+
+type Props = {
+  value: number;
+  disabled?: boolean;
+  size?: "compact" | "mini" | "full";
+  onHalve: (next: number) => void;
+};
+
+export function HalfGramsButton({
+  value,
+  disabled = false,
+  size = "compact",
+  onHalve,
+}: Props) {
+  const blocked = disabled || !canHalveGrams(value);
+
+  return (
+    <Pressable
+      disabled={blocked}
+      onPress={() => onHalve(halveGrams(value))}
+      hitSlop={size === "mini" ? { top: 8, bottom: 4, left: 8, right: 8 } : 6}
+      accessibilityRole="button"
+      accessibilityLabel={HALF_GRAMS_ARIA_LABEL}
+      accessibilityHint={HALF_GRAMS_HINT}
+      style={({ pressed }) => [
+        size === "full" ? styles.full : size === "mini" ? styles.mini : styles.compact,
+        blocked && { opacity: 0.4 },
+        pressed && !blocked && { opacity: 0.85, transform: [{ scale: 0.96 }] },
+      ]}
+    >
+      <Text style={size === "full" ? styles.fullText : styles.labelText}>
+        {size === "full" ? HALF_GRAMS_LABEL_FULL : HALF_GRAMS_LABEL}
+      </Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  compact: {
+    minWidth: 36,
+    minHeight: 36,
+    paddingHorizontal: 8,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#10b981",
+    backgroundColor: "rgba(16, 185, 129, 0.15)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  mini: {
+    minWidth: 40,
+    minHeight: 20,
+    paddingHorizontal: 4,
+    borderRadius: 6,
+    borderWidth: 1,
+    borderColor: "#10b981",
+    backgroundColor: "rgba(16, 185, 129, 0.15)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  full: {
+    minHeight: 44,
+    paddingHorizontal: 12,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: "#10b981",
+    backgroundColor: "rgba(16, 185, 129, 0.15)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  labelText: {
+    color: "#a7f3d0",
+    fontSize: 13,
+    fontWeight: "700",
+  },
+  fullText: {
+    color: "#a7f3d0",
+    fontSize: 14,
+    fontWeight: "700",
+  },
+});

--- a/apps/mobile/components/TodayCartDock.tsx
+++ b/apps/mobile/components/TodayCartDock.tsx
@@ -16,6 +16,19 @@ import {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import type { MealType } from "@ketolog/types";
 import { pfcGramsFromNullablePer100, type PfcGrams } from "@ketolog/domain/pfc";
+import {
+  decrementCount,
+  formatCount,
+  formatGramsShort,
+  HALF_COUNT,
+  incrementCount,
+  isRemovableCount,
+  MIN_GRAMS,
+  roundGrams,
+  toggleHalfCount,
+  totalGramsForLine,
+} from "@ketolog/domain/cart-serving";
+import { HalfGramsButton } from "./HalfGramsButton";
 
 export type CartLineState = {
   menuItemId: string;
@@ -65,6 +78,7 @@ type Props = {
   onClearAll: () => void;
   onRemoveLine: (menuItemId: string) => void;
   onUpdateGramsPerServing: (menuItemId: string, grams: number) => void;
+  onChangeCount: (menuItemId: string, count: number) => void;
 };
 
 export function TodayCartDock({
@@ -79,6 +93,7 @@ export function TodayCartDock({
   onClearAll,
   onRemoveLine,
   onUpdateGramsPerServing,
+  onChangeCount,
 }: Props) {
   const insets = useSafeAreaInsets();
   const { height: windowHeight } = useWindowDimensions();
@@ -97,7 +112,7 @@ export function TodayCartDock({
   function openGramsSheet(menuItemId: string) {
     if (saving) return;
     const line = lines.find((l) => l.menuItemId === menuItemId);
-    setSheetDraft(line ? String(line.gramsPerServing) : "");
+    setSheetDraft(line ? formatGramsShort(line.gramsPerServing) : "");
     setGramsSheetForId(menuItemId);
   }
 
@@ -109,14 +124,14 @@ export function TodayCartDock({
   function applySheetDelta(delta: number) {
     const v = Number.parseFloat(sheetDraft.replace(/,/g, ""));
     const base = Number.isFinite(v) && v > 0 ? v : 1;
-    setSheetDraft(String(Math.max(1, base + delta)));
+    setSheetDraft(formatGramsShort(Math.max(MIN_GRAMS, roundGrams(base + delta))));
   }
 
   function commitGramsSheet() {
     if (!gramsSheetForId || saving) return;
     const n = Number.parseFloat(sheetDraft.replace(/,/g, ""));
     if (!Number.isFinite(n) || n <= 0) {
-      if (sheetLine) setSheetDraft(String(sheetLine.gramsPerServing));
+      if (sheetLine) setSheetDraft(formatGramsShort(sheetLine.gramsPerServing));
       return;
     }
     onUpdateGramsPerServing(gramsSheetForId, n);
@@ -136,8 +151,13 @@ export function TodayCartDock({
 
   if (lines.length === 0) return null;
 
-  const nItems = lines.reduce((s, l) => s + l.count, 0);
+  const nItems = lines.length;
   const shell = CART_MEAL_CHIP_ACTIVE[mealType];
+  const sheetDraftNum = Number.parseFloat(sheetDraft.replace(/,/g, ""));
+  const sheetGramsValue =
+    Number.isFinite(sheetDraftNum) && sheetDraftNum > 0
+      ? sheetDraftNum
+      : sheetLine?.gramsPerServing ?? 1;
 
   return (
     <>
@@ -169,6 +189,12 @@ export function TodayCartDock({
             </Text>
             <Text style={styles.gramsSheetSubtitle}>1回あたり（g）</Text>
             <View style={styles.gramsStepRow}>
+              <HalfGramsButton
+                value={sheetGramsValue}
+                disabled={saving}
+                size="compact"
+                onHalve={(next) => setSheetDraft(formatGramsShort(next))}
+              />
               <Pressable
                 onPress={() => applySheetDelta(-5)}
                 disabled={saving}
@@ -265,7 +291,7 @@ export function TodayCartDock({
           style={({ pressed }) => [styles.headerMainTap, pressed && { opacity: 0.88 }]}
         >
           <View style={styles.headerMain}>
-            <Text style={styles.headerTitle}>カート（{nItems}）</Text>
+            <Text style={styles.headerTitle}>カート（{nItems}品）</Text>
           </View>
         </Pressable>
         <View style={styles.headerActions}>
@@ -320,40 +346,100 @@ export function TodayCartDock({
             nestedScrollEnabled
           >
             {lines.map((line) => {
-              const totalGrams = line.gramsPerServing * line.count;
+              const totalGrams = totalGramsForLine(line);
               const v = pfcGramsFromNullablePer100(
                 line.protein_per_100g,
                 line.fat_per_100g,
                 line.carbs_per_100g,
                 totalGrams
               );
+              const isHalfCount = line.count === HALF_COUNT;
               return (
                 <View key={line.menuItemId} style={styles.lineRow}>
                   <View style={styles.lineBody}>
                     <Text style={styles.lineName} numberOfLines={2}>
                       {line.name}
-                      <Text style={styles.countGrams}>
-                        {" "}
-                        ×{line.count}（{totalGrams}g）
-                      </Text>
                     </Text>
                     <Text style={styles.linePfc}>
                       P{fmtMacroGrams(v.p)} F{fmtMacroGrams(v.f)} C{fmtMacroGrams(v.c)}
                     </Text>
                   </View>
-                  <Pressable
-                    onPress={() => openGramsSheet(line.menuItemId)}
-                    disabled={saving}
-                    style={({ pressed }) => [
-                      styles.gramsCol,
-                      pressed && { opacity: 0.88 },
-                      saving && { opacity: 0.45 },
-                    ]}
-                    accessibilityLabel="1回あたりのグラムを編集"
-                  >
-                    <Text style={styles.gramsLabel}>1回</Text>
-                    <Text style={styles.gramsTapValue}>{fmtMacroGrams(line.gramsPerServing)}g</Text>
-                  </Pressable>
+                  <View style={styles.countCol}>
+                    <Pressable
+                      onPress={() => {
+                        const next = decrementCount(line.count);
+                        if (isRemovableCount(next)) onRemoveLine(line.menuItemId);
+                        else onChangeCount(line.menuItemId, next);
+                      }}
+                      disabled={saving}
+                      style={({ pressed }) => [
+                        styles.countBtn,
+                        pressed && { opacity: 0.8 },
+                        saving && { opacity: 0.45 },
+                      ]}
+                      accessibilityLabel="回数を減らす"
+                    >
+                      <Text style={styles.countBtnText}>−</Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() => onChangeCount(line.menuItemId, toggleHalfCount(line.count))}
+                      disabled={saving}
+                      style={({ pressed }) => [
+                        styles.countValueBtn,
+                        isHalfCount && styles.countValueHalf,
+                        pressed && { opacity: 0.85 },
+                        saving && { opacity: 0.45 },
+                      ]}
+                      accessibilityLabel={
+                        isHalfCount ? "回数を1に戻す" : "回数を0.5にする"
+                      }
+                    >
+                      <Text
+                        style={[
+                          styles.countValueText,
+                          isHalfCount && styles.countValueTextHalf,
+                        ]}
+                      >
+                        {formatCount(line.count)}
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      onPress={() =>
+                        onChangeCount(line.menuItemId, incrementCount(line.count))
+                      }
+                      disabled={saving}
+                      style={({ pressed }) => [
+                        styles.countBtn,
+                        pressed && { opacity: 0.8 },
+                        saving && { opacity: 0.45 },
+                      ]}
+                      accessibilityLabel="回数を増やす"
+                    >
+                      <Text style={styles.countBtnText}>+</Text>
+                    </Pressable>
+                  </View>
+                  <View style={styles.gramsCol}>
+                    <HalfGramsButton
+                      value={line.gramsPerServing}
+                      disabled={saving}
+                      size="mini"
+                      onHalve={(next) => onUpdateGramsPerServing(line.menuItemId, next)}
+                    />
+                    <Pressable
+                      onPress={() => openGramsSheet(line.menuItemId)}
+                      disabled={saving}
+                      style={({ pressed }) => [
+                        styles.gramsTap,
+                        pressed && { opacity: 0.88 },
+                        saving && { opacity: 0.45 },
+                      ]}
+                      accessibilityLabel="1回あたりのグラムを編集"
+                    >
+                      <Text style={styles.gramsTapValue}>
+                        {formatGramsShort(line.gramsPerServing)}g
+                      </Text>
+                    </Pressable>
+                  </View>
                   <Pressable
                     onPress={() => onRemoveLine(line.menuItemId)}
                     disabled={saving}
@@ -468,15 +554,57 @@ const styles = StyleSheet.create({
   },
   lineBody: { flex: 1, minWidth: 0 },
   lineName: { color: "#e5e7eb", fontSize: 14, fontWeight: "500" },
-  countGrams: { color: "#6b7280", fontSize: 12, fontWeight: "400" },
   linePfc: {
     color: "#9ca3af",
     fontSize: 11,
     marginTop: 4,
     fontVariant: ["tabular-nums"],
   },
-  gramsCol: { alignItems: "center", justifyContent: "center", width: 56, minHeight: 44 },
-  gramsLabel: { color: "#6b7280", fontSize: 9, marginBottom: 2 },
+  countCol: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 2,
+  },
+  countBtn: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: "#374151",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  countBtnText: { color: "#fff", fontSize: 14, fontWeight: "600" },
+  countValueBtn: {
+    minWidth: 28,
+    height: 28,
+    paddingHorizontal: 2,
+    alignItems: "center",
+    justifyContent: "center",
+    borderRadius: 6,
+  },
+  countValueHalf: {
+    borderWidth: 1,
+    borderColor: "#10b981",
+  },
+  countValueText: {
+    color: "#34d399",
+    fontSize: 12,
+    fontWeight: "700",
+    fontVariant: ["tabular-nums"],
+  },
+  countValueTextHalf: { color: "#a7f3d0" },
+  gramsCol: {
+    alignItems: "center",
+    justifyContent: "center",
+    width: 56,
+    minHeight: 44,
+    gap: 2,
+  },
+  gramsTap: {
+    alignItems: "center",
+    justifyContent: "center",
+    paddingVertical: 2,
+  },
   gramsTapValue: {
     color: "#fff",
     fontSize: 14,

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -21,6 +21,10 @@ import {
   sumPfc,
   type PfcGrams,
 } from "@ketolog/domain/pfc";
+import {
+  incrementCount,
+  totalGramsForLine,
+} from "@ketolog/domain/cart-serving";
 import { getMealTypeForTimeZone } from "@ketolog/domain/meal-timezone";
 import type { MealType } from "@ketolog/types";
 import {
@@ -286,7 +290,7 @@ export function TodayScreen() {
           line.protein_per_100g,
           line.fat_per_100g,
           line.carbs_per_100g,
-          line.gramsPerServing * line.count
+          totalGramsForLine(line)
         )
       )
     );
@@ -302,7 +306,7 @@ export function TodayScreen() {
         const next = new Map(prev);
         const cur = next.get(line.menuItemId);
         if (cur) {
-          next.set(line.menuItemId, { ...cur, count: cur.count + 1 });
+          next.set(line.menuItemId, { ...cur, count: incrementCount(cur.count) });
         } else {
           next.set(line.menuItemId, line);
         }
@@ -412,6 +416,24 @@ export function TodayScreen() {
     });
   }, []);
 
+  const setCartLineCount = useCallback((menuItemId: string, count: number) => {
+    if (!Number.isFinite(count) || count <= 0) {
+      setCart((prev) => {
+        const next = new Map(prev);
+        next.delete(menuItemId);
+        return next;
+      });
+      return;
+    }
+    setCart((prev) => {
+      const next = new Map(prev);
+      const cur = next.get(menuItemId);
+      if (!cur) return prev;
+      next.set(menuItemId, { ...cur, count });
+      return next;
+    });
+  }, []);
+
   const clearCartForRestaurant = useCallback((restaurantId: string) => {
     setCart((prev) => {
       const next = new Map(prev);
@@ -428,7 +450,7 @@ export function TodayScreen() {
     setCartSaving(true);
     const lines = [...cart.values()];
     const mkRow = (line: CartLineState) => {
-      const totalGrams = line.gramsPerServing * line.count;
+      const totalGrams = totalGramsForLine(line);
       const v = pfcGramsFromNullablePer100(
         line.protein_per_100g,
         line.fat_per_100g,
@@ -452,7 +474,7 @@ export function TodayScreen() {
     const enqueueAll = async () => {
       const now = new Date().toISOString();
       for (const line of lines) {
-        const totalGrams = line.gramsPerServing * line.count;
+        const totalGrams = totalGramsForLine(line);
         const v = pfcGramsFromNullablePer100(
           line.protein_per_100g,
           line.fat_per_100g,
@@ -508,7 +530,7 @@ export function TodayScreen() {
     setCartExpanded(false);
     await load();
     await refreshOutbox();
-    const totalItems = lines.reduce((s, l) => s + l.count, 0);
+    const totalItems = lines.length;
     showToast(`${totalItems} 品目を記録しました`);
     setCartSaving(false);
   }, [
@@ -1089,6 +1111,7 @@ export function TodayScreen() {
           onClearAll={clearCartAll}
           onRemoveLine={removeCartLine}
           onUpdateGramsPerServing={updateCartGramsPerServing}
+          onChangeCount={setCartLineCount}
         />
         </View>
       </View>

--- a/docs/ux/today-clients.md
+++ b/docs/ux/today-clients.md
@@ -9,6 +9,8 @@
 | **メニュー名での絞り込み** | お気に入り・店舗メニュー一覧の検索欄（名前の部分一致） | 同様（`TodayMenuPanel` の `query`） | Web 側は [#302](https://github.com/kzkski/ketolog/issues/302) でモバイルと同等の検索を追加 |
 | **お気に入り横断検索** | お気に入りタブの検索欄に「全店舗を横断して検索」トグル。ON + クエリ時は全店舗メニューを店舗名グループで表示 | 同様（`TodayMenuPanel` / `MenuBrowseSearchField`） | [#339](https://github.com/kzkski/ketolog/issues/339)。店舗タブの検索は従来どおりその店のみ |
 | カートへの追加 | メニュー行の「＋」、量（g）の編集 | 同様 | カートはクライアント内 state |
+| **カート行の列** | 名前 / PFC / 回数 / g（½ 付き） / 削除 | 同様 | 名前横の `×n（合計g）` は出さない（[#345](https://github.com/kzkski/ketolog/issues/345)） |
+| **分量の半分ショートカット** | g 入力の横に `½`（記録済み編集にも同じ） | カート行・grams シート・記録モーダルに同じ `½` | g を ÷2。回数の 0.5 とは別操作 |
 | カートの保存・記録 | 楽観 UI + サーバー保存（`saveMealToLog`） | オンラインは DB 反映待ち、オフラインは outbox | [#304](https://github.com/kzkski/ketolog/issues/304) |
 | グループ見出しの折りたたみ | `MenuGroupCollapseSession`（localStorage） | AsyncStorage 相当（ネイティブ用ストレージ） | スコープはお気に入り / 店舗 ID 単位 |
 | 折りたたみ時のカート件数バッジ | グループヘッダに合計件数（折りたたみ中のみ） | （任意）同様の UI を入れる場合はカート情報の受け渡しが必要 | Web は `MenuItemList` 実装 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.68.0",
+  "version": "1.69.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -19,6 +19,7 @@
     "./insights": "./src/insights.ts",
     "./menu-browse": "./src/menu-browse.ts",
     "./nutrient-input": "./src/nutrient-input.ts",
-    "./claude-integration": "./src/claude-integration.ts"
+    "./claude-integration": "./src/claude-integration.ts",
+    "./cart-serving": "./src/cart-serving.ts"
   }
 }

--- a/packages/domain/src/cart-serving.test.ts
+++ b/packages/domain/src/cart-serving.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import {
+  canHalveGrams,
+  decrementCount,
+  formatCount,
+  formatGramsShort,
+  halveGrams,
+  incrementCount,
+  isRemovableCount,
+  MIN_GRAMS,
+  roundGrams,
+  toggleHalfCount,
+  totalGramsForLine,
+} from "./cart-serving";
+
+describe("roundGrams / halveGrams", () => {
+  it("小数第1位に丸める", () => {
+    expect(roundGrams(52.54)).toBe(52.5);
+    expect(roundGrams(52.55)).toBe(52.6);
+  });
+
+  it("半分にする", () => {
+    expect(halveGrams(105)).toBe(52.5);
+    expect(halveGrams(52.5)).toBe(26.3);
+    expect(halveGrams(200)).toBe(100);
+  });
+
+  it("下限でクランプ", () => {
+    expect(halveGrams(0.1)).toBe(MIN_GRAMS);
+    expect(halveGrams(0.15)).toBe(MIN_GRAMS);
+    expect(canHalveGrams(0.2)).toBe(false);
+    expect(canHalveGrams(0.3)).toBe(true);
+  });
+});
+
+describe("formatGramsShort", () => {
+  it("整数と小数", () => {
+    expect(formatGramsShort(150)).toBe("150");
+    expect(formatGramsShort(52.5)).toBe("52.5");
+  });
+});
+
+describe("count transitions", () => {
+  it("increment: 0.5 → 1、整数は +1", () => {
+    expect(incrementCount(0.5)).toBe(1);
+    expect(incrementCount(1)).toBe(2);
+    expect(incrementCount(2)).toBe(3);
+  });
+
+  it("decrement: 1/0.5 → 0（削除）、それ以外は −1", () => {
+    expect(decrementCount(0.5)).toBe(0);
+    expect(decrementCount(1)).toBe(0);
+    expect(decrementCount(2)).toBe(1);
+    expect(isRemovableCount(0)).toBe(true);
+    expect(isRemovableCount(1)).toBe(false);
+  });
+
+  it("toggleHalfCount: 0.5 ↔ 1", () => {
+    expect(toggleHalfCount(0.5)).toBe(1);
+    expect(toggleHalfCount(1)).toBe(0.5);
+    expect(toggleHalfCount(3)).toBe(0.5);
+  });
+
+  it("formatCount", () => {
+    expect(formatCount(0.5)).toBe("0.5");
+    expect(formatCount(2)).toBe("2");
+  });
+});
+
+describe("totalGramsForLine", () => {
+  it("1回 × 回数を丸める", () => {
+    expect(totalGramsForLine({ gramsPerServing: 105, count: 1 })).toBe(105);
+    expect(totalGramsForLine({ gramsPerServing: 105, count: 0.5 })).toBe(52.5);
+    expect(totalGramsForLine({ gramsPerServing: 52.5, count: 2 })).toBe(105);
+  });
+});

--- a/packages/domain/src/cart-serving.ts
+++ b/packages/domain/src/cart-serving.ts
@@ -1,0 +1,72 @@
+/** カート・分量編集で共有する回数 / グラム操作（UI 非依存） */
+
+export const MIN_GRAMS = 0.1;
+export const HALF_COUNT = 0.5;
+
+/** 半分ボタンの共通ラベル（Web / Mobile で揃える） */
+export const HALF_GRAMS_LABEL = "½";
+export const HALF_GRAMS_LABEL_FULL = "½ 半分";
+export const HALF_GRAMS_ARIA_LABEL = "グラムを半分にする";
+export const HALF_GRAMS_HINT = "現在の分量を半分にします";
+
+export function roundGrams(grams: number): number {
+  return Math.round(grams * 10) / 10;
+}
+
+/** 現在の g を半分にする。下限 MIN_GRAMS。 */
+export function halveGrams(grams: number): number {
+  if (!Number.isFinite(grams) || grams <= 0) return MIN_GRAMS;
+  return Math.max(MIN_GRAMS, roundGrams(grams / 2));
+}
+
+export function canHalveGrams(grams: number): boolean {
+  return Number.isFinite(grams) && grams > MIN_GRAMS * 2;
+}
+
+/** 整数はそのまま、端数は小数第1位 */
+export function formatGramsShort(grams: number): string {
+  if (!Number.isFinite(grams)) return "0";
+  const r = roundGrams(grams);
+  return Number.isInteger(r) ? String(r) : r.toFixed(1);
+}
+
+/**
+ * 回数 +1。0.5 のときは 1 に戻し、1.5 は作らない。
+ */
+export function incrementCount(count: number): number {
+  if (count === HALF_COUNT) return 1;
+  if (!Number.isFinite(count) || count < 1) return 1;
+  return Math.floor(count) + 1;
+}
+
+/**
+ * 回数 −1。1 または 0.5 のときは 0（= 行削除）。
+ */
+export function decrementCount(count: number): number {
+  if (count === HALF_COUNT) return 0;
+  if (!Number.isFinite(count) || count <= 1) return 0;
+  return Math.floor(count) - 1;
+}
+
+/** 0.5 ↔ 1（整数 n≥1 をタップしたら 0.5） */
+export function toggleHalfCount(count: number): number {
+  if (count === HALF_COUNT) return 1;
+  return HALF_COUNT;
+}
+
+export function isRemovableCount(count: number): boolean {
+  return !Number.isFinite(count) || count <= 0;
+}
+
+export function formatCount(count: number): string {
+  if (count === HALF_COUNT) return "0.5";
+  if (!Number.isFinite(count)) return "1";
+  return String(Math.floor(count));
+}
+
+export function totalGramsForLine(line: {
+  gramsPerServing: number;
+  count: number;
+}): number {
+  return roundGrams(line.gramsPerServing * line.count);
+}

--- a/src/app/today/TodayClient.tsx
+++ b/src/app/today/TodayClient.tsx
@@ -26,6 +26,13 @@ import {
 } from "@/lib/diet-phase";
 import { sumPfc } from "@ketolog/domain/pfc";
 import {
+  decrementCount,
+  formatGramsShort,
+  incrementCount,
+  isRemovableCount,
+  totalGramsForLine,
+} from "@ketolog/domain/cart-serving";
+import {
   buildRestaurantExportDocument,
   buildRestaurantTemplateDocument,
   parseSingleRestaurantJson,
@@ -52,6 +59,7 @@ import { MEAL_LABELS } from "@/lib/constants/meal";
 import { PfcHeader } from "./_components/PfcHeader";
 import { ClaudeIntegrationSection } from "./_components/ClaudeIntegrationSection";
 import { CartPanel, type CartEntry } from "./_components/CartPanel";
+import { HalfGramsButton } from "./_components/HalfGramsButton";
 import { MenuItemList } from "./_components/MenuItemList";
 import { RestaurantPanel } from "./_components/RestaurantPanel";
 import type { ItemDrawerState, MenuItemDrawerProps } from "./_components/ItemDrawer";
@@ -584,8 +592,15 @@ function EditEntryDrawer({
           </div>
           <div>
             <label className="block text-xs text-gray-400 mb-1">グラム数</label>
-            <input type="number" value={grams} onChange={(e) => setGrams(e.target.value)}
-              className="w-28 px-3 py-3 sm:py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-base sm:text-sm focus:outline-none focus:border-emerald-500" />
+            <div className="flex items-center gap-2">
+              <input type="number" min={0.1} step={0.1} value={grams} onChange={(e) => setGrams(e.target.value)}
+                className="w-28 px-3 py-3 sm:py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-base sm:text-sm focus:outline-none focus:border-emerald-500" />
+              <HalfGramsButton
+                value={Number.isFinite(gramsNum) && gramsNum > 0 ? gramsNum : entry.grams}
+                size="full"
+                onHalve={(next) => setGrams(formatGramsShort(next))}
+              />
+            </div>
             {preview && (
               <p className="text-xs text-gray-500 mt-1.5 tabular-nums">
                 → P{fmt(preview.p)} / F{fmt(preview.f)} / C{fmt(preview.c)}g
@@ -1433,7 +1448,7 @@ export default function TodayClient({
   const cartPFC = useMemo(() => {
     let acc: PfcGrams = { p: 0, f: 0, c: 0 };
     for (const entry of cart.values()) {
-      const g = entry.gramsPerServing * entry.count;
+      const g = totalGramsForLine(entry);
       const part: PfcGrams =
         entry.kind === "menu"
           ? {
@@ -1561,7 +1576,7 @@ export default function TodayClient({
       const next = new Map(prev);
       const existing = next.get(item.id);
       if (existing?.kind === "menu") {
-        next.set(item.id, { ...existing, count: existing.count + 1 });
+        next.set(item.id, { ...existing, count: incrementCount(existing.count) });
       } else {
         next.set(item.id, { kind: "menu", item, count: 1, gramsPerServing: grams });
       }
@@ -1574,8 +1589,9 @@ export default function TodayClient({
       const next = new Map(prev);
       const existing = next.get(itemId);
       if (!existing || existing.kind !== "menu") return prev;
-      if (existing.count <= 1) next.delete(itemId);
-      else next.set(itemId, { ...existing, count: existing.count - 1 });
+      const nextCount = decrementCount(existing.count);
+      if (isRemovableCount(nextCount)) next.delete(itemId);
+      else next.set(itemId, { ...existing, count: nextCount });
       return next;
     });
   }
@@ -1605,6 +1621,20 @@ export default function TodayClient({
       } else if (existing.kind === "snapshot") {
         next.set(lineKey, { ...existing, gramsPerServing: grams });
       }
+      return next;
+    });
+  }
+
+  function setCartLineCount(lineKey: string, count: number) {
+    if (!Number.isFinite(count) || count <= 0) {
+      removeCartLine(lineKey);
+      return;
+    }
+    setCart((prev) => {
+      const next = new Map(prev);
+      const existing = next.get(lineKey);
+      if (!existing) return prev;
+      next.set(lineKey, { ...existing, count });
       return next;
     });
   }
@@ -1650,7 +1680,7 @@ export default function TodayClient({
     }
     setSaving(true);
     const items: SaveItem[] = cartEntries.map((entry) => {
-      const totalGrams = entry.gramsPerServing * entry.count;
+      const totalGrams = totalGramsForLine(entry);
       if (entry.kind === "menu") {
         const v = pfcGramsFromMenuItem(entry.item, totalGrams);
         return {
@@ -2018,6 +2048,7 @@ export default function TodayClient({
           onClearAll={clearCartAll}
           onRemoveCartLine={removeCartLine}
           onUpdateGramsPerServing={updateCartGramsPerServing}
+          onChangeCount={setCartLineCount}
         />
       </div>
 

--- a/src/app/today/_components/CartPanel.tsx
+++ b/src/app/today/_components/CartPanel.tsx
@@ -3,7 +3,18 @@
 import { useEffect, useState } from "react";
 import type { MenuItem } from "@/types/database";
 import type { MealType, PfcGrams } from "@ketolog/types";
+import {
+  decrementCount,
+  formatCount,
+  formatGramsShort,
+  HALF_COUNT,
+  incrementCount,
+  isRemovableCount,
+  toggleHalfCount,
+  totalGramsForLine,
+} from "@ketolog/domain/cart-serving";
 import { MEAL_LABELS } from "@/lib/constants/meal";
+import { HalfGramsButton } from "./HalfGramsButton";
 
 /** カート内「記録する食事」セグメントの選択中スタイル（タブと同色） */
 const MEAL_CART_SEGMENT_ACTIVE: Record<MealType, string> = {
@@ -64,7 +75,59 @@ function pfcFromPer100(
   };
 }
 
-/** カート行の「1回あたり g」— 数値入力とブラウザ標準の step スピナー（1g 単位）に任せる */
+function CartLineCountStepper({
+  count,
+  disabled,
+  onDecrement,
+  onIncrement,
+  onToggleHalf,
+}: {
+  count: number;
+  disabled: boolean;
+  onDecrement: () => void;
+  onIncrement: () => void;
+  onToggleHalf: () => void;
+}) {
+  const isHalf = count === HALF_COUNT;
+  return (
+    <div className="flex items-center gap-0.5 shrink-0">
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label="回数を減らす"
+        onClick={onDecrement}
+        className="w-6 h-6 flex items-center justify-center rounded-full bg-gray-700 hover:bg-gray-600 text-white text-sm disabled:opacity-50 touch-manipulation"
+      >
+        −
+      </button>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label={isHalf ? "回数を1に戻す" : "回数を0.5にする"}
+        title={isHalf ? "回数を1に戻す" : "回数を0.5にする"}
+        onClick={onToggleHalf}
+        className={`min-w-7 h-6 px-0.5 text-center text-xs font-bold tabular-nums rounded touch-manipulation disabled:opacity-50 ${
+          isHalf
+            ? "text-emerald-300 ring-1 ring-emerald-500/70"
+            : "text-emerald-400"
+        }`}
+      >
+        {formatCount(count)}
+      </button>
+      <button
+        type="button"
+        disabled={disabled}
+        aria-label="回数を増やす"
+        onClick={onIncrement}
+        className="w-6 h-6 flex items-center justify-center rounded-full bg-gray-700 hover:bg-gray-600 text-white text-sm disabled:opacity-50 touch-manipulation"
+      >
+        +
+      </button>
+    </div>
+  );
+}
+
+/** カート行の「1回あたり g」— ½ ショートカット＋数値入力 */
 function CartLineGramsEditor({
   gramsPerServing,
   disabled,
@@ -74,9 +137,11 @@ function CartLineGramsEditor({
   disabled: boolean;
   onCommit: (n: number) => void;
 }) {
-  const [draft, setDraft] = useState(String(gramsPerServing));
+  const [draft, setDraft] = useState(formatGramsShort(gramsPerServing));
+  const [flash, setFlash] = useState(false);
+
   useEffect(() => {
-    setDraft(String(gramsPerServing));
+    setDraft(formatGramsShort(gramsPerServing));
   }, [gramsPerServing]);
 
   function commitDraft() {
@@ -84,33 +149,49 @@ function CartLineGramsEditor({
     if (Number.isFinite(n) && n > 0) {
       onCommit(n);
     } else {
-      setDraft(String(gramsPerServing));
+      setDraft(formatGramsShort(gramsPerServing));
     }
   }
 
+  function handleHalve(next: number) {
+    onCommit(next);
+    setFlash(true);
+    window.setTimeout(() => setFlash(false), 400);
+  }
+
   return (
-    <div className="flex flex-col items-end gap-0.5 shrink-0">
-      <span className="text-[9px] text-gray-500 leading-none">1回</span>
-      <input
-        type="number"
-        min={1}
-        step={1}
-        value={draft}
+    <div className="flex items-center gap-1 shrink-0">
+      <HalfGramsButton
+        value={gramsPerServing}
         disabled={disabled}
-        onChange={(e) => {
-          const v = e.target.value;
-          setDraft(v);
-          if (v === "") return;
-          const n = Number.parseFloat(v);
-          if (Number.isFinite(n) && n > 0) {
-            onCommit(n);
-          }
-        }}
-        onBlur={commitDraft}
-        onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
-        className="w-[3.75rem] sm:w-16 text-center text-xs sm:text-sm bg-gray-800 border border-emerald-600/80 rounded px-0.5 py-1 text-white tabular-nums shrink-0"
-        aria-label="1回あたりのグラム数"
+        size="compact"
+        onHalve={handleHalve}
       />
+      <div className="flex items-center gap-0.5">
+        <input
+          type="number"
+          min={0.1}
+          step={0.1}
+          value={draft}
+          disabled={disabled}
+          onChange={(e) => {
+            const v = e.target.value;
+            setDraft(v);
+            if (v === "") return;
+            const n = Number.parseFloat(v);
+            if (Number.isFinite(n) && n > 0) {
+              onCommit(n);
+            }
+          }}
+          onBlur={commitDraft}
+          onKeyDown={(e) => e.key === "Enter" && (e.target as HTMLInputElement).blur()}
+          className={`w-[3.25rem] sm:w-14 text-center text-xs sm:text-sm bg-gray-800 border rounded px-0.5 py-1 text-white tabular-nums shrink-0 transition-colors ${
+            flash ? "border-emerald-400" : "border-emerald-600/80"
+          }`}
+          aria-label="1回あたりのグラム数"
+        />
+        <span className="text-[10px] text-gray-500">g</span>
+      </div>
     </div>
   );
 }
@@ -170,6 +251,7 @@ function CartExpandedBody({
   cartPFC,
   removeCartLine,
   onUpdateGramsPerServing,
+  onChangeCount,
   onSave,
   saving,
   layout = "inline",
@@ -180,6 +262,7 @@ function CartExpandedBody({
   cartPFC: PfcGrams;
   removeCartLine: (key: string) => void;
   onUpdateGramsPerServing: (lineKey: string, grams: number) => void;
+  onChangeCount: (lineKey: string, count: number) => void;
   onSave: () => void | Promise<void>;
   saving: boolean;
   /** モバイルのオーバーレイでは一覧を縦に伸ばす */
@@ -211,7 +294,7 @@ function CartExpandedBody({
       </div>
       <div className={listScrollClass}>
         {cartEntries.map((entry) => {
-          const totalGrams = entry.gramsPerServing * entry.count;
+          const totalGrams = totalGramsForLine(entry);
           const v =
             entry.kind === "menu"
               ? pfc(entry.item, totalGrams)
@@ -232,18 +315,26 @@ function CartExpandedBody({
           return (
             <div
               key={lineKey}
-              className="flex flex-wrap items-center gap-x-2 gap-y-2 px-4 py-1.5 border-b border-gray-800/50"
+              className="flex flex-wrap items-center gap-x-2 gap-y-1 px-4 py-1.5 border-b border-gray-800/50"
             >
-              <span className="text-sm text-gray-200 truncate flex-1 min-w-[10rem]">
+              <span className="text-sm text-gray-200 truncate flex-1 min-w-[8rem]">
                 {title}
                 {snapshotTag}
-                <span className="text-gray-500 ml-1 text-xs whitespace-nowrap">
-                  ×{entry.count}（{totalGrams}g）
-                </span>
               </span>
               <span className="text-xs text-gray-400 shrink-0 tabular-nums">
                 P{fmt(v.p)} F{fmt(v.f)} C{fmt(v.c)}
               </span>
+              <CartLineCountStepper
+                count={entry.count}
+                disabled={saving}
+                onDecrement={() => {
+                  const next = decrementCount(entry.count);
+                  if (isRemovableCount(next)) removeCartLine(lineKey);
+                  else onChangeCount(lineKey, next);
+                }}
+                onIncrement={() => onChangeCount(lineKey, incrementCount(entry.count))}
+                onToggleHalf={() => onChangeCount(lineKey, toggleHalfCount(entry.count))}
+              />
               <CartLineGramsEditor
                 gramsPerServing={entry.gramsPerServing}
                 disabled={saving}
@@ -292,6 +383,7 @@ export type CartPanelProps = {
   onClearAll: () => void;
   onRemoveCartLine: (mapKey: string) => void;
   onUpdateGramsPerServing: (lineKey: string, grams: number) => void;
+  onChangeCount: (lineKey: string, count: number) => void;
 };
 
 export function CartPanel({
@@ -306,8 +398,21 @@ export function CartPanel({
   onClearAll,
   onRemoveCartLine,
   onUpdateGramsPerServing,
+  onChangeCount,
 }: CartPanelProps) {
   if (cartEntries.length === 0) return null;
+
+  const bodyProps = {
+    mealType,
+    setMealType: onMealTypeChange,
+    cartEntries,
+    cartPFC: cartPfc,
+    removeCartLine: onRemoveCartLine,
+    onUpdateGramsPerServing,
+    onChangeCount,
+    onSave,
+    saving,
+  };
 
   return (
     <>
@@ -350,17 +455,7 @@ export function CartPanel({
               clearingDisabled={saving}
             />
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-              <CartExpandedBody
-                layout="sheet"
-                mealType={mealType}
-                setMealType={onMealTypeChange}
-                cartEntries={cartEntries}
-                cartPFC={cartPfc}
-                removeCartLine={onRemoveCartLine}
-                onUpdateGramsPerServing={onUpdateGramsPerServing}
-                onSave={onSave}
-                saving={saving}
-              />
+              <CartExpandedBody layout="sheet" {...bodyProps} />
             </div>
           </div>
         </div>
@@ -376,18 +471,7 @@ export function CartPanel({
           onClearAll={onClearAll}
           clearingDisabled={saving}
         />
-        {cartExpanded && (
-          <CartExpandedBody
-            mealType={mealType}
-            setMealType={onMealTypeChange}
-            cartEntries={cartEntries}
-            cartPFC={cartPfc}
-            removeCartLine={onRemoveCartLine}
-            onUpdateGramsPerServing={onUpdateGramsPerServing}
-            onSave={onSave}
-            saving={saving}
-          />
-        )}
+        {cartExpanded && <CartExpandedBody {...bodyProps} />}
       </div>
     </>
   );

--- a/src/app/today/_components/HalfGramsButton.tsx
+++ b/src/app/today/_components/HalfGramsButton.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import {
+  canHalveGrams,
+  HALF_GRAMS_ARIA_LABEL,
+  HALF_GRAMS_HINT,
+  HALF_GRAMS_LABEL,
+  HALF_GRAMS_LABEL_FULL,
+  halveGrams,
+} from "@ketolog/domain/cart-serving";
+
+type HalfGramsButtonProps = {
+  value: number;
+  disabled?: boolean;
+  size?: "compact" | "full";
+  onHalve: (next: number) => void;
+};
+
+export function HalfGramsButton({
+  value,
+  disabled = false,
+  size = "compact",
+  onHalve,
+}: HalfGramsButtonProps) {
+  const blocked = disabled || !canHalveGrams(value);
+
+  return (
+    <button
+      type="button"
+      disabled={blocked}
+      title={HALF_GRAMS_HINT}
+      aria-label={HALF_GRAMS_ARIA_LABEL}
+      onClick={() => onHalve(halveGrams(value))}
+      className={
+        size === "full"
+          ? "shrink-0 min-h-11 px-3 rounded-lg border border-emerald-500/70 bg-emerald-500/15 text-emerald-300 text-sm font-bold touch-manipulation active:scale-95 active:bg-emerald-500/35 transition disabled:opacity-40"
+          : "shrink-0 min-w-7 min-h-7 px-1.5 rounded-lg border border-emerald-500/70 bg-emerald-500/15 text-emerald-300 text-xs font-bold touch-manipulation active:scale-95 active:bg-emerald-500/35 transition disabled:opacity-40"
+      }
+    >
+      {size === "full" ? HALF_GRAMS_LABEL_FULL : HALF_GRAMS_LABEL}
+    </button>
+  );
+}

--- a/src/app/today/_components/MenuItemRow.tsx
+++ b/src/app/today/_components/MenuItemRow.tsx
@@ -8,6 +8,7 @@ import {
   type MacroHighlightTargets,
 } from "@/lib/macroHighlights";
 import type { CartEntry } from "./CartPanel";
+import { formatCount } from "@ketolog/domain/cart-serving";
 
 function fmt(n: number) {
   return n < 10 ? n.toFixed(1) : Math.round(n).toString();
@@ -161,7 +162,7 @@ export function MenuItemRow({
           >
             −
           </button>
-          <span className="w-4 sm:w-5 text-center text-xs sm:text-sm font-bold text-emerald-400 tabular-nums">{count}</span>
+          <span className="w-7 sm:w-8 text-center text-xs sm:text-sm font-bold text-emerald-400 tabular-nums">{formatCount(count)}</span>
           <button
             type="button"
             onClick={() => onAdd(displayGrams)}


### PR DESCRIPTION
## Summary
- カート行を「名前 / PFC / 回数 / g / 削除」に整理し、名前横の `×n（合計g）` 重複を削除
- 分量の `½` ショートカット（g ÷ 2）を Web/Mobile のカート・grams シート・記録済み編集に統一配置
- 回数はステッパー＋数字タップで 0.5 ↔ 1（1.5 は作らない）。計算ロジックは `@ketolog/domain/cart-serving`

closes #345

## Test plan
- [ ] Web: メニューをカートに追加 → 行の `½` で 1回 g が半分になり PFC が追従 → 記録
- [ ] Web: 回数の数字タップで 0.5、`+` で 1 に戻る。メニュー行の `+` でも 1.5 にならない
- [ ] Web: 記録済みの ✎ 編集で `½ 半分` が使え、保存後の g が半分
- [ ] Mobile: カート行の `½`（シートを開かず）と grams シート内の `½` の両方
- [ ] Mobile: 記録編集モーダルでも `½` が使える
- [ ] 狭幅（〜375px）でカート行の縦が増えすぎていないこと


Made with [Cursor](https://cursor.com)