### PR TITLE
fix: PFCスナップショットの日付 import を修正

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 ### Changed
 
+## [1.70.3] - 2026-07-26
+
+### Fixed
+
+- **Today**: `pfc-target-snapshot` Server Action が存在しない `getTodayJstDate` を `@ketolog/domain/date` から import していたため、Vercel の Next.js ビルドが失敗していた問題を修正（`toJstDateString` を使用）。
+
 ## [1.70.2] - 2026-07-26
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.70.2",
+  "version": "1.70.3",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/src/app/today/actions/pfc-target-snapshot.ts
+++ b/src/app/today/actions/pfc-target-snapshot.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import { getTodayJstDate } from "@ketolog/domain/date";
+import { toJstDateString } from "@ketolog/domain/date";
 import {
   snapshotSourceForSettingsChange,
   type PfcTargetSnapshotSource,
@@ -49,7 +49,7 @@ export async function syncTodayPfcTargetSnapshotAfterSettingsChange(
 
   return writePfcTargetSnapshot(supabase, {
     userId: user.id,
-    date: getTodayJstDate(),
+    date: toJstDateString(),
     settings: {
       diet_phase: clampDietPhase(next.diet_phase),
       phase_profiles: normalizePhaseProfiles(next.phase_profiles),


### PR DESCRIPTION
## Summary
- `pfc-target-snapshot.ts` が `@ketolog/domain/date` から存在しない `getTodayJstDate` を import しており、Vercel の Next.js / Turbopack ビルドが失敗していた
- `toJstDateString` に修正

## Test plan
- [ ] CI 通過
- [ ] マージ後 Vercel 本番ビルドが成功する


Made with [Cursor](https://cursor.com)