### PR TITLE
feat: InsightsにPFC記録日達成率を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@
 
 ### Changed
 
+## [1.70.0] - 2026-07-26
+
+### Added
+
+- **分析 / Insights**: 可変プリセット運用向けに「記録日達成率(%)」を追加。その日当時の PFC 目標スナップショットに対する達成率の平均・推移を Web / iOS で表示（生グラム表示は切替で併存）。目標履歴は `daily_pfc_target_snapshot` に保存（[#344](https://github.com/kzkski/ketolog/issues/344)）。
+
+### Changed
+
 ## [1.69.1] - 2026-07-25
 
 ### Fixed

--- a/apps/mobile/components/FoodLogEntryModal.tsx
+++ b/apps/mobile/components/FoodLogEntryModal.tsx
@@ -24,6 +24,8 @@ import {
   type FoodLogOutboxDraft,
 } from "../lib/food-log-outbox";
 import { getIsOnline, isTransientNetworkError } from "../lib/network";
+import { writePfcTargetSnapshot } from "../lib/pfc-target-snapshot-write";
+import { normalizeUserSettings } from "@ketolog/domain/diet-phase";
 import { HalfGramsButton } from "./HalfGramsButton";
 
 const MEALS: MealType[] = ["breakfast", "lunch", "dinner", "snack"];
@@ -222,6 +224,21 @@ export function FoodLogEntryModal({
       onToast(`保存に失敗しました: ${error.message}`);
       return;
     }
+
+    const { data: settingsRow } = await supabase
+      .from("user_settings")
+      .select("diet_phase, phase_profiles")
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (settingsRow) {
+      void writePfcTargetSnapshot(supabase, {
+        userId,
+        date,
+        settings: normalizeUserSettings(settingsRow),
+        source: "food_log_ensure",
+      });
+    }
+
     onToast("保存しました");
     onClose();
     await onSaved();

--- a/apps/mobile/components/InsightsPfcChart.tsx
+++ b/apps/mobile/components/InsightsPfcChart.tsx
@@ -5,9 +5,9 @@ import Svg, { Line, Polyline, Text as SvgText } from "react-native-svg";
 
 type Point = {
   date: string;
-  protein: number;
-  fat: number;
-  carbs: number;
+  protein: number | null;
+  fat: number | null;
+  carbs: number | null;
 };
 
 const CHART_LEFT = 44;
@@ -21,6 +21,8 @@ const LEGEND_ROW_H = 26;
 
 type Props = {
   data: Point[];
+  /** 軸ラベル等用。現状は未表示だが Web と揃えて受け取る */
+  unitLabel?: string;
 };
 
 function dateTickLabel(date: string): string {
@@ -53,7 +55,35 @@ function xTickIndices(len: number): number[] {
   return out;
 }
 
-export function InsightsPfcChart({ data }: Props) {
+function isFiniteNumber(v: number | null | undefined): v is number {
+  return v != null && Number.isFinite(v);
+}
+
+/** null で途切れる折れ線セグメント（連続する有効点のみを結ぶ） */
+function buildPolylineSegments(
+  data: Point[],
+  key: "protein" | "fat" | "carbs",
+  xAt: (i: number) => number,
+  yAt: (v: number) => number
+): string[] {
+  const segments: string[] = [];
+  let current: string[] = [];
+  for (let i = 0; i < data.length; i++) {
+    const v = data[i]![key];
+    if (!isFiniteNumber(v)) {
+      if (current.length > 0) {
+        segments.push(current.join(" "));
+        current = [];
+      }
+      continue;
+    }
+    current.push(`${xAt(i)},${yAt(v)}`);
+  }
+  if (current.length > 0) segments.push(current.join(" "));
+  return segments;
+}
+
+export function InsightsPfcChart({ data, unitLabel: _unitLabel = "g" }: Props) {
   const { width: winW } = useWindowDimensions();
   const [measuredW, setMeasuredW] = useState(0);
 
@@ -73,23 +103,24 @@ export function InsightsPfcChart({ data }: Props) {
     const n = data.length;
     if (n === 0) {
       return {
-        proteinPts: "",
-        fatPts: "",
-        carbsPts: "",
+        proteinSegs: [] as string[],
+        fatSegs: [] as string[],
+        carbsSegs: [] as string[],
         yMax: 1,
         yTicks: [0, 1],
         xTicks: [] as { i: number; label: string; x: number }[],
         gridYs: [] as number[],
       };
     }
-    const rawMax = Math.max(...data.flatMap((d) => [d.protein, d.fat, d.carbs]));
+    const finiteVals = data
+      .flatMap((d) => [d.protein, d.fat, d.carbs])
+      .filter(isFiniteNumber);
+    const rawMax = finiteVals.length > 0 ? Math.max(...finiteVals) : 0;
     const yMax = niceYMax(rawMax);
     const yTicks = yTickValues(yMax);
     const xAt = (i: number) =>
       n <= 1 ? plotLeft + plotW / 2 : plotLeft + (plotW * i) / (n - 1);
     const yAt = (v: number) => CHART_TOP + innerH - (v / yMax) * innerH;
-    const mk = (key: "protein" | "fat" | "carbs") =>
-      data.map((d, i) => `${xAt(i)},${yAt(d[key])}`).join(" ");
     const gridYs = yTicks.map((tv) => yAt(tv));
     const xi = xTickIndices(n);
     const xTicks = xi.map((i) => ({
@@ -98,9 +129,9 @@ export function InsightsPfcChart({ data }: Props) {
       x: xAt(i),
     }));
     return {
-      proteinPts: mk("protein"),
-      fatPts: mk("fat"),
-      carbsPts: mk("carbs"),
+      proteinSegs: buildPolylineSegments(data, "protein", xAt, yAt),
+      fatSegs: buildPolylineSegments(data, "fat", xAt, yAt),
+      carbsSegs: buildPolylineSegments(data, "carbs", xAt, yAt),
       yMax,
       yTicks,
       xTicks,
@@ -175,24 +206,33 @@ export function InsightsPfcChart({ data }: Props) {
             {t.label}
           </SvgText>
         ))}
-        <Polyline
-          points={layout.proteinPts}
-          fill="none"
-          stroke="#60a5fa"
-          strokeWidth={2}
-        />
-        <Polyline
-          points={layout.fatPts}
-          fill="none"
-          stroke="#facc15"
-          strokeWidth={2}
-        />
-        <Polyline
-          points={layout.carbsPts}
-          fill="none"
-          stroke="#34d399"
-          strokeWidth={2}
-        />
+        {layout.proteinSegs.map((pts, i) => (
+          <Polyline
+            key={`p-${i}`}
+            points={pts}
+            fill="none"
+            stroke="#60a5fa"
+            strokeWidth={2}
+          />
+        ))}
+        {layout.fatSegs.map((pts, i) => (
+          <Polyline
+            key={`f-${i}`}
+            points={pts}
+            fill="none"
+            stroke="#facc15"
+            strokeWidth={2}
+          />
+        ))}
+        {layout.carbsSegs.map((pts, i) => (
+          <Polyline
+            key={`c-${i}`}
+            points={pts}
+            fill="none"
+            stroke="#34d399"
+            strokeWidth={2}
+          />
+        ))}
       </Svg>
       <View style={styles.legendRow}>
         <View style={styles.legendItem}>

--- a/apps/mobile/components/MenuItemEditorModal.tsx
+++ b/apps/mobile/components/MenuItemEditorModal.tsx
@@ -37,6 +37,8 @@ import {
   type FoodLogOutboxDraft,
 } from "../lib/food-log-outbox";
 import { getIsOnline, isTransientNetworkError } from "../lib/network";
+import { writePfcTargetSnapshot } from "../lib/pfc-target-snapshot-write";
+import { normalizeUserSettings } from "@ketolog/domain/diet-phase";
 import { resolveMenuItemGroupOrder } from "../lib/resolve-menu-item-group-order";
 import {
   lookupSharedProductByBarcodeMobile,
@@ -985,6 +987,21 @@ export function MenuItemEditorModal({
       onToast(`保存に失敗しました: ${error.message}`);
       return;
     }
+
+    const { data: settingsRow } = await supabase
+      .from("user_settings")
+      .select("diet_phase, phase_profiles")
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (settingsRow && draft) {
+      void writePfcTargetSnapshot(supabase, {
+        userId,
+        date: draft.date,
+        settings: normalizeUserSettings(settingsRow),
+        source: "food_log_ensure",
+      });
+    }
+
     onToast("保存しました");
     onClose();
     await onSaved();

--- a/apps/mobile/components/TodaySettingsModal.tsx
+++ b/apps/mobile/components/TodaySettingsModal.tsx
@@ -13,6 +13,9 @@ import {
 } from "react-native";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { DietPhase, PhaseProfiles } from "@ketolog/domain/diet-phase";
+import { snapshotSourceForSettingsChange } from "@ketolog/domain/pfc-target-snapshot";
+import { toJstDateString } from "@ketolog/domain/date";
+import { writePfcTargetSnapshot } from "../lib/pfc-target-snapshot-write";
 
 import {
   buildFullDataExportPayload,
@@ -118,6 +121,8 @@ export function TodaySettingsModal({
       if (next === selectedSlot) return;
       setSlotSaving(true);
       setError(null);
+      const prev = { diet_phase: settings.diet_phase, phase_profiles: settings.phase_profiles };
+      const nextSettings = { diet_phase: next, phase_profiles: profiles };
       const { error: upErr } = await supabase.from("user_settings").upsert(
         {
           user_id: userId,
@@ -132,9 +137,18 @@ export function TodaySettingsModal({
         return;
       }
       setSelectedSlot(next);
-      onSettingsUpdated({ diet_phase: next, phase_profiles: profiles });
+      onSettingsUpdated(nextSettings);
+      const source = snapshotSourceForSettingsChange(prev, nextSettings);
+      if (source) {
+        void writePfcTargetSnapshot(supabase, {
+          userId,
+          date: toJstDateString(),
+          settings: nextSettings,
+          source,
+        });
+      }
     },
-    [selectedSlot, supabase, userId, profiles, onSettingsUpdated]
+    [selectedSlot, supabase, userId, profiles, onSettingsUpdated, settings]
   );
 
   const handleSaveProfiles = useCallback(async () => {
@@ -185,6 +199,8 @@ export function TodaySettingsModal({
     setProfiles(normalized);
     setSaving(true);
     setError(null);
+    const prev = { diet_phase: settings.diet_phase, phase_profiles: settings.phase_profiles };
+    const nextSettings = { diet_phase: selectedSlot, phase_profiles: normalized };
     const { error: upErr } = await supabase.from("user_settings").upsert(
       {
         user_id: userId,
@@ -198,7 +214,16 @@ export function TodaySettingsModal({
       setError(upErr.message);
       return;
     }
-    onSettingsUpdated({ diet_phase: selectedSlot, phase_profiles: normalized });
+    onSettingsUpdated(nextSettings);
+    const source = snapshotSourceForSettingsChange(prev, nextSettings);
+    if (source) {
+      void writePfcTargetSnapshot(supabase, {
+        userId,
+        date: toJstDateString(),
+        settings: nextSettings,
+        source,
+      });
+    }
     onToast?.("目標を保存しました");
     onClose();
   }, [
@@ -210,6 +235,7 @@ export function TodaySettingsModal({
     onSettingsUpdated,
     onClose,
     onToast,
+    settings,
   ]);
 
   const handleDownloadFullData = useCallback(async () => {

--- a/apps/mobile/lib/fetch-insights-food-log-mobile.ts
+++ b/apps/mobile/lib/fetch-insights-food-log-mobile.ts
@@ -1,5 +1,8 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { InsightFoodLogEntry } from "@ketolog/domain/insights";
+import type {
+  InsightFoodLogEntry,
+  InsightPfcTargetSnapshot,
+} from "@ketolog/domain/insights";
 import type { MealType } from "@ketolog/types";
 
 const INSIGHTS_PAGE_SIZE = 1000;
@@ -58,4 +61,37 @@ export async function fetchInsightsFoodLogForDateRange(
   }
 
   return { entries, error: null };
+}
+
+export async function fetchInsightsPfcTargetSnapshotsForDateRange(
+  supabase: SupabaseClient,
+  userId: string,
+  start: string,
+  end: string
+): Promise<{ snapshots: InsightPfcTargetSnapshot[]; error: string | null }> {
+  const { data, error } = await supabase
+    .from("daily_pfc_target_snapshot")
+    .select(
+      "date, diet_phase, phase_name, protein_target_g, fat_target_g, carbs_target_g"
+    )
+    .eq("user_id", userId)
+    .gte("date", start)
+    .lte("date", end)
+    .order("date", { ascending: true });
+
+  if (error) return { snapshots: [], error: error.message };
+
+  const snapshots: InsightPfcTargetSnapshot[] = (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    return {
+      date: String(r.date),
+      diet_phase: Number(r.diet_phase),
+      phase_name: r.phase_name == null ? null : String(r.phase_name),
+      protein_target_g: Number(r.protein_target_g),
+      fat_target_g: Number(r.fat_target_g),
+      carbs_target_g: Number(r.carbs_target_g),
+    };
+  });
+
+  return { snapshots, error: null };
 }

--- a/apps/mobile/lib/food-log-outbox.ts
+++ b/apps/mobile/lib/food-log-outbox.ts
@@ -3,9 +3,11 @@
  */
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { normalizeUserSettings } from "@ketolog/domain/diet-phase";
 import type { MealType } from "@ketolog/types";
 
 import { isTransientNetworkError } from "./network";
+import { writePfcTargetSnapshot } from "./pfc-target-snapshot-write";
 
 const storageKey = (userId: string) =>
   `@ketolog/food_log_outbox/v1/${userId}`;
@@ -114,12 +116,31 @@ export async function sendFoodLogDraft(
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const payload = buildFoodLogInsertPayload(userId, draft);
   const { error } = await supabase.from("food_log").insert(payload);
-  if (!error) return { ok: true };
-  if (error.code === "23505") return { ok: true };
-  if (isTransientNetworkError(error)) {
-    return { ok: false, error: "通信に失敗しました。しばらくしてから再送してください。" };
+  if (error) {
+    if (error.code === "23505") {
+      // duplicate id — treat as success, still try ensure below
+    } else if (isTransientNetworkError(error)) {
+      return { ok: false, error: "通信に失敗しました。しばらくしてから再送してください。" };
+    } else {
+      return { ok: false, error: error.message };
+    }
   }
-  return { ok: false, error: error.message };
+
+  const { data: settingsRow } = await supabase
+    .from("user_settings")
+    .select("diet_phase, phase_profiles")
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (settingsRow) {
+    void writePfcTargetSnapshot(supabase, {
+      userId,
+      date: draft.date,
+      settings: normalizeUserSettings(settingsRow),
+      source: "food_log_ensure",
+    });
+  }
+
+  return { ok: true };
 }
 
 export { newClientRowId };

--- a/apps/mobile/lib/pfc-target-snapshot-write.ts
+++ b/apps/mobile/lib/pfc-target-snapshot-write.ts
@@ -1,0 +1,45 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { DietPhase, PhaseProfiles } from "@ketolog/domain/diet-phase";
+import {
+  buildPfcTargetSnapshotWriteRow,
+  isInsertOnlyPfcTargetSnapshotSource,
+  type PfcTargetSnapshotSource,
+} from "@ketolog/domain/pfc-target-snapshot";
+
+type Settings = {
+  diet_phase: DietPhase;
+  phase_profiles: PhaseProfiles;
+};
+
+export async function writePfcTargetSnapshot(
+  supabase: SupabaseClient,
+  input: {
+    userId: string;
+    date: string;
+    settings: Settings;
+    source: PfcTargetSnapshotSource;
+  }
+): Promise<{ error: string | null }> {
+  const row = buildPfcTargetSnapshotWriteRow({
+    userId: input.userId,
+    date: input.date,
+    diet_phase: input.settings.diet_phase,
+    phase_profiles: input.settings.phase_profiles,
+    source: input.source,
+  });
+
+  if (isInsertOnlyPfcTargetSnapshotSource(input.source)) {
+    const { error } = await supabase.from("daily_pfc_target_snapshot").upsert(row, {
+      onConflict: "user_id,date",
+      ignoreDuplicates: true,
+    });
+    if (error) return { error: error.message };
+    return { error: null };
+  }
+
+  const { error } = await supabase.from("daily_pfc_target_snapshot").upsert(row, {
+    onConflict: "user_id,date",
+  });
+  if (error) return { error: error.message };
+  return { error: null };
+}

--- a/apps/mobile/screens/InsightsScreen.tsx
+++ b/apps/mobile/screens/InsightsScreen.tsx
@@ -15,10 +15,12 @@ import { Ionicons } from "@expo/vector-icons";
 import type { MealType } from "@ketolog/types";
 import { addDaysJst } from "@ketolog/domain/date";
 import {
+  buildAchievementRates,
   buildInsights,
   getPresetRange,
   getTodayJstDate,
   type InsightFoodLogEntry,
+  type InsightPfcTargetSnapshot,
 } from "@ketolog/domain/insights";
 import {
   pfcRatioPercents,
@@ -33,7 +35,10 @@ import {
 import { useAuthSessionContext } from "../contexts/AuthSessionContext";
 import { loadFoodLogOutbox } from "../lib/food-log-outbox";
 import { getSupabase } from "../lib/supabase";
-import { fetchInsightsFoodLogForDateRange } from "../lib/fetch-insights-food-log-mobile";
+import {
+  fetchInsightsFoodLogForDateRange,
+  fetchInsightsPfcTargetSnapshotsForDateRange,
+} from "../lib/fetch-insights-food-log-mobile";
 import { shareUtf8JsonFile } from "../lib/share-json-mobile";
 import { InsightsPfcChart } from "../components/InsightsPfcChart";
 
@@ -66,6 +71,7 @@ const CUSTOM_RANGE_MAX_DAYS = 90;
 
 type Preset = "7d" | "30d" | "custom";
 type MealFilter = MealType | "all";
+type MetricMode = "achievement" | "grams";
 
 function fmtNum(v: number): string {
   return v.toFixed(1);
@@ -105,6 +111,8 @@ export function InsightsScreen() {
   const [start, setStart] = useState(preset7.start);
   const [end, setEnd] = useState(preset7.end);
   const [entries, setEntries] = useState<InsightFoodLogEntry[]>([]);
+  const [snapshots, setSnapshots] = useState<InsightPfcTargetSnapshot[]>([]);
+  const [metricMode, setMetricMode] = useState<MetricMode>("achievement");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -124,23 +132,36 @@ export function InsightsScreen() {
       setLoading(true);
       setError(null);
       const mealTypes = nextMealFilter === "all" ? undefined : [nextMealFilter];
-      const result = await fetchInsightsFoodLogForDateRange(
-        supabase,
-        userId,
-        nextStart,
-        nextEnd,
-        mealTypes
-      );
+      const [foodResult, snapResult] = await Promise.all([
+        fetchInsightsFoodLogForDateRange(
+          supabase,
+          userId,
+          nextStart,
+          nextEnd,
+          mealTypes
+        ),
+        fetchInsightsPfcTargetSnapshotsForDateRange(
+          supabase,
+          userId,
+          nextStart,
+          nextEnd
+        ),
+      ]);
       setLoading(false);
-      if (result.error) {
-        setError(result.error);
+      if (foodResult.error) {
+        setError(foodResult.error);
+        return;
+      }
+      if (snapResult.error) {
+        setError(snapResult.error);
         return;
       }
       setPreset(nextPreset);
       setMealFilter(nextMealFilter);
       setStart(nextStart);
       setEnd(nextEnd);
-      setEntries(result.entries);
+      setEntries(foodResult.entries);
+      setSnapshots(snapResult.snapshots);
       setExpanded(new Set());
     },
     [supabase, userId, mealFilter]
@@ -183,6 +204,14 @@ export function InsightsScreen() {
         mealTypes: mealFilter === "all" ? undefined : [mealFilter],
       }),
     [entries, start, end, mealFilter]
+  );
+  const achievement = useMemo(
+    () => buildAchievementRates(insight.daily, snapshots, insight.chart.length),
+    [insight.daily, snapshots, insight.chart.length]
+  );
+  const achievementByDate = useMemo(
+    () => new Map(achievement.dailyAchievement.map((d) => [d.date, d])),
+    [achievement.dailyAchievement]
   );
   const avgGrams = useMemo(
     () =>
@@ -431,97 +460,193 @@ export function InsightsScreen() {
 
         <View style={styles.card}>
           <View style={styles.cardTitleRow}>
-            <Text style={styles.cardTitle}>平均PFCバランス</Text>
-            <View style={styles.ratioBasisGroup} accessibilityRole="tablist">
-              <Pressable
-                onPress={() => selectRatioBasis("kcal")}
-                style={[styles.ratioBasisBtn, ratioBasis === "kcal" && styles.ratioBasisBtnOn]}
-                accessibilityRole="tab"
-                accessibilityState={{ selected: ratioBasis === "kcal" }}
-              >
-                <Text
-                  style={[
-                    styles.ratioBasisBtnText,
-                    ratioBasis === "kcal" && styles.ratioBasisBtnTextOn,
-                  ]}
-                >
-                  カロリー比
-                </Text>
-              </Pressable>
-              <Pressable
-                onPress={() => selectRatioBasis("gram")}
-                style={[styles.ratioBasisBtn, ratioBasis === "gram" && styles.ratioBasisBtnOn]}
-                accessibilityRole="tab"
-                accessibilityState={{ selected: ratioBasis === "gram" }}
-              >
-                <Text
-                  style={[
-                    styles.ratioBasisBtnText,
-                    ratioBasis === "gram" && styles.ratioBasisBtnTextOn,
-                  ]}
-                >
-                  重量比
-                </Text>
-              </Pressable>
-            </View>
-          </View>
-          {ratioBasis === "kcal" ? (
-            <Text style={styles.avgKcalLine}>
-              平均 {fmtNum(avgDailyKcal)} kcal/日
-              <Text style={styles.avgKcalHint}> · P4・F9・C4 kcal/g</Text>
+            <Text style={styles.cardTitle}>
+              {metricMode === "achievement" ? "記録日達成率" : "平均PFCバランス"}
             </Text>
-          ) : null}
-          <View style={styles.avgGrid}>
-            <View style={styles.avgCell}>
-              <Text style={styles.avgCap}>たんぱく質 (P)</Text>
-              <Text style={[styles.avgVal, { color: "#93c5fd" }]}>
-                {fmtNum(insight.summary.avgProtein)} g
-              </Text>
-              <Text style={styles.avgPct}>{fmtNum(avgRatioPct.p)}%</Text>
-            </View>
-            <View style={styles.avgCell}>
-              <Text style={styles.avgCap}>脂質 (F)</Text>
-              <Text style={[styles.avgVal, { color: "#fde047" }]}>
-                {fmtNum(insight.summary.avgFat)} g
-              </Text>
-              <Text style={styles.avgPct}>{fmtNum(avgRatioPct.f)}%</Text>
-            </View>
-            <View style={styles.avgCell}>
-              <Text style={styles.avgCap}>糖質 (C)</Text>
-              <Text style={[styles.avgVal, { color: "#6ee7b7" }]}>
-                {fmtNum(insight.summary.avgCarbs)} g
-              </Text>
-              <Text style={styles.avgPct}>{fmtNum(avgRatioPct.c)}%</Text>
+            <View style={styles.metricControls}>
+              <View style={styles.ratioBasisGroup} accessibilityRole="tablist">
+                <Pressable
+                  onPress={() => setMetricMode("achievement")}
+                  style={[
+                    styles.ratioBasisBtn,
+                    metricMode === "achievement" && styles.ratioBasisBtnOn,
+                  ]}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: metricMode === "achievement" }}
+                >
+                  <Text
+                    style={[
+                      styles.ratioBasisBtnText,
+                      metricMode === "achievement" && styles.ratioBasisBtnTextOn,
+                    ]}
+                  >
+                    達成率
+                  </Text>
+                </Pressable>
+                <Pressable
+                  onPress={() => setMetricMode("grams")}
+                  style={[
+                    styles.ratioBasisBtn,
+                    metricMode === "grams" && styles.ratioBasisBtnOn,
+                  ]}
+                  accessibilityRole="tab"
+                  accessibilityState={{ selected: metricMode === "grams" }}
+                >
+                  <Text
+                    style={[
+                      styles.ratioBasisBtnText,
+                      metricMode === "grams" && styles.ratioBasisBtnTextOn,
+                    ]}
+                  >
+                    生グラム
+                  </Text>
+                </Pressable>
+              </View>
+              {metricMode === "grams" ? (
+                <View style={styles.ratioBasisGroup} accessibilityRole="tablist">
+                  <Pressable
+                    onPress={() => selectRatioBasis("kcal")}
+                    style={[
+                      styles.ratioBasisBtn,
+                      ratioBasis === "kcal" && styles.ratioBasisBtnOn,
+                    ]}
+                    accessibilityRole="tab"
+                    accessibilityState={{ selected: ratioBasis === "kcal" }}
+                  >
+                    <Text
+                      style={[
+                        styles.ratioBasisBtnText,
+                        ratioBasis === "kcal" && styles.ratioBasisBtnTextOn,
+                      ]}
+                    >
+                      カロリー比
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => selectRatioBasis("gram")}
+                    style={[
+                      styles.ratioBasisBtn,
+                      ratioBasis === "gram" && styles.ratioBasisBtnOn,
+                    ]}
+                    accessibilityRole="tab"
+                    accessibilityState={{ selected: ratioBasis === "gram" }}
+                  >
+                    <Text
+                      style={[
+                        styles.ratioBasisBtnText,
+                        ratioBasis === "gram" && styles.ratioBasisBtnTextOn,
+                      ]}
+                    >
+                      重量比
+                    </Text>
+                  </Pressable>
+                </View>
+              ) : null}
             </View>
           </View>
-          <View style={styles.ratioBar}>
-            <View
-              style={[
-                styles.ratioSeg,
-                { backgroundColor: "#60a5fa" },
-                ratioFlexFromPercents(avgRatioPct.p),
-              ]}
-            />
-            <View
-              style={[
-                styles.ratioSeg,
-                { backgroundColor: "#facc15" },
-                ratioFlexFromPercents(avgRatioPct.f),
-              ]}
-            />
-            <View
-              style={[
-                styles.ratioSeg,
-                { backgroundColor: "#34d399" },
-                ratioFlexFromPercents(avgRatioPct.c),
-              ]}
-            />
-          </View>
+          {metricMode === "achievement" ? (
+            <>
+              <Text style={styles.avgKcalLine}>
+                記録日 {achievement.summary.recordedDayCount} 日
+                <Text style={styles.avgKcalHint}>
+                  {" "}
+                  · 除外 {achievement.summary.excludedDayCount} 日（目標履歴なし／食事なし）
+                </Text>
+              </Text>
+              {achievement.summary.recordedDayCount === 0 ? (
+                <Text style={styles.achBanner}>
+                  この期間は目標スナップショット付きの記録日がありません。Today
+                  でプリセットを選ぶか食事を記録すると、以降の達成率を集計できます。
+                </Text>
+              ) : (
+                <View style={styles.avgGrid}>
+                  <View style={styles.avgCell}>
+                    <Text style={styles.avgCap}>たんぱく質 (P)</Text>
+                    <Text style={[styles.avgVal, { color: "#93c5fd" }]}>
+                      {fmtNum(achievement.summary.avgProteinPct ?? 0)}%
+                    </Text>
+                  </View>
+                  <View style={styles.avgCell}>
+                    <Text style={styles.avgCap}>脂質 (F)</Text>
+                    <Text style={[styles.avgVal, { color: "#fde047" }]}>
+                      {fmtNum(achievement.summary.avgFatPct ?? 0)}%
+                    </Text>
+                  </View>
+                  <View style={styles.avgCell}>
+                    <Text style={styles.avgCap}>糖質 (C)</Text>
+                    <Text style={[styles.avgVal, { color: "#6ee7b7" }]}>
+                      {fmtNum(achievement.summary.avgCarbsPct ?? 0)}%
+                    </Text>
+                  </View>
+                </View>
+              )}
+            </>
+          ) : (
+            <>
+              {ratioBasis === "kcal" ? (
+                <Text style={styles.avgKcalLine}>
+                  平均 {fmtNum(avgDailyKcal)} kcal/日
+                  <Text style={styles.avgKcalHint}> · P4・F9・C4 kcal/g</Text>
+                </Text>
+              ) : null}
+              <View style={styles.avgGrid}>
+                <View style={styles.avgCell}>
+                  <Text style={styles.avgCap}>たんぱく質 (P)</Text>
+                  <Text style={[styles.avgVal, { color: "#93c5fd" }]}>
+                    {fmtNum(insight.summary.avgProtein)} g
+                  </Text>
+                  <Text style={styles.avgPct}>{fmtNum(avgRatioPct.p)}%</Text>
+                </View>
+                <View style={styles.avgCell}>
+                  <Text style={styles.avgCap}>脂質 (F)</Text>
+                  <Text style={[styles.avgVal, { color: "#fde047" }]}>
+                    {fmtNum(insight.summary.avgFat)} g
+                  </Text>
+                  <Text style={styles.avgPct}>{fmtNum(avgRatioPct.f)}%</Text>
+                </View>
+                <View style={styles.avgCell}>
+                  <Text style={styles.avgCap}>糖質 (C)</Text>
+                  <Text style={[styles.avgVal, { color: "#6ee7b7" }]}>
+                    {fmtNum(insight.summary.avgCarbs)} g
+                  </Text>
+                  <Text style={styles.avgPct}>{fmtNum(avgRatioPct.c)}%</Text>
+                </View>
+              </View>
+              <View style={styles.ratioBar}>
+                <View
+                  style={[
+                    styles.ratioSeg,
+                    { backgroundColor: "#60a5fa" },
+                    ratioFlexFromPercents(avgRatioPct.p),
+                  ]}
+                />
+                <View
+                  style={[
+                    styles.ratioSeg,
+                    { backgroundColor: "#facc15" },
+                    ratioFlexFromPercents(avgRatioPct.f),
+                  ]}
+                />
+                <View
+                  style={[
+                    styles.ratioSeg,
+                    { backgroundColor: "#34d399" },
+                    ratioFlexFromPercents(avgRatioPct.c),
+                  ]}
+                />
+              </View>
+            </>
+          )}
         </View>
 
         <View style={styles.card}>
-          <Text style={styles.cardTitle}>日次PFC推移</Text>
-          <InsightsPfcChart data={insight.chart} />
+          <Text style={styles.cardTitle}>
+            {metricMode === "achievement" ? "日次達成率推移" : "日次PFC推移"}
+          </Text>
+          <InsightsPfcChart
+            data={metricMode === "achievement" ? achievement.chart : insight.chart}
+            unitLabel={metricMode === "achievement" ? "%" : "g"}
+          />
         </View>
 
         <View style={styles.card}>
@@ -530,17 +655,47 @@ export function InsightsScreen() {
             const isOpen = expanded.has(day.date);
             const dayGrams = toPfcGrams(day.protein, day.fat, day.carbs);
             const dayRatioPct = pfcRatioPercents(dayGrams, ratioBasis);
+            const dayAch = achievementByDate.get(day.date);
             return (
               <View key={day.date} style={styles.dayBlock}>
                 <Pressable onPress={() => toggleDate(day.date)} style={styles.dayHeader}>
                   <View style={styles.dayHeaderMain}>
                     <Text style={styles.dayTitle} numberOfLines={1}>
                       {isOpen ? "▼" : "▶"} {jstDateLabel(day.date)}
+                      {dayAch?.phaseName ? (
+                        <Text style={styles.dayPhase}> · {dayAch.phaseName}</Text>
+                      ) : null}
                     </Text>
                     <View style={styles.dayPfcRow}>
-                      <Text style={[styles.dayPfc, { color: "#93c5fd" }]}>{fmtNum(day.protein)}</Text>
-                      <Text style={[styles.dayPfc, { color: "#fde047" }]}>{fmtNum(day.fat)}</Text>
-                      <Text style={[styles.dayPfc, { color: "#6ee7b7" }]}>{fmtNum(day.carbs)}</Text>
+                      {metricMode === "achievement" ? (
+                        <>
+                          <Text style={[styles.dayPfc, { color: "#93c5fd" }]}>
+                            {dayAch?.proteinPct != null
+                              ? `${fmtNum(dayAch.proteinPct)}%`
+                              : "—"}
+                          </Text>
+                          <Text style={[styles.dayPfc, { color: "#fde047" }]}>
+                            {dayAch?.fatPct != null ? `${fmtNum(dayAch.fatPct)}%` : "—"}
+                          </Text>
+                          <Text style={[styles.dayPfc, { color: "#6ee7b7" }]}>
+                            {dayAch?.carbsPct != null
+                              ? `${fmtNum(dayAch.carbsPct)}%`
+                              : "—"}
+                          </Text>
+                        </>
+                      ) : (
+                        <>
+                          <Text style={[styles.dayPfc, { color: "#93c5fd" }]}>
+                            {fmtNum(day.protein)}
+                          </Text>
+                          <Text style={[styles.dayPfc, { color: "#fde047" }]}>
+                            {fmtNum(day.fat)}
+                          </Text>
+                          <Text style={[styles.dayPfc, { color: "#6ee7b7" }]}>
+                            {fmtNum(day.carbs)}
+                          </Text>
+                        </>
+                      )}
                     </View>
                     <View style={styles.ratioBar}>
                       <View
@@ -682,10 +837,17 @@ const styles = StyleSheet.create({
   cardTitle: { color: COLORS.text, fontSize: 14, fontWeight: "600" },
   cardTitleRow: {
     flexDirection: "row",
-    alignItems: "center",
+    alignItems: "flex-start",
     justifyContent: "space-between",
     gap: 8,
     marginBottom: 10,
+    flexWrap: "wrap",
+  },
+  metricControls: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    alignItems: "center",
+    gap: 6,
   },
   ratioBasisGroup: {
     flexDirection: "row",
@@ -705,6 +867,12 @@ const styles = StyleSheet.create({
   ratioBasisBtnTextOn: { color: "#fff" },
   avgKcalLine: { color: COLORS.muted, fontSize: 11, marginBottom: 8 },
   avgKcalHint: { color: "#6b7280" },
+  achBanner: {
+    color: "#fcd34d",
+    fontSize: 12,
+    lineHeight: 17,
+  },
+  dayPhase: { color: COLORS.muted, fontSize: 11, fontWeight: "400" },
   presetRow: { flexDirection: "row", flexWrap: "wrap", gap: 8, alignItems: "center" },
   presetBtn: {
     paddingHorizontal: 12,
@@ -815,7 +983,7 @@ const styles = StyleSheet.create({
   dayHeaderMain: { flex: 1, minWidth: 0, paddingRight: 8 },
   dayTitle: { color: COLORS.text, fontSize: 14, fontWeight: "600" },
   dayPfcRow: { flexDirection: "row", justifyContent: "flex-end", gap: 10, marginTop: 6 },
-  dayPfc: { fontSize: 12, width: 44, textAlign: "right", fontVariant: ["tabular-nums"] },
+  dayPfc: { fontSize: 12, width: 52, textAlign: "right", fontVariant: ["tabular-nums"] },
   dayCount: { color: COLORS.muted, fontSize: 11 },
   dayBody: {
     borderTopWidth: StyleSheet.hairlineWidth,

--- a/apps/mobile/screens/TodayScreen.tsx
+++ b/apps/mobile/screens/TodayScreen.tsx
@@ -68,6 +68,8 @@ import {
 import type { FavoriteMenuItemPayload } from "../lib/fetch-favorite-groups-payload";
 import { getIsOnline, isTransientNetworkError } from "../lib/network";
 import { getOrCreateSnapshotRestaurant } from "../lib/get-or-create-snapshot-restaurant";
+import { writePfcTargetSnapshot } from "../lib/pfc-target-snapshot-write";
+import { snapshotSourceForSettingsChange } from "@ketolog/domain/pfc-target-snapshot";
 
 type UserSettingsState = {
   diet_phase: DietPhase;
@@ -253,7 +255,17 @@ export function TodayScreen() {
       setSnapshotRestaurantId(snapRes.data?.id ?? null);
     }
 
-    setSettings(normalizeUserSettings(settingsRes.data));
+    const nextSettings = normalizeUserSettings(settingsRes.data);
+    setSettings(nextSettings);
+
+    const todayJst = toJstDateString();
+    void writePfcTargetSnapshot(supabase, {
+      userId,
+      date: todayJst,
+      settings: nextSettings,
+      source: "app_ensure",
+    });
+
     const rows = logRes.data ?? [];
     setLogEntries(
       rows.map((r) => ({
@@ -526,6 +538,15 @@ export function TodayScreen() {
       return;
     }
 
+    if (settings) {
+      void writePfcTargetSnapshot(supabase, {
+        userId,
+        date: selectedDate,
+        settings,
+        source: "food_log_ensure",
+      });
+    }
+
     setCart(new Map());
     setCartExpanded(false);
     await load();
@@ -542,6 +563,7 @@ export function TodayScreen() {
     refreshOutbox,
     load,
     showToast,
+    settings,
   ]);
 
   /** Web 今日ビューの「＋」と同じく、メニュー追加ドロワー（`MenuItemEditorModal`）を開く */
@@ -697,6 +719,8 @@ export function TodayScreen() {
       if (!userId || !settings || ph === settings.diet_phase) return;
       setPhaseSaving(true);
       setLoadError(null);
+      const prev = settings;
+      const next = { diet_phase: ph, phase_profiles: settings.phase_profiles };
       const { error } = await supabase.from("user_settings").upsert(
         {
           user_id: userId,
@@ -708,7 +732,16 @@ export function TodayScreen() {
       if (error) {
         setLoadError(error.message);
       } else {
-        setSettings((s) => (s ? { ...s, diet_phase: ph } : s));
+        setSettings(next);
+        const source = snapshotSourceForSettingsChange(prev, next);
+        if (source) {
+          void writePfcTargetSnapshot(supabase, {
+            userId,
+            date: toJstDateString(),
+            settings: next,
+            source,
+          });
+        }
       }
       setPhaseSaving(false);
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.69.1",
+  "version": "1.70.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -17,6 +17,7 @@
     "./restaurant-json-v1": "./src/restaurant-json-v1.ts",
     "./restaurant-import": "./src/restaurant-import.ts",
     "./insights": "./src/insights.ts",
+    "./pfc-target-snapshot": "./src/pfc-target-snapshot.ts",
     "./menu-browse": "./src/menu-browse.ts",
     "./nutrient-input": "./src/nutrient-input.ts",
     "./claude-integration": "./src/claude-integration.ts",

--- a/packages/domain/src/insights.ts
+++ b/packages/domain/src/insights.ts
@@ -33,6 +33,36 @@ export type TopItem = {
   count: number;
 };
 
+/** Insights 達成率用の日次目標（DB スナップショット） */
+export type InsightPfcTargetSnapshot = {
+  date: string;
+  diet_phase: number;
+  phase_name: string | null;
+  protein_target_g: number;
+  fat_target_g: number;
+  carbs_target_g: number;
+};
+
+export type DailyAchievement = {
+  date: string;
+  included: boolean;
+  phaseName: string | null;
+  dietPhase: number | null;
+  proteinPct: number | null;
+  fatPct: number | null;
+  carbsPct: number | null;
+};
+
+export type AchievementSummary = {
+  /** 記録日達成率の平均。記録日が0なら null */
+  avgProteinPct: number | null;
+  avgFatPct: number | null;
+  avgCarbsPct: number | null;
+  recordedDayCount: number;
+  excludedDayCount: number;
+  periodDayCount: number;
+};
+
 export function getTodayJstDate(): string {
   return toJstDateString();
 }
@@ -140,6 +170,100 @@ export function buildInsights(
       protein: d.protein,
       fat: d.fat,
       carbs: d.carbs,
+    })),
+  };
+}
+
+function achievementPct(consumed: number, target: number): number | null {
+  if (!(target > 0) || !Number.isFinite(target) || !Number.isFinite(consumed)) return null;
+  return (consumed / target) * 100;
+}
+
+/**
+ * 記録日達成率: snapshot があり、かつその日の（フィルタ後）food_log が1件以上の日だけ平均に含める。
+ * チャート欠損日は null（折れ線ギャップ）。
+ */
+export function buildAchievementRates(
+  daily: DailyInsight[],
+  snapshots: InsightPfcTargetSnapshot[],
+  periodDayCount: number
+): {
+  summary: AchievementSummary;
+  dailyAchievement: DailyAchievement[];
+  chart: Array<{
+    date: string;
+    protein: number | null;
+    fat: number | null;
+    carbs: number | null;
+  }>;
+} {
+  const byDate = new Map(snapshots.map((s) => [s.date, s]));
+  // daily は新しい順のことがあるので日付昇順でチャートを組む
+  const dailyAsc = [...daily].sort((a, b) => a.date.localeCompare(b.date));
+
+  const dailyAchievement: DailyAchievement[] = dailyAsc.map((day) => {
+    const snap = byDate.get(day.date);
+    const hasEntries = day.entries.length > 0;
+    if (!snap || !hasEntries) {
+      return {
+        date: day.date,
+        included: false,
+        phaseName: snap?.phase_name ?? null,
+        dietPhase: snap?.diet_phase ?? null,
+        proteinPct: null,
+        fatPct: null,
+        carbsPct: null,
+      };
+    }
+    const proteinPct = achievementPct(day.protein, Number(snap.protein_target_g));
+    const fatPct = achievementPct(day.fat, Number(snap.fat_target_g));
+    const carbsPct = achievementPct(day.carbs, Number(snap.carbs_target_g));
+    if (proteinPct == null || fatPct == null || carbsPct == null) {
+      return {
+        date: day.date,
+        included: false,
+        phaseName: snap.phase_name,
+        dietPhase: snap.diet_phase,
+        proteinPct: null,
+        fatPct: null,
+        carbsPct: null,
+      };
+    }
+    return {
+      date: day.date,
+      included: true,
+      phaseName: snap.phase_name,
+      dietPhase: snap.diet_phase,
+      proteinPct,
+      fatPct,
+      carbsPct,
+    };
+  });
+
+  const included = dailyAchievement.filter((d) => d.included);
+  const recordedDayCount = included.length;
+  const avg = (pick: (d: DailyAchievement) => number | null): number | null => {
+    if (recordedDayCount === 0) return null;
+    let sum = 0;
+    for (const d of included) sum += pick(d) ?? 0;
+    return sum / recordedDayCount;
+  };
+
+  return {
+    summary: {
+      avgProteinPct: avg((d) => d.proteinPct),
+      avgFatPct: avg((d) => d.fatPct),
+      avgCarbsPct: avg((d) => d.carbsPct),
+      recordedDayCount,
+      excludedDayCount: Math.max(0, periodDayCount - recordedDayCount),
+      periodDayCount,
+    },
+    dailyAchievement,
+    chart: dailyAchievement.map((d) => ({
+      date: d.date,
+      protein: d.proteinPct,
+      fat: d.fatPct,
+      carbs: d.carbsPct,
     })),
   };
 }

--- a/packages/domain/src/pfc-target-snapshot.test.ts
+++ b/packages/domain/src/pfc-target-snapshot.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import {
+  activePhaseTargetsChanged,
+  buildPfcTargetSnapshotWriteRow,
+  canOverwritePfcTargetSnapshot,
+  isInsertOnlyPfcTargetSnapshotSource,
+  snapshotSourceForSettingsChange,
+} from "./pfc-target-snapshot";
+import { DEFAULT_PHASE_PROFILES } from "./diet-phase";
+import { buildAchievementRates, buildInsights } from "./insights";
+
+describe("pfc-target-snapshot source priority", () => {
+  it("allows switch to overwrite ensure", () => {
+    expect(canOverwritePfcTargetSnapshot("food_log_ensure", "app_switch")).toBe(true);
+    expect(canOverwritePfcTargetSnapshot("app_switch", "food_log_ensure")).toBe(false);
+  });
+
+  it("marks ensure/backfill as insert-only", () => {
+    expect(isInsertOnlyPfcTargetSnapshotSource("food_log_ensure")).toBe(true);
+    expect(isInsertOnlyPfcTargetSnapshotSource("app_ensure")).toBe(true);
+    expect(isInsertOnlyPfcTargetSnapshotSource("claude_backfill")).toBe(true);
+    expect(isInsertOnlyPfcTargetSnapshotSource("app_switch")).toBe(false);
+  });
+
+  it("detects active profile edits vs inactive-only", () => {
+    const base = { diet_phase: 1 as const, phase_profiles: DEFAULT_PHASE_PROFILES };
+    const inactiveOnly = {
+      diet_phase: 1 as const,
+      phase_profiles: {
+        ...DEFAULT_PHASE_PROFILES,
+        "2": { ...DEFAULT_PHASE_PROFILES["2"], protein_target_g: 999 },
+      },
+    };
+    expect(activePhaseTargetsChanged(base, inactiveOnly)).toBe(false);
+    expect(snapshotSourceForSettingsChange(base, inactiveOnly)).toBeNull();
+
+    const activeEdit = {
+      diet_phase: 1 as const,
+      phase_profiles: {
+        ...DEFAULT_PHASE_PROFILES,
+        "1": { ...DEFAULT_PHASE_PROFILES["1"], carbs_target_g: 30 },
+      },
+    };
+    expect(snapshotSourceForSettingsChange(base, activeEdit)).toBe("app_profile_edit");
+
+    const switched = { diet_phase: 2 as const, phase_profiles: DEFAULT_PHASE_PROFILES };
+    expect(snapshotSourceForSettingsChange(base, switched)).toBe("app_switch");
+  });
+
+  it("builds write row from active profile", () => {
+    const row = buildPfcTargetSnapshotWriteRow({
+      userId: "u1",
+      date: "2026-07-26",
+      diet_phase: 3,
+      phase_profiles: DEFAULT_PHASE_PROFILES,
+      source: "app_switch",
+      updatedAt: "2026-07-26T00:00:00.000Z",
+    });
+    expect(row.diet_phase).toBe(3);
+    expect(row.phase_name).toBe("TKD");
+    expect(row.protein_target_g).toBe(110);
+    expect(row.fat_target_g).toBe(110);
+    expect(row.carbs_target_g).toBe(60);
+    expect(row.source).toBe("app_switch");
+  });
+});
+
+describe("buildAchievementRates", () => {
+  it("averages only recorded days with snapshots", () => {
+    const insight = buildInsights(
+      [
+        {
+          id: "1",
+          date: "2026-07-20",
+          meal_type: "lunch",
+          eaten_at: "2026-07-20T12:00:00Z",
+          item_name: "卵",
+          grams: 100,
+          protein_g: 50,
+          fat_g: 75,
+          carbs_g: 10,
+          source: "manual",
+          menu_item_id: null,
+          created_at: "2026-07-20T12:00:01Z",
+        },
+      ],
+      "2026-07-20",
+      "2026-07-21"
+    );
+    const achievement = buildAchievementRates(
+      insight.daily,
+      [
+        {
+          date: "2026-07-20",
+          diet_phase: 1,
+          phase_name: "導入期",
+          protein_target_g: 100,
+          fat_target_g: 150,
+          carbs_target_g: 20,
+        },
+      ],
+      2
+    );
+    expect(achievement.summary.recordedDayCount).toBe(1);
+    expect(achievement.summary.excludedDayCount).toBe(1);
+    expect(achievement.summary.avgProteinPct).toBeCloseTo(50);
+    expect(achievement.summary.avgFatPct).toBeCloseTo(50);
+    expect(achievement.summary.avgCarbsPct).toBeCloseTo(50);
+    expect(achievement.chart[0]!.protein).toBeCloseTo(50);
+    expect(achievement.chart[1]!.protein).toBeNull();
+  });
+
+  it("excludes days with food but no snapshot", () => {
+    const insight = buildInsights(
+      [
+        {
+          id: "1",
+          date: "2026-07-20",
+          meal_type: "lunch",
+          eaten_at: "2026-07-20T12:00:00Z",
+          item_name: "卵",
+          grams: 100,
+          protein_g: 100,
+          fat_g: 100,
+          carbs_g: 100,
+          source: "manual",
+          menu_item_id: null,
+          created_at: "2026-07-20T12:00:01Z",
+        },
+      ],
+      "2026-07-20",
+      "2026-07-20"
+    );
+    const achievement = buildAchievementRates(insight.daily, [], 1);
+    expect(achievement.summary.recordedDayCount).toBe(0);
+    expect(achievement.summary.avgProteinPct).toBeNull();
+    expect(achievement.summary.excludedDayCount).toBe(1);
+  });
+});

--- a/packages/domain/src/pfc-target-snapshot.ts
+++ b/packages/domain/src/pfc-target-snapshot.ts
@@ -1,0 +1,111 @@
+/**
+ * 日次 PFC 目標スナップショット（達成率集計用）。
+ * DB 行の組み立てと source 優先度のみ。書き込み I/O はアプリ層。
+ */
+
+import {
+  activePhaseProfile,
+  type DietPhase,
+  type PhaseProfiles,
+} from "./diet-phase";
+
+export const PFC_TARGET_SNAPSHOT_SOURCES = [
+  "app_switch",
+  "app_profile_edit",
+  "food_log_ensure",
+  "app_ensure",
+  "claude_backfill",
+] as const;
+
+export type PfcTargetSnapshotSource = (typeof PFC_TARGET_SNAPSHOT_SOURCES)[number];
+
+/** 数値が大きいほど優先。ensure / backfill は既存行を上書きしない想定。 */
+export const PFC_TARGET_SNAPSHOT_SOURCE_RANK: Record<PfcTargetSnapshotSource, number> = {
+  app_switch: 3,
+  app_profile_edit: 3,
+  food_log_ensure: 2,
+  app_ensure: 2,
+  claude_backfill: 1,
+};
+
+export function isPfcTargetSnapshotSource(value: unknown): value is PfcTargetSnapshotSource {
+  return (
+    typeof value === "string" &&
+    (PFC_TARGET_SNAPSHOT_SOURCES as readonly string[]).includes(value)
+  );
+}
+
+export function canOverwritePfcTargetSnapshot(
+  existing: PfcTargetSnapshotSource,
+  incoming: PfcTargetSnapshotSource
+): boolean {
+  return PFC_TARGET_SNAPSHOT_SOURCE_RANK[incoming] >= PFC_TARGET_SNAPSHOT_SOURCE_RANK[existing];
+}
+
+/** INSERT-only 系（既存行があれば触らない） */
+export function isInsertOnlyPfcTargetSnapshotSource(source: PfcTargetSnapshotSource): boolean {
+  return (
+    source === "food_log_ensure" || source === "app_ensure" || source === "claude_backfill"
+  );
+}
+
+export type PfcTargetSnapshotWriteRow = {
+  user_id: string;
+  date: string;
+  diet_phase: DietPhase;
+  phase_name: string;
+  protein_target_g: number;
+  fat_target_g: number;
+  carbs_target_g: number;
+  source: PfcTargetSnapshotSource;
+  updated_at: string;
+};
+
+export function buildPfcTargetSnapshotWriteRow(input: {
+  userId: string;
+  date: string;
+  diet_phase: DietPhase;
+  phase_profiles: PhaseProfiles;
+  source: PfcTargetSnapshotSource;
+  updatedAt?: string;
+}): PfcTargetSnapshotWriteRow {
+  const profile = activePhaseProfile({
+    diet_phase: input.diet_phase,
+    phase_profiles: input.phase_profiles,
+  });
+  return {
+    user_id: input.userId,
+    date: input.date,
+    diet_phase: input.diet_phase,
+    phase_name: profile.name,
+    protein_target_g: profile.protein_target_g,
+    fat_target_g: profile.fat_target_g,
+    carbs_target_g: profile.carbs_target_g,
+    source: input.source,
+    updated_at: input.updatedAt ?? new Date().toISOString(),
+  };
+}
+
+export function activePhaseTargetsChanged(
+  prev: { diet_phase: DietPhase; phase_profiles: PhaseProfiles },
+  next: { diet_phase: DietPhase; phase_profiles: PhaseProfiles }
+): boolean {
+  if (prev.diet_phase !== next.diet_phase) return true;
+  const a = activePhaseProfile(prev);
+  const b = activePhaseProfile(next);
+  return (
+    a.protein_target_g !== b.protein_target_g ||
+    a.fat_target_g !== b.fat_target_g ||
+    a.carbs_target_g !== b.carbs_target_g ||
+    a.name !== b.name
+  );
+}
+
+export function snapshotSourceForSettingsChange(
+  prev: { diet_phase: DietPhase; phase_profiles: PhaseProfiles },
+  next: { diet_phase: DietPhase; phase_profiles: PhaseProfiles }
+): PfcTargetSnapshotSource | null {
+  if (!activePhaseTargetsChanged(prev, next)) return null;
+  if (prev.diet_phase !== next.diet_phase) return "app_switch";
+  return "app_profile_edit";
+}

--- a/src/app/insights/InsightsChart.tsx
+++ b/src/app/insights/InsightsChart.tsx
@@ -13,9 +13,9 @@ import {
 
 type Point = {
   date: string;
-  protein: number;
-  fat: number;
-  carbs: number;
+  protein: number | null;
+  fat: number | null;
+  carbs: number | null;
 };
 
 function dateLabel(date: string): string {
@@ -51,7 +51,13 @@ function LegendContent(props: { payload?: LegendItem[] }) {
   );
 }
 
-export default function InsightsChart({ data }: { data: Point[] }) {
+export default function InsightsChart({
+  data,
+  unitLabel = "g",
+}: {
+  data: Point[];
+  unitLabel?: string;
+}) {
   return (
     <div className="h-56 w-full">
       <ResponsiveContainer width="100%" height="100%">
@@ -65,15 +71,43 @@ export default function InsightsChart({ data }: { data: Point[] }) {
           />
           <YAxis stroke="#9ca3af" tick={{ fontSize: 11 }} />
           <Tooltip
-            formatter={(value) => (typeof value === "number" ? value.toFixed(1) : String(value ?? ""))}
+            formatter={(value) =>
+              typeof value === "number"
+                ? `${value.toFixed(1)}${unitLabel}`
+                : String(value ?? "")
+            }
             labelFormatter={(label) => `${label}`}
             contentStyle={{ backgroundColor: "#111827", border: "1px solid #374151" }}
             itemSorter={(item) => PFC_TOOLTIP_ORDER[String(item.name ?? "")] ?? 99}
           />
           <Legend content={<LegendContent />} />
-          <Line type="monotone" dataKey="protein" name="P" stroke="#60a5fa" strokeWidth={2} dot={false} />
-          <Line type="monotone" dataKey="fat" name="F" stroke="#facc15" strokeWidth={2} dot={false} />
-          <Line type="monotone" dataKey="carbs" name="C" stroke="#34d399" strokeWidth={2} dot={false} />
+          <Line
+            type="monotone"
+            dataKey="protein"
+            name="P"
+            stroke="#60a5fa"
+            strokeWidth={2}
+            dot={false}
+            connectNulls={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="fat"
+            name="F"
+            stroke="#facc15"
+            strokeWidth={2}
+            dot={false}
+            connectNulls={false}
+          />
+          <Line
+            type="monotone"
+            dataKey="carbs"
+            name="C"
+            stroke="#34d399"
+            strokeWidth={2}
+            dot={false}
+            connectNulls={false}
+          />
         </LineChart>
       </ResponsiveContainer>
     </div>

--- a/src/app/insights/InsightsClient.tsx
+++ b/src/app/insights/InsightsClient.tsx
@@ -11,15 +11,20 @@ import {
 } from "@ketolog/domain/pfc";
 import {
   addDaysJst,
+  buildAchievementRates,
   buildInsights,
   getPresetRange,
   type InsightFoodLogEntry,
+  type InsightPfcTargetSnapshot,
 } from "@/lib/insights";
 import {
   readInsightsPfcRatioBasis,
   writeInsightsPfcRatioBasis,
 } from "@/lib/insights-pfc-ratio-storage";
-import { getInsightsFoodLogForDateRange } from "./actions";
+import {
+  getInsightsFoodLogForDateRange,
+  getInsightsPfcTargetSnapshotsForDateRange,
+} from "./actions";
 import { MEAL_LABELS, MEAL_TAB_STYLES, MEAL_TYPES } from "@/lib/constants/meal";
 import type { MealType } from "@ketolog/types";
 
@@ -32,9 +37,16 @@ const CUSTOM_RANGE_MAX_DAYS = 90;
 
 type Preset = "7d" | "30d" | "custom";
 type MealFilter = MealType | "all";
+type MetricMode = "achievement" | "grams";
 
 function fmtNum(v: number): string {
   return v.toFixed(1);
+}
+
+function metricModeButtonClass(active: boolean): string {
+  return `rounded-md px-2 py-1 text-[10px] font-medium transition-colors sm:text-[11px] ${
+    active ? "bg-emerald-600 text-white" : "bg-gray-800 text-gray-300 hover:bg-gray-700"
+  }`;
 }
 
 function ratioStyleFromPercents(pct: number): { width: string } {
@@ -80,9 +92,11 @@ function mealFilterButtonClass(mealFilter: MealFilter, target: MealFilter): stri
 
 export default function InsightsClient({
   initialEntries,
+  initialSnapshots,
   today,
 }: {
   initialEntries: InsightFoodLogEntry[];
+  initialSnapshots: InsightPfcTargetSnapshot[];
   today: string;
 }) {
   const preset7 = getPresetRange(today, 7);
@@ -90,7 +104,9 @@ export default function InsightsClient({
   const [start, setStart] = useState(preset7.start);
   const [end, setEnd] = useState(preset7.end);
   const [entries, setEntries] = useState(initialEntries);
+  const [snapshots, setSnapshots] = useState(initialSnapshots);
   const [mealFilter, setMealFilter] = useState<MealFilter>("all");
+  const [metricMode, setMetricMode] = useState<MetricMode>("achievement");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
@@ -113,6 +129,15 @@ export default function InsightsClient({
   const insight = useMemo(
     () => buildInsights(entries, start, end, { mealTypes: selectedMealTypes }),
     [entries, start, end, selectedMealTypes]
+  );
+  const periodDayCount = insight.chart.length;
+  const achievement = useMemo(
+    () => buildAchievementRates(insight.daily, snapshots, periodDayCount),
+    [insight.daily, snapshots, periodDayCount]
+  );
+  const achievementByDate = useMemo(
+    () => new Map(achievement.dailyAchievement.map((d) => [d.date, d])),
+    [achievement.dailyAchievement]
   );
   const avgGrams = useMemo(
     () =>
@@ -138,17 +163,25 @@ export default function InsightsClient({
     setLoading(true);
     setError(null);
     const mealTypes = nextMealFilter === "all" ? undefined : [nextMealFilter];
-    const result = await getInsightsFoodLogForDateRange(nextStart, nextEnd, mealTypes);
+    const [foodResult, snapResult] = await Promise.all([
+      getInsightsFoodLogForDateRange(nextStart, nextEnd, mealTypes),
+      getInsightsPfcTargetSnapshotsForDateRange(nextStart, nextEnd),
+    ]);
     setLoading(false);
-    if (result.error) {
-      setError(result.error);
+    if (foodResult.error) {
+      setError(foodResult.error);
+      return;
+    }
+    if (snapResult.error) {
+      setError(snapResult.error);
       return;
     }
     setPreset(nextPreset);
     setStart(nextStart);
     setEnd(nextEnd);
     setMealFilter(nextMealFilter);
-    setEntries(result.entries);
+    setEntries(foodResult.entries);
+    setSnapshots(snapResult.snapshots);
     setExpanded(new Set());
   }
 
@@ -303,65 +336,145 @@ export default function InsightsClient({
 
         <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3">
           <div className="mb-2 flex flex-wrap items-center justify-between gap-2">
-            <h2 className="text-sm font-medium text-white">平均PFCバランス</h2>
-            <div
-              className="flex shrink-0 rounded-lg border border-gray-800 bg-gray-950/80 p-0.5"
-              role="group"
-              aria-label="PFC比率の表示基準"
-            >
-              <button
-                type="button"
-                onClick={() => selectRatioBasis("kcal")}
-                className={ratioBasisButtonClass(ratioBasis === "kcal")}
-                aria-pressed={ratioBasis === "kcal"}
+            <h2 className="text-sm font-medium text-white">
+              {metricMode === "achievement" ? "記録日達成率" : "平均PFCバランス"}
+            </h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <div
+                className="flex shrink-0 rounded-lg border border-gray-800 bg-gray-950/80 p-0.5"
+                role="group"
+                aria-label="分析指標"
               >
-                カロリー比
-              </button>
-              <button
-                type="button"
-                onClick={() => selectRatioBasis("gram")}
-                className={ratioBasisButtonClass(ratioBasis === "gram")}
-                aria-pressed={ratioBasis === "gram"}
-              >
-                重量比
-              </button>
+                <button
+                  type="button"
+                  onClick={() => setMetricMode("achievement")}
+                  className={metricModeButtonClass(metricMode === "achievement")}
+                  aria-pressed={metricMode === "achievement"}
+                >
+                  達成率
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setMetricMode("grams")}
+                  className={metricModeButtonClass(metricMode === "grams")}
+                  aria-pressed={metricMode === "grams"}
+                >
+                  生グラム
+                </button>
+              </div>
+              {metricMode === "grams" ? (
+                <div
+                  className="flex shrink-0 rounded-lg border border-gray-800 bg-gray-950/80 p-0.5"
+                  role="group"
+                  aria-label="PFC比率の表示基準"
+                >
+                  <button
+                    type="button"
+                    onClick={() => selectRatioBasis("kcal")}
+                    className={ratioBasisButtonClass(ratioBasis === "kcal")}
+                    aria-pressed={ratioBasis === "kcal"}
+                  >
+                    カロリー比
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => selectRatioBasis("gram")}
+                    className={ratioBasisButtonClass(ratioBasis === "gram")}
+                    aria-pressed={ratioBasis === "gram"}
+                  >
+                    重量比
+                  </button>
+                </div>
+              ) : null}
             </div>
           </div>
-          {ratioBasis === "kcal" ? (
-            <p className="mb-2 text-[11px] text-gray-400">
-              平均 {fmtNum(avgDailyKcal)} kcal/日
-              <span className="text-gray-500"> · P4・F9・C4 kcal/g</span>
-            </p>
-          ) : null}
-          <div className="grid grid-cols-3 gap-2 text-center">
-            <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
-              <p className="text-[11px] text-gray-400">たんぱく質 (P)</p>
-              <p className="text-sm font-semibold text-blue-300">{fmtNum(insight.summary.avgProtein)} g</p>
-              <p className="text-[11px] text-blue-200/90">{fmtNum(avgRatioPct.p)}%</p>
-            </div>
-            <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
-              <p className="text-[11px] text-gray-400">脂質 (F)</p>
-              <p className="text-sm font-semibold text-yellow-300">{fmtNum(insight.summary.avgFat)} g</p>
-              <p className="text-[11px] text-yellow-200/90">{fmtNum(avgRatioPct.f)}%</p>
-            </div>
-            <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
-              <p className="text-[11px] text-gray-400">糖質 (C)</p>
-              <p className="text-sm font-semibold text-emerald-300">{fmtNum(insight.summary.avgCarbs)} g</p>
-              <p className="text-[11px] text-emerald-200/90">{fmtNum(avgRatioPct.c)}%</p>
-            </div>
-          </div>
-          <div className="mt-2 h-2 w-full overflow-hidden rounded bg-gray-800">
-            <div className="flex h-full w-full">
-              <div className="bg-blue-400" style={ratioStyleFromPercents(avgRatioPct.p)} />
-              <div className="bg-yellow-400" style={ratioStyleFromPercents(avgRatioPct.f)} />
-              <div className="bg-emerald-400" style={ratioStyleFromPercents(avgRatioPct.c)} />
-            </div>
-          </div>
+          {metricMode === "achievement" ? (
+            <>
+              <p className="mb-2 text-[11px] text-gray-400">
+                記録日 {achievement.summary.recordedDayCount} 日
+                <span className="text-gray-500">
+                  {" "}
+                  · 除外 {achievement.summary.excludedDayCount} 日（目標履歴なし／食事なし）
+                </span>
+              </p>
+              {achievement.summary.recordedDayCount === 0 ? (
+                <p className="text-xs text-amber-300/90">
+                  この期間は目標スナップショット付きの記録日がありません。Today
+                  でプリセットを選ぶか食事を記録すると、以降の達成率を集計できます。
+                </p>
+              ) : (
+                <div className="grid grid-cols-3 gap-2 text-center">
+                  <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+                    <p className="text-[11px] text-gray-400">たんぱく質 (P)</p>
+                    <p className="text-sm font-semibold text-blue-300">
+                      {fmtNum(achievement.summary.avgProteinPct ?? 0)}%
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+                    <p className="text-[11px] text-gray-400">脂質 (F)</p>
+                    <p className="text-sm font-semibold text-yellow-300">
+                      {fmtNum(achievement.summary.avgFatPct ?? 0)}%
+                    </p>
+                  </div>
+                  <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+                    <p className="text-[11px] text-gray-400">糖質 (C)</p>
+                    <p className="text-sm font-semibold text-emerald-300">
+                      {fmtNum(achievement.summary.avgCarbsPct ?? 0)}%
+                    </p>
+                  </div>
+                </div>
+              )}
+            </>
+          ) : (
+            <>
+              {ratioBasis === "kcal" ? (
+                <p className="mb-2 text-[11px] text-gray-400">
+                  平均 {fmtNum(avgDailyKcal)} kcal/日
+                  <span className="text-gray-500"> · P4・F9・C4 kcal/g</span>
+                </p>
+              ) : null}
+              <div className="grid grid-cols-3 gap-2 text-center">
+                <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+                  <p className="text-[11px] text-gray-400">たんぱく質 (P)</p>
+                  <p className="text-sm font-semibold text-blue-300">
+                    {fmtNum(insight.summary.avgProtein)} g
+                  </p>
+                  <p className="text-[11px] text-blue-200/90">{fmtNum(avgRatioPct.p)}%</p>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+                  <p className="text-[11px] text-gray-400">脂質 (F)</p>
+                  <p className="text-sm font-semibold text-yellow-300">
+                    {fmtNum(insight.summary.avgFat)} g
+                  </p>
+                  <p className="text-[11px] text-yellow-200/90">{fmtNum(avgRatioPct.f)}%</p>
+                </div>
+                <div className="rounded-lg border border-gray-800 bg-gray-900/60 py-2">
+                  <p className="text-[11px] text-gray-400">糖質 (C)</p>
+                  <p className="text-sm font-semibold text-emerald-300">
+                    {fmtNum(insight.summary.avgCarbs)} g
+                  </p>
+                  <p className="text-[11px] text-emerald-200/90">{fmtNum(avgRatioPct.c)}%</p>
+                </div>
+              </div>
+              <div className="mt-2 h-2 w-full overflow-hidden rounded bg-gray-800">
+                <div className="flex h-full w-full">
+                  <div className="bg-blue-400" style={ratioStyleFromPercents(avgRatioPct.p)} />
+                  <div className="bg-yellow-400" style={ratioStyleFromPercents(avgRatioPct.f)} />
+                  <div className="bg-emerald-400" style={ratioStyleFromPercents(avgRatioPct.c)} />
+                </div>
+              </div>
+            </>
+          )}
         </div>
 
         <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3">
-          <h2 className="mb-2 text-sm font-medium text-white">日次PFC推移</h2>
-          <InsightsChart data={insight.chart} />
+          <h2 className="mb-2 text-sm font-medium text-white">
+            {metricMode === "achievement" ? "日次達成率推移" : "日次PFC推移"}
+          </h2>
+          <InsightsChart
+            data={metricMode === "achievement" ? achievement.chart : insight.chart}
+            unitLabel={metricMode === "achievement" ? "%" : "g"}
+          />
         </div>
 
         <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3 space-y-2">
@@ -370,6 +483,7 @@ export default function InsightsClient({
             const isOpen = expanded.has(day.date);
             const dayGrams = toPfcGrams(day.protein, day.fat, day.carbs);
             const dayRatioPct = pfcRatioPercents(dayGrams, ratioBasis);
+            const dayAch = achievementByDate.get(day.date);
             return (
               <div key={day.date} className="rounded-lg border border-gray-800 bg-gray-950/60">
                 <button
@@ -381,10 +495,31 @@ export default function InsightsClient({
                     <div className="grid grid-cols-[minmax(0,1fr)_4.2rem_4.2rem_4.2rem] items-center gap-1 text-xs">
                       <p className="truncate text-sm text-white">
                         {isOpen ? "▼" : "▶"} {jstDateLabel(day.date)}
+                        {dayAch?.phaseName ? (
+                          <span className="ml-1 text-[11px] text-gray-500">
+                            · {dayAch.phaseName}
+                          </span>
+                        ) : null}
                       </p>
-                      <span className="text-right text-blue-300">{fmtNum(day.protein)}</span>
-                      <span className="text-right text-yellow-300">{fmtNum(day.fat)}</span>
-                      <span className="text-right text-emerald-300">{fmtNum(day.carbs)}</span>
+                      {metricMode === "achievement" ? (
+                        <>
+                          <span className="text-right text-blue-300">
+                            {dayAch?.proteinPct != null ? `${fmtNum(dayAch.proteinPct)}%` : "—"}
+                          </span>
+                          <span className="text-right text-yellow-300">
+                            {dayAch?.fatPct != null ? `${fmtNum(dayAch.fatPct)}%` : "—"}
+                          </span>
+                          <span className="text-right text-emerald-300">
+                            {dayAch?.carbsPct != null ? `${fmtNum(dayAch.carbsPct)}%` : "—"}
+                          </span>
+                        </>
+                      ) : (
+                        <>
+                          <span className="text-right text-blue-300">{fmtNum(day.protein)}</span>
+                          <span className="text-right text-yellow-300">{fmtNum(day.fat)}</span>
+                          <span className="text-right text-emerald-300">{fmtNum(day.carbs)}</span>
+                        </>
+                      )}
                     </div>
                     <div className="mt-1.5 h-2 w-full overflow-hidden rounded bg-gray-800">
                       <div className="flex h-full w-full">

--- a/src/app/insights/actions.ts
+++ b/src/app/insights/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
-import type { InsightFoodLogEntry } from "@/lib/insights";
+import type { InsightFoodLogEntry, InsightPfcTargetSnapshot } from "@/lib/insights";
 import type { MealType } from "@ketolog/types";
 
 const INSIGHTS_PAGE_SIZE = 1000;
@@ -61,4 +61,38 @@ export async function getInsightsFoodLogForDateRange(
   }
 
   return { entries, error: null };
+}
+
+export async function getInsightsPfcTargetSnapshotsForDateRange(
+  start: string,
+  end: string
+): Promise<{ snapshots: InsightPfcTargetSnapshot[]; error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { snapshots: [], error: "認証が必要です" };
+
+  const { data, error } = await supabase
+    .from("daily_pfc_target_snapshot")
+    .select(
+      "date, diet_phase, phase_name, protein_target_g, fat_target_g, carbs_target_g"
+    )
+    .eq("user_id", user.id)
+    .gte("date", start)
+    .lte("date", end)
+    .order("date", { ascending: true });
+
+  if (error) return { snapshots: [], error: error.message };
+
+  const snapshots: InsightPfcTargetSnapshot[] = (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    return {
+      date: String(r.date),
+      diet_phase: Number(r.diet_phase),
+      phase_name: r.phase_name == null ? null : String(r.phase_name),
+      protein_target_g: Number(r.protein_target_g),
+      fat_target_g: Number(r.fat_target_g),
+      carbs_target_g: Number(r.carbs_target_g),
+    };
+  });
+
+  return { snapshots, error: null };
 }

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -1,7 +1,10 @@
 import { redirect } from "next/navigation";
 import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import { getPresetRange, getTodayJstDate } from "@/lib/insights";
-import { getInsightsFoodLogForDateRange } from "./actions";
+import {
+  getInsightsFoodLogForDateRange,
+  getInsightsPfcTargetSnapshotsForDateRange,
+} from "./actions";
 import InsightsClient from "./InsightsClient";
 
 export default async function InsightsPage() {
@@ -10,7 +13,16 @@ export default async function InsightsPage() {
 
   const today = getTodayJstDate();
   const initialRange = getPresetRange(today, 7);
-  const result = await getInsightsFoodLogForDateRange(initialRange.start, initialRange.end);
+  const [foodResult, snapResult] = await Promise.all([
+    getInsightsFoodLogForDateRange(initialRange.start, initialRange.end),
+    getInsightsPfcTargetSnapshotsForDateRange(initialRange.start, initialRange.end),
+  ]);
 
-  return <InsightsClient initialEntries={result.entries} today={today} />;
+  return (
+    <InsightsClient
+      initialEntries={foodResult.entries}
+      initialSnapshots={snapResult.snapshots}
+      today={today}
+    />
+  );
 }

--- a/src/app/today/actions/food-log.ts
+++ b/src/app/today/actions/food-log.ts
@@ -4,6 +4,7 @@ import { sumPfc } from "@ketolog/domain/pfc";
 import type { PfcGrams } from "@ketolog/types";
 import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import type { FoodLogEntry, TodayConsumed } from "@/types/database";
+import { ensurePfcTargetSnapshotForDate } from "./pfc-target-snapshot";
 
 export type SaveItem = {
   menuItemId: string | null;
@@ -58,6 +59,9 @@ export async function saveMealToLog(
   );
 
   if (error) return { error: error.message };
+
+  const snap = await ensurePfcTargetSnapshotForDate(date, "food_log_ensure");
+  if (snap.error) return { error: snap.error };
   return { error: null };
 }
 

--- a/src/app/today/actions/pfc-target-snapshot.ts
+++ b/src/app/today/actions/pfc-target-snapshot.ts
@@ -1,0 +1,76 @@
+"use server";
+
+import { getTodayJstDate } from "@ketolog/domain/date";
+import {
+  snapshotSourceForSettingsChange,
+  type PfcTargetSnapshotSource,
+} from "@ketolog/domain/pfc-target-snapshot";
+import {
+  clampDietPhase,
+  normalizePhaseProfiles,
+  normalizeUserSettings,
+  type PhaseProfiles,
+} from "@/lib/diet-phase";
+import { writePfcTargetSnapshot } from "@/lib/pfc-target-snapshot-write";
+import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
+
+async function loadSettingsForUser(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  userId: string
+) {
+  const { data } = await supabase
+    .from("user_settings")
+    .select("diet_phase, phase_profiles")
+    .eq("user_id", userId)
+    .maybeSingle();
+  return normalizeUserSettings(data);
+}
+
+/** 切替 / アクティブ profile 編集後の当日スナップショット upsert */
+export async function syncTodayPfcTargetSnapshotAfterSettingsChange(
+  prev: { diet_phase: number; phase_profiles: PhaseProfiles },
+  next: { diet_phase: number; phase_profiles: PhaseProfiles }
+): Promise<{ error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { error: "認証が必要です" };
+
+  const source = snapshotSourceForSettingsChange(
+    {
+      diet_phase: clampDietPhase(prev.diet_phase),
+      phase_profiles: normalizePhaseProfiles(prev.phase_profiles),
+    },
+    {
+      diet_phase: clampDietPhase(next.diet_phase),
+      phase_profiles: normalizePhaseProfiles(next.phase_profiles),
+    }
+  );
+  if (!source) return { error: null };
+
+  return writePfcTargetSnapshot(supabase, {
+    userId: user.id,
+    date: getTodayJstDate(),
+    settings: {
+      diet_phase: clampDietPhase(next.diet_phase),
+      phase_profiles: normalizePhaseProfiles(next.phase_profiles),
+    },
+    source,
+  });
+}
+
+/** Today 表示時 / 初回 food_log 用の INSERT-only ensure */
+export async function ensurePfcTargetSnapshotForDate(
+  date: string,
+  source: Extract<PfcTargetSnapshotSource, "app_ensure" | "food_log_ensure">
+): Promise<{ error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { error: "認証が必要です" };
+
+  const settings = await loadSettingsForUser(supabase, user.id);
+  return writePfcTargetSnapshot(supabase, {
+    userId: user.id,
+    date,
+    settings,
+    source,
+  });
+}

--- a/src/app/today/actions/settings.ts
+++ b/src/app/today/actions/settings.ts
@@ -7,6 +7,7 @@ import {
   normalizeUserSettings,
   type PhaseProfiles,
 } from "@/lib/diet-phase";
+import { syncTodayPfcTargetSnapshotAfterSettingsChange } from "./pfc-target-snapshot";
 
 export type UserSettingsPatch = {
   diet_phase?: number;
@@ -39,5 +40,11 @@ export async function updateUserSettings(data: UserSettingsPatch): Promise<{ err
   );
 
   if (error) return { error: error.message };
+
+  const snap = await syncTodayPfcTargetSnapshotAfterSettingsChange(base, {
+    diet_phase,
+    phase_profiles,
+  });
+  if (snap.error) return { error: snap.error };
   return { error: null };
 }

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -16,6 +16,7 @@ import { normalizeUserSettings } from "@/lib/diet-phase";
 import { sumPfc } from "@ketolog/domain/pfc";
 import type { PfcGrams } from "@ketolog/types";
 import { loadPresets } from "@/lib/presets-server";
+import { writePfcTargetSnapshot } from "@/lib/pfc-target-snapshot-write";
 
 export type { PresetMeta } from "@/lib/presets-server";
 
@@ -65,6 +66,14 @@ export default async function TodayPage() {
   const settings: UserSettings = settingsRes.data
     ? normalizeUserSettings(settingsRes.data)
     : normalizeUserSettings(null);
+
+  // 当日スナップショットが無ければ現行設定で確保（既存行は触らない）
+  void writePfcTargetSnapshot(supabase, {
+    userId: user.id,
+    date: today,
+    settings,
+    source: "app_ensure",
+  });
 
   const rawRestaurants: Restaurant[] = restaurantsRes.data ?? [];
   const rawWithSnapshot =

--- a/src/lib/insights.ts
+++ b/src/lib/insights.ts
@@ -1,9 +1,13 @@
 export {
   addDaysJst,
+  buildAchievementRates,
   buildInsights,
   getPresetRange,
   getTodayJstDate,
+  type AchievementSummary,
+  type DailyAchievement,
   type DailyInsight,
   type InsightFoodLogEntry,
+  type InsightPfcTargetSnapshot,
   type TopItem,
 } from "@ketolog/domain/insights";

--- a/src/lib/pfc-target-snapshot-write.ts
+++ b/src/lib/pfc-target-snapshot-write.ts
@@ -1,0 +1,49 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import {
+  buildPfcTargetSnapshotWriteRow,
+  isInsertOnlyPfcTargetSnapshotSource,
+  type PfcTargetSnapshotSource,
+} from "@ketolog/domain/pfc-target-snapshot";
+import type { DietPhase, PhaseProfiles } from "@ketolog/domain/diet-phase";
+
+type Settings = {
+  diet_phase: DietPhase;
+  phase_profiles: PhaseProfiles;
+};
+
+/**
+ * スナップショット書き込み。
+ * ensure 系は INSERT-only（既存行は触らない）。switch / profile_edit は upsert。
+ */
+export async function writePfcTargetSnapshot(
+  supabase: SupabaseClient,
+  input: {
+    userId: string;
+    date: string;
+    settings: Settings;
+    source: PfcTargetSnapshotSource;
+  }
+): Promise<{ error: string | null }> {
+  const row = buildPfcTargetSnapshotWriteRow({
+    userId: input.userId,
+    date: input.date,
+    diet_phase: input.settings.diet_phase,
+    phase_profiles: input.settings.phase_profiles,
+    source: input.source,
+  });
+
+  if (isInsertOnlyPfcTargetSnapshotSource(input.source)) {
+    const { error } = await supabase.from("daily_pfc_target_snapshot").upsert(row, {
+      onConflict: "user_id,date",
+      ignoreDuplicates: true,
+    });
+    if (error) return { error: error.message };
+    return { error: null };
+  }
+
+  const { error } = await supabase.from("daily_pfc_target_snapshot").upsert(row, {
+    onConflict: "user_id,date",
+  });
+  if (error) return { error: error.message };
+  return { error: null };
+}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -5,6 +5,18 @@ export type UserSettings = {
   phase_profiles: PhaseProfiles;
 };
 
+/** 日次 PFC 目標スナップショット（Insights 達成率用） */
+export type DailyPfcTargetSnapshot = {
+  id?: string;
+  date: string;
+  diet_phase: DietPhase;
+  phase_name: string | null;
+  protein_target_g: number;
+  fat_target_g: number;
+  carbs_target_g: number;
+  source: string;
+};
+
 export type Restaurant = {
   id: string;
   name: string;

--- a/supabase/migrations/20260726050000_daily_pfc_target_snapshot.sql
+++ b/supabase/migrations/20260726050000_daily_pfc_target_snapshot.sql
@@ -1,0 +1,45 @@
+-- その日評価時点の PFC 目標スナップショット（Insights 達成率用）
+-- date は food_log と同じ JST 暦日（活動日 D）。
+
+CREATE TABLE IF NOT EXISTS daily_pfc_target_snapshot (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  date date NOT NULL,
+  diet_phase smallint NOT NULL,
+  phase_name text,
+  protein_target_g numeric NOT NULL,
+  fat_target_g numeric NOT NULL,
+  carbs_target_g numeric NOT NULL,
+  source text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT daily_pfc_target_snapshot_diet_phase_check
+    CHECK (diet_phase >= 1 AND diet_phase <= 3),
+  CONSTRAINT daily_pfc_target_snapshot_source_check
+    CHECK (source IN (
+      'app_switch',
+      'app_profile_edit',
+      'food_log_ensure',
+      'app_ensure',
+      'claude_backfill'
+    )),
+  CONSTRAINT daily_pfc_target_snapshot_targets_positive_check
+    CHECK (
+      protein_target_g > 0
+      AND fat_target_g > 0
+      AND carbs_target_g > 0
+    ),
+  CONSTRAINT daily_pfc_target_snapshot_user_id_date_key UNIQUE (user_id, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_daily_pfc_target_snapshot_user_date
+  ON daily_pfc_target_snapshot (user_id, date);
+
+ALTER TABLE daily_pfc_target_snapshot ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS daily_pfc_target_snapshot_owner_access ON daily_pfc_target_snapshot;
+CREATE POLICY daily_pfc_target_snapshot_owner_access ON daily_pfc_target_snapshot
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE daily_pfc_target_snapshot IS
+  '日次 PFC 目標スナップショット。Insights 達成率は当時の目標で評価する。';


### PR DESCRIPTION
## Summary
- 可変プリセット運用向けに、その日当時の PFC 目標スナップショット（`daily_pfc_target_snapshot`）と **記録日達成率(%)** を追加
- Web / iOS の分析画面で達成率をデフォルト表示（生グラムは切替で併存）
- 切替・初回食事保存・Today表示でスナップショットを書き込み（ensure は INSERT-only）
- カロリー収支・EA は [#348](https://github.com/kzkski/ketolog/issues/348) に分割

closes #344

## Test plan
- [ ] migration 適用後、Today でプリセット切替 → `daily_pfc_target_snapshot` に当日行ができる
- [ ] 食事を記録（既存行があれば ensure が上書きしない）
- [ ] Insights（Web）: 達成率が表示され、除外日数が分かる／生グラムに切替できる
- [ ] Insights（iOS）: 同上
- [ ] 目標スナップショットがない過去期間は達成率にバナーが出る
- [ ] `npm test` が通る


Made with [Cursor](https://cursor.com)