### PR TITLE
fix: 本番 migration 履歴との版番号ずれを解消

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 ### Changed
 
+## [1.70.1] - 2026-07-26
+
+### Fixed
+
+- **DB / migrations**: 本番 `schema_migrations` にのみ存在する MyVitalRelay 由来の版番号向けに `remote_history` プレースホルダーを追加し、`supabase db push` が履歴不一致で失敗しないようにした（#349 マージ後の prod-db-migrate 失敗の修正）。
+
 ## [1.70.0] - 2026-07-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.70.0",
+  "version": "1.70.1",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/supabase/migrations/20260704063000_remote_history.sql
+++ b/supabase/migrations/20260704063000_remote_history.sql
@@ -1,0 +1,4 @@
+-- Placeholder: remote schema_migrations にのみ存在する版の履歴整合用。
+-- 本番では MyVitalRelay の training_log DDL（20260704063000_create_training_log.sql）として適用済み。
+-- 内容の再適用は不要。
+SELECT 1;

--- a/supabase/migrations/20260706100000_remote_history.sql
+++ b/supabase/migrations/20260706100000_remote_history.sql
@@ -1,0 +1,4 @@
+-- Placeholder: remote schema_migrations にのみ存在する版の履歴整合用。
+-- 本番では MyVitalRelay の sleep_segment 論理 UNIQUE（20260706100000）として適用済み。
+-- 内容の再適用は不要。
+SELECT 1;

--- a/supabase/migrations/20260708100000_remote_history.sql
+++ b/supabase/migrations/20260708100000_remote_history.sql
@@ -1,0 +1,4 @@
+-- Placeholder: remote schema_migrations にのみ存在する版の履歴整合用。
+-- 本番では MyVitalRelay の daily_activity_summary（20260708100000）として適用済み。
+-- 内容の再適用は不要。
+SELECT 1;

--- a/supabase/migrations/20260709100000_remote_history.sql
+++ b/supabase/migrations/20260709100000_remote_history.sql
@@ -1,0 +1,4 @@
+-- Placeholder: remote schema_migrations にのみ存在する版の履歴整合用。
+-- 本番では MyVitalRelay の training_log 論理 UNIQUE（20260709100000）として適用済み。
+-- 内容の再適用は不要。
+SELECT 1;

--- a/supabase/migrations/20260712120000_remote_history.sql
+++ b/supabase/migrations/20260712120000_remote_history.sql
@@ -1,0 +1,4 @@
+-- Placeholder: remote schema_migrations にのみ存在する版の履歴整合用。
+-- 本番では MyVitalRelay の Garmin sync / Claude access（20260712120000）として適用済み。
+-- 内容の再適用は不要。
+SELECT 1;

--- a/supabase/migrations/20260713021307_remote_history.sql
+++ b/supabase/migrations/20260713021307_remote_history.sql
@@ -1,0 +1,3 @@
+-- Placeholder: remote schema_migrations にのみ存在する版の履歴整合用。
+-- 本番で適用済み（リポジトリ未収録のタイムスタンプ。DDL 再適用は不要）。
+SELECT 1;

--- a/supabase/migrations/20260713052726_remote_history.sql
+++ b/supabase/migrations/20260713052726_remote_history.sql
@@ -1,0 +1,3 @@
+-- Placeholder: remote schema_migrations にのみ存在する版の履歴整合用。
+-- 本番で適用済み（リポジトリ未収録のタイムスタンプ。DDL 再適用は不要）。
+SELECT 1;


### PR DESCRIPTION
## Summary
- 本番 `schema_migrations` に存在するが ketolog ローカルに無い版（主に MyVitalRelay 由来）向けに `*_remote_history.sql`（`SELECT 1`）を追加
- #349 マージ後の `prod-db-migrate` 失敗（Remote migration versions not found in local）を解消し、未適用の `daily_pfc_target_snapshot` を push できるようにする

## Test plan
- [ ] CI 通過
- [ ] マージ後 `prod-db-migrate` が成功し、`daily_pfc_target_snapshot` が作成される


Made with [Cursor](https://cursor.com)