### PR TITLE
chore: DAS / training_log を migrations と型に揃える

### DIFF
--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -94,3 +94,40 @@ export type FoodLogEntry = {
   source: string | null;
   menu_item_id: string | null;
 };
+
+/**
+ * 日次 active/basal（MyVitalRelay）。
+ * `date` は格納日 = 活動日 D+1。集計時は -1 日して food_log と揃える。
+ */
+export type DailyActivitySummary = {
+  id?: string;
+  date: string;
+  active_calories_kcal: number | null;
+  basal_calories_kcal: number | null;
+  notes?: string | null;
+  synced_at?: string | null;
+};
+
+/** ワークアウト1行。`date` は活動日 D（シフトなし）。EEE は calories_burned。 */
+export type TrainingLogRow = {
+  id?: string;
+  date: string;
+  calories_burned: number | null;
+  data_source?: string;
+  discipline?: string;
+  start_time?: string | null;
+  end_time?: string | null;
+};
+
+/**
+ * 体組成サンプル。体重と体脂肪は別行になりうる。
+ * `body_fat_pct` は 0–100（パーセント）。
+ */
+export type BodyCompositionSample = {
+  id?: string;
+  date: string;
+  measured_at: string;
+  weight_kg: number | null;
+  body_fat_pct: number | null;
+  healthkit_uuid?: string | null;
+};

--- a/supabase/migrations/20260726130000_create_daily_activity_summary.sql
+++ b/supabase/migrations/20260726130000_create_daily_activity_summary.sql
@@ -1,0 +1,39 @@
+-- daily_activity_summary: 日次アクティブ/基礎代謝カロリー（MyVitalRelay HealthKit リレー）
+-- 本番（ykcbevvorckcigwwtftw）へ MyVitalRelay 経由で適用済み。ketolog 履歴整合用の冪等 DDL。
+-- date の意味: 格納日 = 活動日 D+1（集計時は -1 日して food_log.date と揃える）。
+
+CREATE TABLE IF NOT EXISTS daily_activity_summary (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id),
+  date date NOT NULL,
+  active_calories_kcal numeric,
+  basal_calories_kcal numeric,
+  notes text,
+  synced_at timestamptz DEFAULT now()
+);
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'daily_activity_summary_user_id_date_key'
+  ) THEN
+    ALTER TABLE daily_activity_summary
+      ADD CONSTRAINT daily_activity_summary_user_id_date_key
+      UNIQUE (user_id, date);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_daily_activity_summary_user_date
+  ON daily_activity_summary (user_id, date);
+
+ALTER TABLE daily_activity_summary ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS daily_activity_summary_owner_access ON daily_activity_summary;
+CREATE POLICY daily_activity_summary_owner_access ON daily_activity_summary
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE daily_activity_summary IS
+  '日次 active/basal カロリー。MyVitalRelay が HealthKit から upsert。';
+
+COMMENT ON COLUMN daily_activity_summary.date IS
+  '格納日 = 活動日 D+1（Asia/Tokyo）。Insights 等の集計では -1 日して food_log.date と揃える。';

--- a/supabase/migrations/20260726130100_create_training_log.sql
+++ b/supabase/migrations/20260726130100_create_training_log.sql
@@ -1,0 +1,50 @@
+-- training_log: 1 HealthKit ワークアウト = 1行（MyVitalRelay）
+-- 本番へ MyVitalRelay 経由で適用済み。履歴 placeholder（20260704063102）は触らず、冪等 CREATE で揃える。
+
+CREATE TABLE IF NOT EXISTS training_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid NOT NULL REFERENCES auth.users(id),
+  date date NOT NULL,
+  data_source text NOT NULL CHECK (data_source IN ('garmin', 'life_fitness', 'manual')),
+  healthkit_uuid uuid UNIQUE,
+  discipline text NOT NULL CHECK (discipline IN ('run', 'bike', 'swim', 'brick', 'strength', 'other')),
+  workout_type text,
+  start_time timestamptz,
+  end_time timestamptz,
+  duration_min numeric,
+  distance_km numeric,
+  avg_speed_kmh numeric,
+  calories_burned numeric,
+  avg_hr numeric,
+  max_hr numeric,
+  elevation_gain_m numeric,
+  hr_zone_minutes jsonb,
+  cadence numeric,
+  power_watts numeric,
+  stroke_count numeric,
+  stroke_style text CHECK (stroke_style IN ('freestyle', 'backstroke', 'breaststroke', 'butterfly', 'mixed', 'unknown')),
+  equipment text,
+  surface text,
+  rpe smallint CHECK (rpe BETWEEN 1 AND 10),
+  srpe numeric GENERATED ALWAYS AS (duration_min * rpe) STORED,
+  condition_notes text,
+  notes text,
+  metadata jsonb DEFAULT '{}'::jsonb,
+  created_at timestamptz DEFAULT now(),
+  updated_at timestamptz DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_training_log_user_date
+  ON training_log (user_id, date);
+
+ALTER TABLE training_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS training_log_owner_access ON training_log;
+CREATE POLICY training_log_owner_access ON training_log
+  FOR ALL USING (auth.uid() = user_id) WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE training_log IS
+  'ワークアウト1セッション=1行。EEE（エネルギー可用性）は calories_burned の日次合計。date は活動日 D（シフトなし）。';
+
+COMMENT ON COLUMN training_log.date IS
+  'ワークアウト開始の JST 暦日（活動日 D）。daily_activity_summary.date の D+1 規約とは異なる。';

--- a/supabase/migrations/20260726130200_training_log_logical_unique.sql
+++ b/supabase/migrations/20260726130200_training_log_logical_unique.sql
@@ -1,0 +1,34 @@
+-- training_log: 論理キー UNIQUE（MyVitalRelay 20260709100000 相当・冪等）
+-- 本番適用済み想定。新規環境向けに重複クリーンアップ後、制約を IF NOT EXISTS で追加。
+
+DELETE FROM training_log t
+USING (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY user_id, start_time, end_time, workout_type
+           ORDER BY
+             (CASE
+               WHEN rpe IS NOT NULL
+                 OR condition_notes IS NOT NULL
+                 OR notes IS NOT NULL
+               THEN 0 ELSE 1
+             END) ASC,
+             created_at DESC
+         ) AS rn
+  FROM training_log
+  WHERE start_time IS NOT NULL
+    AND end_time IS NOT NULL
+    AND workout_type IS NOT NULL
+) ranked
+WHERE t.id = ranked.id AND ranked.rn > 1;
+
+DO $$ BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'training_log_logical_unique'
+  ) THEN
+    ALTER TABLE training_log
+      ADD CONSTRAINT training_log_logical_unique
+      UNIQUE (user_id, start_time, end_time, workout_type);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
- `daily_activity_summary` / `training_log` の冪等 DDL を ketolog migrations に追加（履歴 placeholder は未編集）
- `training_log` 論理 UNIQUE を冪等 migration で揃える
- `src/types/database.ts` に DAS / training_log / body_composition_sample の行型を追加
- [#348](https://github.com/kzkski/ketolog/issues/348) 実装の前提（closes は付けない）

## Test plan
- [ ] 新規環境で migration 適用時に両テーブルが作成される
- [ ] 本番相当（既にテーブルあり）で migration がエラーなく通る（IF NOT EXISTS）
- [ ] `20260704063102_remote_history.sql` が差分に含まれていないこと


Made with [Cursor](https://cursor.com)