### PR TITLE
fix: 本番 migration の欠落履歴を repair してから push する

### DIFF
--- a/.github/workflows/prod-db-migrate.yml
+++ b/.github/workflows/prod-db-migrate.yml
@@ -12,6 +12,7 @@ on:
       - main
     paths:
       - "supabase/migrations/**"
+      - ".github/workflows/prod-db-migrate.yml"
 
 jobs:
   migrate:
@@ -51,6 +52,35 @@ jobs:
           SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
           SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}
         run: supabase link --project-ref "$SUPABASE_PROJECT_REF"
+
+      # MyVitalRelay が共有本番へ新しい版を先に積むと、ketolog 側の「それより古いが
+      # schema_migrations から欠落した版」が out-of-order 扱いになり db push が拒否する。
+      # 実 DDL は既に本番にある前提で、履歴だけ applied に揃えてから未適用分を push する。
+      # （baseline 等を --include-all で再実行すると破壊的になりうるため使わない）
+      - name: Repair out-of-order migration history
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          set -eu
+          supabase migration repair --status applied \
+            20260211120000 \
+            20260409015501 \
+            20260409095719 \
+            20260412035245 \
+            20260412120000 \
+            20260412120001 \
+            20260412130000 \
+            20260413100000 \
+            20260414120000 \
+            20260415180000 \
+            20260416120000 \
+            20260417120000 \
+            20260427120000 \
+            20260706054829 \
+            20260708224747 \
+            20260710014053 \
+            20260710120000 \
+            20260710140000
 
       - name: Apply migrations
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 ### Changed
 
+## [1.70.2] - 2026-07-26
+
+### Fixed
+
+- **DB / migrations**: 共有本番で MyVitalRelay 由来の新しい migration 版が先行しているとき、ketolog 側の欠落履歴を `migration repair --status applied` で揃えてから `db push` するよう prod-db-migrate を修正。baseline 等の再実行を避けつつ、未適用の `daily_pfc_target_snapshot` を適用できるようにした。
+
 ## [1.70.1] - 2026-07-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.70.1",
+  "version": "1.70.2",
   "private": true,
   "workspaces": [
     "apps/*",


### PR DESCRIPTION
## Summary
- #350 で remote_history を足したあとも、`db push` が「last remote より前に挿入が必要」で失敗
- 共有本番で MyVitalRelay 由来の新しい版が最新になり、ketolog 側の既存版が `schema_migrations` から欠けている状態
- `migration repair --status applied` で欠落履歴を揃えてから `db push`（`--include-all` による baseline 再実行はしない）
- これにより未適用の `20260726050000_daily_pfc_target_snapshot` が適用される想定

## Test plan
- [ ] CI 通過
- [ ] マージ後 `prod-db-migrate` が成功する
- [ ] ログに `Applying migration 20260726050000_daily_pfc_target_snapshot.sql` が出る


Made with [Cursor](https://cursor.com)