### PR TITLE
feat: Insightsに期間カロリー収支・EAを追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Insights**: 期間カロリー収支とエネルギー可用性（EA）のサマリー、REDs 風の参考色分けを追加（Web / Mobile）。収支は摂取 − (basal+active)、EA は (摂取−EEE)/FFM。医療診断ではない旨の注記あり。活動量・体組成は HealthKit 連携（MyVitalRelay）由来。収支・EA は食事フィルタに依存せず全日で計算する（#348）。
+
 ### Fixed
 
 - **DB / daily_log**: `public.daily_log` ビューを `security_invoker` に変更し、`anon` の過剰 GRANT を剥奪、`authenticated` は SELECT のみに制限した。SECURITY DEFINER による RLS バイパス（他ユーザーの日次集計が見える問題）を解消（[MyVitalRelay#14](https://github.com/kzkski/MyVitalRelay/issues/14)）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,17 @@
 
 ## [Unreleased]
 
-### Added
-
-- **Insights**: 期間カロリー収支とエネルギー可用性（EA）のサマリー、REDs 風の参考色分けを追加（Web / Mobile）。収支は摂取 − (basal+active)、EA は (摂取−EEE)/FFM。医療診断ではない旨の注記あり。活動量・体組成は HealthKit 連携（MyVitalRelay）由来。収支・EA は食事フィルタに依存せず全日で計算する（#348）。
-
 ### Fixed
 
 - **DB / daily_log**: `public.daily_log` ビューを `security_invoker` に変更し、`anon` の過剰 GRANT を剥奪、`authenticated` は SELECT のみに制限した。SECURITY DEFINER による RLS バイパス（他ユーザーの日次集計が見える問題）を解消（[MyVitalRelay#14](https://github.com/kzkski/MyVitalRelay/issues/14)）。
 
 ### Changed
+
+## [1.71.0] - 2026-07-26
+
+### Added
+
+- **Insights**: 期間カロリー収支とエネルギー可用性（EA）のサマリー、REDs 風の参考色分けを追加（Web / Mobile）。収支は摂取 − (basal+active)、EA は (摂取−EEE)/FFM。医療診断ではない旨の注記あり。活動量・体組成は HealthKit 連携（MyVitalRelay）由来。収支・EA は食事フィルタに依存せず全日で計算する（#348）。
 
 ## [1.70.3] - 2026-07-26
 

--- a/apps/mobile/components/InsightsPeriodEnergySection.tsx
+++ b/apps/mobile/components/InsightsPeriodEnergySection.tsx
@@ -1,0 +1,170 @@
+import { StyleSheet, Text, View } from "react-native";
+import type { PeriodEnergySummary, RedsBand } from "@ketolog/domain/energy-availability";
+
+const BAND_LABEL: Record<Exclude<RedsBand, null>, string> = {
+  red: "LEA リスク帯（参考）",
+  yellow: "注意",
+  green: "当面の余裕",
+};
+
+const BAND_DOT: Record<Exclude<RedsBand, null>, string> = {
+  red: "#ef4444",
+  yellow: "#eab308",
+  green: "#34d399",
+};
+
+function fmtNum(v: number): string {
+  return v.toFixed(1);
+}
+
+function fmtSigned(v: number): string {
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${fmtNum(v)}`;
+}
+
+export function InsightsPeriodEnergySection({
+  summary,
+  mealFilterActive,
+}: {
+  summary: PeriodEnergySummary;
+  mealFilterActive: boolean;
+}) {
+  const band = summary.redsBand;
+
+  return (
+    <View style={styles.card}>
+      <Text style={styles.title}>期間カロリー収支・EA</Text>
+      <View style={styles.row}>
+        <View style={styles.cell}>
+          <Text style={styles.label}>期間平均収支</Text>
+          {summary.avgBalanceKcal == null ? (
+            <Text style={styles.na}>計算不可</Text>
+          ) : (
+            <Text style={styles.value}>
+              {fmtSigned(summary.avgBalanceKcal)}{" "}
+              <Text style={styles.unit}>kcal/日</Text>
+            </Text>
+          )}
+          <Text style={styles.meta}>
+            有効 {summary.balanceValidDayCount} 日 · 除外 {summary.balanceExcludedDayCount} 日
+          </Text>
+        </View>
+        <View style={styles.cell}>
+          <Text style={styles.label}>期間平均 EA</Text>
+          {summary.periodEa == null ? (
+            <Text style={styles.na}>計算不可</Text>
+          ) : (
+            <View style={styles.eaValueRow}>
+              {band ? (
+                <View style={[styles.dot, { backgroundColor: BAND_DOT[band] }]} />
+              ) : null}
+              <Text style={styles.value}>
+                {fmtNum(summary.periodEa)} <Text style={styles.unit}>kcal/kgFFM/日</Text>
+              </Text>
+            </View>
+          )}
+          {band ? <Text style={styles.bandLabel}>{BAND_LABEL[band]}</Text> : null}
+          <Text style={styles.meta}>
+            有効 {summary.eaValidDayCount} 日 · 除外 {summary.eaExcludedDayCount} 日
+          </Text>
+        </View>
+      </View>
+      <Text style={styles.note}>医療診断ではありません。閾値（20 / 30）は参考の目安です。</Text>
+      <Text style={styles.note}>
+        本日は活動量の確定待ち・日未完了のため集計対象外です。
+      </Text>
+      <Text style={styles.note}>
+        食事未記録日は摂取 0 kcal として EA に含めます（記録漏れでも低く出ることがあります）。
+      </Text>
+      {mealFilterActive ? (
+        <Text style={styles.warn}>収支・EA は全日の食事で計算しています。</Text>
+      ) : null}
+      {summary.balanceValidDayCount === 0 && summary.eaValidDayCount === 0 ? (
+        <Text style={styles.warn}>
+          活動量・体組成データがない場合は HealthKit 連携（MyVitalRelay）が必要です。
+        </Text>
+      ) : null}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    backgroundColor: "rgba(17, 24, 39, 0.7)",
+    padding: 12,
+    gap: 6,
+  },
+  title: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+    marginBottom: 4,
+  },
+  row: {
+    flexDirection: "row",
+    gap: 8,
+  },
+  cell: {
+    flex: 1,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#1f2937",
+    backgroundColor: "rgba(17, 24, 39, 0.6)",
+    paddingHorizontal: 8,
+    paddingVertical: 8,
+  },
+  label: {
+    color: "#9ca3af",
+    fontSize: 11,
+  },
+  value: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
+    marginTop: 4,
+  },
+  unit: {
+    color: "#9ca3af",
+    fontSize: 11,
+    fontWeight: "400",
+  },
+  na: {
+    color: "#6b7280",
+    fontSize: 14,
+    marginTop: 4,
+  },
+  meta: {
+    color: "#6b7280",
+    fontSize: 10,
+    marginTop: 4,
+  },
+  eaValueRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    marginTop: 4,
+  },
+  dot: {
+    width: 10,
+    height: 10,
+    borderRadius: 5,
+  },
+  bandLabel: {
+    color: "#9ca3af",
+    fontSize: 10,
+    marginTop: 4,
+  },
+  note: {
+    color: "#6b7280",
+    fontSize: 10,
+    lineHeight: 14,
+  },
+  warn: {
+    color: "#fcd34d",
+    fontSize: 10,
+    lineHeight: 14,
+  },
+});

--- a/apps/mobile/lib/fetch-insights-energy-mobile.ts
+++ b/apps/mobile/lib/fetch-insights-energy-mobile.ts
@@ -1,0 +1,97 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { addDaysJst } from "@ketolog/domain/date";
+import type {
+  BodyCompRow,
+  DasRow,
+  TrainingBurnRow,
+} from "@ketolog/domain/energy-availability";
+
+export async function fetchInsightsDasForDateRange(
+  supabase: SupabaseClient,
+  userId: string,
+  start: string,
+  end: string
+): Promise<{ rows: DasRow[]; error: string | null }> {
+  const storageStart = addDaysJst(start, 1);
+  const storageEnd = addDaysJst(end, 1);
+
+  const { data, error } = await supabase
+    .from("daily_activity_summary")
+    .select("date, basal_calories_kcal, active_calories_kcal")
+    .eq("user_id", userId)
+    .gte("date", storageStart)
+    .lte("date", storageEnd)
+    .order("date", { ascending: true });
+
+  if (error) return { rows: [], error: error.message };
+
+  const rows: DasRow[] = (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    return {
+      date: String(r.date),
+      basal_calories_kcal:
+        r.basal_calories_kcal == null ? null : Number(r.basal_calories_kcal),
+      active_calories_kcal:
+        r.active_calories_kcal == null ? null : Number(r.active_calories_kcal),
+    };
+  });
+
+  return { rows, error: null };
+}
+
+export async function fetchInsightsTrainingBurnForDateRange(
+  supabase: SupabaseClient,
+  userId: string,
+  start: string,
+  end: string
+): Promise<{ rows: TrainingBurnRow[]; error: string | null }> {
+  const { data, error } = await supabase
+    .from("training_log")
+    .select("date, calories_burned")
+    .eq("user_id", userId)
+    .gte("date", start)
+    .lte("date", end)
+    .order("date", { ascending: true });
+
+  if (error) return { rows: [], error: error.message };
+
+  const rows: TrainingBurnRow[] = (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    return {
+      date: String(r.date),
+      calories_burned:
+        r.calories_burned == null ? null : Number(r.calories_burned),
+    };
+  });
+
+  return { rows, error: null };
+}
+
+export async function fetchInsightsBodyCompForDateRange(
+  supabase: SupabaseClient,
+  userId: string,
+  start: string,
+  end: string
+): Promise<{ rows: BodyCompRow[]; error: string | null }> {
+  const { data, error } = await supabase
+    .from("body_composition_sample")
+    .select("date, measured_at, weight_kg, body_fat_pct")
+    .eq("user_id", userId)
+    .gte("date", start)
+    .lte("date", end)
+    .order("measured_at", { ascending: true });
+
+  if (error) return { rows: [], error: error.message };
+
+  const rows: BodyCompRow[] = (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    return {
+      date: String(r.date),
+      measured_at: String(r.measured_at),
+      weight_kg: r.weight_kg == null ? null : Number(r.weight_kg),
+      body_fat_pct: r.body_fat_pct == null ? null : Number(r.body_fat_pct),
+    };
+  });
+
+  return { rows, error: null };
+}

--- a/apps/mobile/screens/InsightsScreen.tsx
+++ b/apps/mobile/screens/InsightsScreen.tsx
@@ -23,6 +23,12 @@ import {
   type InsightPfcTargetSnapshot,
 } from "@ketolog/domain/insights";
 import {
+  buildPeriodEnergyMetrics,
+  type BodyCompRow,
+  type DasRow,
+  type TrainingBurnRow,
+} from "@ketolog/domain/energy-availability";
+import {
   pfcRatioPercents,
   pfcTotalKcal,
   type PfcGrams,
@@ -39,8 +45,14 @@ import {
   fetchInsightsFoodLogForDateRange,
   fetchInsightsPfcTargetSnapshotsForDateRange,
 } from "../lib/fetch-insights-food-log-mobile";
+import {
+  fetchInsightsBodyCompForDateRange,
+  fetchInsightsDasForDateRange,
+  fetchInsightsTrainingBurnForDateRange,
+} from "../lib/fetch-insights-energy-mobile";
 import { shareUtf8JsonFile } from "../lib/share-json-mobile";
 import { InsightsPfcChart } from "../components/InsightsPfcChart";
+import { InsightsPeriodEnergySection } from "../components/InsightsPeriodEnergySection";
 
 const COLORS = {
   bg: "#0a0a0a",
@@ -111,7 +123,11 @@ export function InsightsScreen() {
   const [start, setStart] = useState(preset7.start);
   const [end, setEnd] = useState(preset7.end);
   const [entries, setEntries] = useState<InsightFoodLogEntry[]>([]);
+  const [energyEntries, setEnergyEntries] = useState<InsightFoodLogEntry[]>([]);
   const [snapshots, setSnapshots] = useState<InsightPfcTargetSnapshot[]>([]);
+  const [dasRows, setDasRows] = useState<DasRow[]>([]);
+  const [trainingRows, setTrainingRows] = useState<TrainingBurnRow[]>([]);
+  const [bodyCompRows, setBodyCompRows] = useState<BodyCompRow[]>([]);
   const [metricMode, setMetricMode] = useState<MetricMode>("achievement");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -132,28 +148,59 @@ export function InsightsScreen() {
       setLoading(true);
       setError(null);
       const mealTypes = nextMealFilter === "all" ? undefined : [nextMealFilter];
-      const [foodResult, snapResult] = await Promise.all([
-        fetchInsightsFoodLogForDateRange(
-          supabase,
-          userId,
-          nextStart,
-          nextEnd,
-          mealTypes
-        ),
-        fetchInsightsPfcTargetSnapshotsForDateRange(
-          supabase,
-          userId,
-          nextStart,
-          nextEnd
-        ),
-      ]);
+      const energyFoodPromise = fetchInsightsFoodLogForDateRange(
+        supabase,
+        userId,
+        nextStart,
+        nextEnd
+      );
+      const foodPromise =
+        mealTypes == null
+          ? energyFoodPromise
+          : fetchInsightsFoodLogForDateRange(
+              supabase,
+              userId,
+              nextStart,
+              nextEnd,
+              mealTypes
+            );
+      const [foodResult, energyFoodResult, snapResult, dasResult, trainingResult, bodyResult] =
+        await Promise.all([
+          foodPromise,
+          energyFoodPromise,
+          fetchInsightsPfcTargetSnapshotsForDateRange(
+            supabase,
+            userId,
+            nextStart,
+            nextEnd
+          ),
+          fetchInsightsDasForDateRange(supabase, userId, nextStart, nextEnd),
+          fetchInsightsTrainingBurnForDateRange(supabase, userId, nextStart, nextEnd),
+          fetchInsightsBodyCompForDateRange(supabase, userId, nextStart, nextEnd),
+        ]);
       setLoading(false);
       if (foodResult.error) {
         setError(foodResult.error);
         return;
       }
+      if (energyFoodResult.error) {
+        setError(energyFoodResult.error);
+        return;
+      }
       if (snapResult.error) {
         setError(snapResult.error);
+        return;
+      }
+      if (dasResult.error) {
+        setError(dasResult.error);
+        return;
+      }
+      if (trainingResult.error) {
+        setError(trainingResult.error);
+        return;
+      }
+      if (bodyResult.error) {
+        setError(bodyResult.error);
         return;
       }
       setPreset(nextPreset);
@@ -161,7 +208,11 @@ export function InsightsScreen() {
       setStart(nextStart);
       setEnd(nextEnd);
       setEntries(foodResult.entries);
+      setEnergyEntries(energyFoodResult.entries);
       setSnapshots(snapResult.snapshots);
+      setDasRows(dasResult.rows);
+      setTrainingRows(trainingResult.rows);
+      setBodyCompRows(bodyResult.rows);
       setExpanded(new Set());
     },
     [supabase, userId, mealFilter]
@@ -227,6 +278,32 @@ export function InsightsScreen() {
     [avgGrams, ratioBasis]
   );
   const avgDailyKcal = useMemo(() => pfcTotalKcal(avgGrams), [avgGrams]);
+
+  const energyInsight = useMemo(
+    () => buildInsights(energyEntries, start, end),
+    [energyEntries, start, end]
+  );
+  const periodEnergy = useMemo(() => {
+    const dailyIntake = energyInsight.chart.map((d) => {
+      const day = energyInsight.daily.find((x) => x.date === d.date);
+      return {
+        date: d.date,
+        intake_kcal: pfcTotalKcal({ p: d.protein, f: d.fat, c: d.carbs }),
+        hasFood: (day?.entries.length ?? 0) > 0,
+      };
+    });
+    return buildPeriodEnergyMetrics({
+      start,
+      end,
+      todayJst: today,
+      excludeToday: true,
+      excludeIncompleteToday: true,
+      dailyIntake,
+      dasRows,
+      trainingRows,
+      bodyCompRows,
+    });
+  }, [energyInsight, start, end, today, dasRows, trainingRows, bodyCompRows]);
 
   function validateCustomRange(nextStart: string, nextEnd: string): string | null {
     if (nextStart > nextEnd) return "開始日は終了日以前にしてください。";
@@ -638,6 +715,11 @@ export function InsightsScreen() {
             </>
           )}
         </View>
+
+        <InsightsPeriodEnergySection
+          summary={periodEnergy.summary}
+          mealFilterActive={mealFilter !== "all"}
+        />
 
         <View style={styles.card}>
           <Text style={styles.cardTitle}>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ketolog",
-  "version": "1.70.3",
+  "version": "1.71.0",
   "private": true,
   "workspaces": [
     "apps/*",

--- a/packages/domain/package.json
+++ b/packages/domain/package.json
@@ -17,6 +17,7 @@
     "./restaurant-json-v1": "./src/restaurant-json-v1.ts",
     "./restaurant-import": "./src/restaurant-import.ts",
     "./insights": "./src/insights.ts",
+    "./energy-availability": "./src/energy-availability.ts",
     "./pfc-target-snapshot": "./src/pfc-target-snapshot.ts",
     "./menu-browse": "./src/menu-browse.ts",
     "./nutrient-input": "./src/nutrient-input.ts",

--- a/packages/domain/src/energy-availability.test.ts
+++ b/packages/domain/src/energy-availability.test.ts
@@ -1,0 +1,310 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPeriodEnergyMetrics,
+  classifyRedsBand,
+  dasStorageDateToActivityDate,
+  indexDasByActivityDate,
+  jstNoonUtcMs,
+  resolveFfmKgForDate,
+  sumEeeByDate,
+  type BodyCompRow,
+  type DailyIntake,
+  type DasRow,
+  type TrainingBurnRow,
+} from "./energy-availability";
+
+describe("dasStorageDateToActivityDate", () => {
+  it("shifts storage date by -1 day", () => {
+    expect(dasStorageDateToActivityDate("2026-07-02")).toBe("2026-07-01");
+    expect(dasStorageDateToActivityDate("2026-08-01")).toBe("2026-07-31");
+  });
+});
+
+describe("indexDasByActivityDate", () => {
+  it("maps storage date to activity date without adding training", () => {
+    const map = indexDasByActivityDate([
+      { date: "2026-07-02", basal_calories_kcal: 1500, active_calories_kcal: 500 },
+    ]);
+    expect(map.get("2026-07-01")).toEqual({ basal: 1500, active: 500 });
+    expect(map.has("2026-07-02")).toBe(false);
+  });
+});
+
+describe("resolveFfmKgForDate", () => {
+  it("joins same-day weight and body fat (0–100%)", () => {
+    const samples: BodyCompRow[] = [
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T01:00:00.000Z",
+        weight_kg: 70,
+        body_fat_pct: null,
+      },
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T02:00:00.000Z",
+        weight_kg: null,
+        body_fat_pct: 20,
+      },
+    ];
+    expect(resolveFfmKgForDate("2026-07-01", samples)).toBe(56);
+  });
+
+  it("returns null when weight or body fat is missing", () => {
+    expect(
+      resolveFfmKgForDate("2026-07-01", [
+        {
+          date: "2026-07-01",
+          measured_at: "2026-07-01T01:00:00.000Z",
+          weight_kg: 70,
+          body_fat_pct: null,
+        },
+      ])
+    ).toBeNull();
+    expect(
+      resolveFfmKgForDate("2026-07-01", [
+        {
+          date: "2026-07-01",
+          measured_at: "2026-07-01T01:00:00.000Z",
+          weight_kg: null,
+          body_fat_pct: 20,
+        },
+      ])
+    ).toBeNull();
+  });
+
+  it("picks weight closest to JST noon when multiple", () => {
+    // JST noon 2026-07-01 = 2026-07-01T03:00:00.000Z
+    expect(jstNoonUtcMs("2026-07-01")).toBe(Date.parse("2026-07-01T03:00:00.000Z"));
+    const samples: BodyCompRow[] = [
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T00:00:00.000Z",
+        weight_kg: 80,
+        body_fat_pct: null,
+      },
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T02:50:00.000Z",
+        weight_kg: 70,
+        body_fat_pct: null,
+      },
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T03:00:00.000Z",
+        weight_kg: null,
+        body_fat_pct: 20,
+      },
+    ];
+    expect(resolveFfmKgForDate("2026-07-01", samples)).toBe(56);
+  });
+});
+
+describe("sumEeeByDate", () => {
+  it("sums calories_burned and treats missing as 0", () => {
+    const rows: TrainingBurnRow[] = [
+      { date: "2026-07-01", calories_burned: 200 },
+      { date: "2026-07-01", calories_burned: 200 },
+      { date: "2026-07-02", calories_burned: null },
+    ];
+    const map = sumEeeByDate(rows);
+    expect(map.get("2026-07-01")).toBe(400);
+    expect(map.get("2026-07-02")).toBe(0);
+  });
+});
+
+describe("classifyRedsBand", () => {
+  it("classifies provisional thresholds", () => {
+    expect(classifyRedsBand(null)).toBeNull();
+    expect(classifyRedsBand(19.9)).toBe("red");
+    expect(classifyRedsBand(20)).toBe("yellow");
+    expect(classifyRedsBand(29.9)).toBe("yellow");
+    expect(classifyRedsBand(30)).toBe("green");
+  });
+});
+
+describe("buildPeriodEnergyMetrics", () => {
+  const intake = (rows: Array<Partial<DailyIntake> & { date: string }>): DailyIntake[] =>
+    rows.map((r) => ({
+      date: r.date,
+      intake_kcal: r.intake_kcal ?? 0,
+      hasFood: r.hasFood ?? false,
+    }));
+
+  it("does not add training calories into balance", () => {
+    const das: DasRow[] = [
+      { date: "2026-07-02", basal_calories_kcal: 1500, active_calories_kcal: 500 },
+    ];
+    const training: TrainingBurnRow[] = [{ date: "2026-07-01", calories_burned: 9999 }];
+    const result = buildPeriodEnergyMetrics({
+      start: "2026-07-01",
+      end: "2026-07-01",
+      todayJst: "2026-07-10",
+      excludeToday: true,
+      excludeIncompleteToday: true,
+      dailyIntake: intake([{ date: "2026-07-01", intake_kcal: 2200, hasFood: true }]),
+      dasRows: das,
+      trainingRows: training,
+      bodyCompRows: [],
+    });
+    expect(result.dailyBalance[0]?.balance_kcal).toBe(200); // 2200 - (1500+500)
+    expect(result.summary.avgBalanceKcal).toBe(200);
+  });
+
+  it("excludes balance when food missing or basal/active incomplete", () => {
+    const result = buildPeriodEnergyMetrics({
+      start: "2026-07-01",
+      end: "2026-07-02",
+      todayJst: "2026-07-10",
+      excludeToday: true,
+      excludeIncompleteToday: true,
+      dailyIntake: intake([
+        { date: "2026-07-01", intake_kcal: 0, hasFood: false },
+        { date: "2026-07-02", intake_kcal: 2000, hasFood: true },
+      ]),
+      dasRows: [
+        { date: "2026-07-02", basal_calories_kcal: 1500, active_calories_kcal: 500 },
+        { date: "2026-07-03", basal_calories_kcal: 1500, active_calories_kcal: null },
+      ],
+      trainingRows: [],
+      bodyCompRows: [],
+    });
+    expect(result.dailyBalance.find((d) => d.date === "2026-07-01")?.included).toBe(false);
+    expect(result.dailyBalance.find((d) => d.date === "2026-07-02")?.included).toBe(false);
+    expect(result.summary.avgBalanceKcal).toBeNull();
+  });
+
+  it("includes EA with intake=0 when food missing but FFM present (U1=B)", () => {
+    const body: BodyCompRow[] = [
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T03:00:00.000Z",
+        weight_kg: 70,
+        body_fat_pct: null,
+      },
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T03:00:00.000Z",
+        weight_kg: null,
+        body_fat_pct: 20,
+      },
+    ];
+    const result = buildPeriodEnergyMetrics({
+      start: "2026-07-01",
+      end: "2026-07-01",
+      todayJst: "2026-07-10",
+      excludeToday: true,
+      excludeIncompleteToday: true,
+      dailyIntake: intake([{ date: "2026-07-01", intake_kcal: 0, hasFood: false }]),
+      dasRows: [],
+      trainingRows: [{ date: "2026-07-01", calories_burned: 400 }],
+      bodyCompRows: body,
+    });
+    expect(result.dailyBalance[0]?.included).toBe(false);
+    expect(result.dailyEa[0]?.included).toBe(true);
+    expect(result.dailyEa[0]?.ea).toBeCloseTo((0 - 400) / 56, 5);
+    expect(result.summary.periodEa).toBeCloseTo(-400 / 56, 5);
+  });
+
+  it("uses mean of valid daily EA (not week-total / avg FFM)", () => {
+    const bodyFor = (date: string): BodyCompRow[] => [
+      {
+        date,
+        measured_at: `${date}T03:00:00.000Z`,
+        weight_kg: 70,
+        body_fat_pct: null,
+      },
+      {
+        date,
+        measured_at: `${date}T03:00:00.000Z`,
+        weight_kg: null,
+        body_fat_pct: 20,
+      },
+    ];
+    const result = buildPeriodEnergyMetrics({
+      start: "2026-07-01",
+      end: "2026-07-02",
+      todayJst: "2026-07-10",
+      excludeToday: true,
+      excludeIncompleteToday: true,
+      dailyIntake: intake([
+        { date: "2026-07-01", intake_kcal: 2200, hasFood: true },
+        { date: "2026-07-02", intake_kcal: 1800, hasFood: true },
+      ]),
+      dasRows: [],
+      trainingRows: [
+        { date: "2026-07-01", calories_burned: 400 },
+        { date: "2026-07-02", calories_burned: 0 },
+      ],
+      bodyCompRows: [...bodyFor("2026-07-01"), ...bodyFor("2026-07-02")],
+    });
+    const ea1 = (2200 - 400) / 56;
+    const ea2 = (1800 - 0) / 56;
+    expect(result.summary.periodEa).toBeCloseTo((ea1 + ea2) / 2, 5);
+  });
+
+  it("excludes today from balance and EA with separate flags", () => {
+    const body: BodyCompRow[] = [
+      {
+        date: "2026-07-10",
+        measured_at: "2026-07-10T03:00:00.000Z",
+        weight_kg: 70,
+        body_fat_pct: null,
+      },
+      {
+        date: "2026-07-10",
+        measured_at: "2026-07-10T03:00:00.000Z",
+        weight_kg: null,
+        body_fat_pct: 20,
+      },
+    ];
+    const result = buildPeriodEnergyMetrics({
+      start: "2026-07-10",
+      end: "2026-07-10",
+      todayJst: "2026-07-10",
+      excludeToday: true,
+      excludeIncompleteToday: true,
+      dailyIntake: intake([{ date: "2026-07-10", intake_kcal: 2200, hasFood: true }]),
+      dasRows: [
+        { date: "2026-07-11", basal_calories_kcal: 1500, active_calories_kcal: 500 },
+      ],
+      trainingRows: [],
+      bodyCompRows: body,
+    });
+    expect(result.dailyBalance[0]?.included).toBe(false);
+    expect(result.dailyEa[0]?.included).toBe(false);
+    expect(result.summary.avgBalanceKcal).toBeNull();
+    expect(result.summary.periodEa).toBeNull();
+    expect(result.summary.redsBand).toBeNull();
+  });
+
+  it("treats missing EEE as 0", () => {
+    const body: BodyCompRow[] = [
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T03:00:00.000Z",
+        weight_kg: 70,
+        body_fat_pct: null,
+      },
+      {
+        date: "2026-07-01",
+        measured_at: "2026-07-01T03:00:00.000Z",
+        weight_kg: null,
+        body_fat_pct: 20,
+      },
+    ];
+    const result = buildPeriodEnergyMetrics({
+      start: "2026-07-01",
+      end: "2026-07-01",
+      todayJst: "2026-07-10",
+      excludeToday: true,
+      excludeIncompleteToday: true,
+      dailyIntake: intake([{ date: "2026-07-01", intake_kcal: 2240, hasFood: true }]),
+      dasRows: [],
+      trainingRows: [],
+      bodyCompRows: body,
+    });
+    expect(result.dailyEa[0]?.eee_kcal).toBe(0);
+    expect(result.dailyEa[0]?.ea).toBeCloseTo(40, 5);
+    expect(result.summary.redsBand).toBe("green");
+  });
+});

--- a/packages/domain/src/energy-availability.ts
+++ b/packages/domain/src/energy-availability.ts
@@ -1,0 +1,281 @@
+import { addDaysJst, eachDate } from "./date";
+
+/** DAS 1行（格納日のまま。シフトは domain 側） */
+export type DasRow = {
+  date: string;
+  basal_calories_kcal: number | null;
+  active_calories_kcal: number | null;
+};
+
+export type TrainingBurnRow = {
+  date: string;
+  calories_burned: number | null;
+};
+
+export type BodyCompRow = {
+  date: string;
+  measured_at: string;
+  weight_kg: number | null;
+  body_fat_pct: number | null;
+};
+
+export type DailyIntake = {
+  date: string;
+  intake_kcal: number;
+  hasFood: boolean;
+};
+
+export type DailyBalance = {
+  date: string;
+  included: boolean;
+  intake_kcal: number | null;
+  basal_kcal: number | null;
+  active_kcal: number | null;
+  balance_kcal: number | null;
+};
+
+export type DailyEa = {
+  date: string;
+  included: boolean;
+  intake_kcal: number;
+  eee_kcal: number;
+  ffm_kg: number | null;
+  ea: number | null;
+  hasFood: boolean;
+};
+
+export type RedsBand = "red" | "yellow" | "green" | null;
+
+export type PeriodEnergySummary = {
+  periodDayCount: number;
+  balanceEligibleDayCount: number;
+  eaEligibleDayCount: number;
+  balanceValidDayCount: number;
+  balanceExcludedDayCount: number;
+  avgBalanceKcal: number | null;
+  eaValidDayCount: number;
+  eaExcludedDayCount: number;
+  periodEa: number | null;
+  redsBand: RedsBand;
+};
+
+export type PeriodEnergyResult = {
+  summary: PeriodEnergySummary;
+  dailyBalance: DailyBalance[];
+  dailyEa: DailyEa[];
+};
+
+/** provisional（Issue #348）。IOC 目安に近い参考閾値。 */
+export const EA_THRESHOLD_RED = 20;
+export const EA_THRESHOLD_YELLOW = 30;
+
+/** DAS 格納日 → 活動日 D */
+export function dasStorageDateToActivityDate(storageDate: string): string {
+  return addDaysJst(storageDate, -1);
+}
+
+/**
+ * その暦日の JST 正午（日本は DST なし = UTC 同日 03:00）。
+ * FFM 候補の measured_at 比較用アンカー。
+ */
+export function jstNoonUtcMs(date: string): number {
+  const [y, m, d] = date.split("-").map(Number);
+  return Date.UTC(y, (m ?? 1) - 1, d ?? 1, 3, 0, 0);
+}
+
+function pickClosestToNoon<T extends { measured_at: string }>(
+  date: string,
+  rows: T[]
+): T | null {
+  if (rows.length === 0) return null;
+  if (rows.length === 1) return rows[0]!;
+  const noon = jstNoonUtcMs(date);
+  let best = rows[0]!;
+  let bestDist = Math.abs(Date.parse(best.measured_at) - noon);
+  for (let i = 1; i < rows.length; i++) {
+    const row = rows[i]!;
+    const dist = Math.abs(Date.parse(row.measured_at) - noon);
+    if (dist < bestDist) {
+      best = row;
+      bestDist = dist;
+    }
+  }
+  return best;
+}
+
+/**
+ * 同暦日の weight 行と body_fat 行を結合。
+ * 同種複数は JST 正午に measured_at が最も近い行。
+ * body_fat_pct は 0–100%。片欠けは null。
+ */
+export function resolveFfmKgForDate(date: string, samples: BodyCompRow[]): number | null {
+  const daySamples = samples.filter((s) => s.date === date);
+  const weightRows = daySamples.filter((s) => s.weight_kg != null && Number.isFinite(s.weight_kg));
+  const bfRows = daySamples.filter(
+    (s) => s.body_fat_pct != null && Number.isFinite(s.body_fat_pct)
+  );
+  const weightRow = pickClosestToNoon(date, weightRows);
+  const bfRow = pickClosestToNoon(date, bfRows);
+  if (!weightRow || !bfRow) return null;
+  const weight = Number(weightRow.weight_kg);
+  const bf = Number(bfRow.body_fat_pct);
+  if (!(weight > 0) || !(bf >= 0) || bf >= 100) return null;
+  return weight * (1 - bf / 100);
+}
+
+export function sumEeeByDate(rows: TrainingBurnRow[]): Map<string, number> {
+  const map = new Map<string, number>();
+  for (const row of rows) {
+    const burn = row.calories_burned;
+    const kcal = burn == null || !Number.isFinite(burn) ? 0 : Number(burn);
+    map.set(row.date, (map.get(row.date) ?? 0) + kcal);
+  }
+  return map;
+}
+
+/**
+ * DAS → 活動日キー。UNIQUE (user_id, date) 前提。
+ * 同一活動日に複数行が来た場合は後から来た行で上書きせず、最初の行を保持（テストは一意）。
+ */
+export function indexDasByActivityDate(
+  rows: DasRow[]
+): Map<string, { basal: number | null; active: number | null }> {
+  const map = new Map<string, { basal: number | null; active: number | null }>();
+  for (const row of rows) {
+    const activityDate = dasStorageDateToActivityDate(row.date);
+    if (map.has(activityDate)) continue;
+    map.set(activityDate, {
+      basal: row.basal_calories_kcal,
+      active: row.active_calories_kcal,
+    });
+  }
+  return map;
+}
+
+export function classifyRedsBand(periodEa: number | null): RedsBand {
+  if (periodEa == null || !Number.isFinite(periodEa)) return null;
+  if (periodEa < EA_THRESHOLD_RED) return "red";
+  if (periodEa < EA_THRESHOLD_YELLOW) return "yellow";
+  return "green";
+}
+
+export function buildPeriodEnergyMetrics(input: {
+  start: string;
+  end: string;
+  todayJst: string;
+  /** Balance 用。DAS 未確定のため推奨 true */
+  excludeToday: boolean;
+  /** EA 用。日未完了のため推奨 true */
+  excludeIncompleteToday: boolean;
+  dailyIntake: DailyIntake[];
+  dasRows: DasRow[];
+  trainingRows: TrainingBurnRow[];
+  bodyCompRows: BodyCompRow[];
+}): PeriodEnergyResult {
+  const days = eachDate(input.start, input.end);
+  const intakeByDate = new Map(input.dailyIntake.map((d) => [d.date, d]));
+  const dasByActivity = indexDasByActivityDate(input.dasRows);
+  const eeeByDate = sumEeeByDate(input.trainingRows);
+
+  const dailyBalance: DailyBalance[] = [];
+  const dailyEa: DailyEa[] = [];
+
+  let balanceEligible = 0;
+  let eaEligible = 0;
+  let balanceSum = 0;
+  let balanceValid = 0;
+  let eaSum = 0;
+  let eaValid = 0;
+
+  for (const date of days) {
+    const skipBalanceToday = input.excludeToday && date >= input.todayJst;
+    const skipEaToday = input.excludeIncompleteToday && date >= input.todayJst;
+    if (!skipBalanceToday) balanceEligible += 1;
+    if (!skipEaToday) eaEligible += 1;
+
+    const intake = intakeByDate.get(date) ?? {
+      date,
+      intake_kcal: 0,
+      hasFood: false,
+    };
+    const das = dasByActivity.get(date);
+    const basal = das?.basal ?? null;
+    const active = das?.active ?? null;
+    const balanceOk =
+      !skipBalanceToday &&
+      intake.hasFood &&
+      basal != null &&
+      Number.isFinite(basal) &&
+      active != null &&
+      Number.isFinite(active);
+
+    if (balanceOk) {
+      const balance_kcal = intake.intake_kcal - (Number(basal) + Number(active));
+      dailyBalance.push({
+        date,
+        included: true,
+        intake_kcal: intake.intake_kcal,
+        basal_kcal: Number(basal),
+        active_kcal: Number(active),
+        balance_kcal,
+      });
+      balanceSum += balance_kcal;
+      balanceValid += 1;
+    } else {
+      dailyBalance.push({
+        date,
+        included: false,
+        intake_kcal: intake.hasFood ? intake.intake_kcal : null,
+        basal_kcal: basal,
+        active_kcal: active,
+        balance_kcal: null,
+      });
+    }
+
+    const ffm = resolveFfmKgForDate(date, input.bodyCompRows);
+    const eee = eeeByDate.get(date) ?? 0;
+    const eaOk = !skipEaToday && ffm != null && ffm > 0;
+    if (eaOk) {
+      const ea = (intake.intake_kcal - eee) / ffm!;
+      dailyEa.push({
+        date,
+        included: true,
+        intake_kcal: intake.intake_kcal,
+        eee_kcal: eee,
+        ffm_kg: ffm,
+        ea,
+        hasFood: intake.hasFood,
+      });
+      eaSum += ea;
+      eaValid += 1;
+    } else {
+      dailyEa.push({
+        date,
+        included: false,
+        intake_kcal: intake.intake_kcal,
+        eee_kcal: eee,
+        ffm_kg: ffm,
+        ea: null,
+        hasFood: intake.hasFood,
+      });
+    }
+  }
+
+  const periodEa = eaValid === 0 ? null : eaSum / eaValid;
+  return {
+    summary: {
+      periodDayCount: days.length,
+      balanceEligibleDayCount: balanceEligible,
+      eaEligibleDayCount: eaEligible,
+      balanceValidDayCount: balanceValid,
+      balanceExcludedDayCount: Math.max(0, balanceEligible - balanceValid),
+      avgBalanceKcal: balanceValid === 0 ? null : balanceSum / balanceValid,
+      eaValidDayCount: eaValid,
+      eaExcludedDayCount: Math.max(0, eaEligible - eaValid),
+      periodEa,
+      redsBand: classifyRedsBand(periodEa),
+    },
+    dailyBalance,
+    dailyEa,
+  };
+}

--- a/src/app/insights/InsightsClient.tsx
+++ b/src/app/insights/InsightsClient.tsx
@@ -18,13 +18,23 @@ import {
   type InsightPfcTargetSnapshot,
 } from "@/lib/insights";
 import {
+  buildPeriodEnergyMetrics,
+  type BodyCompRow,
+  type DasRow,
+  type TrainingBurnRow,
+} from "@ketolog/domain/energy-availability";
+import {
   readInsightsPfcRatioBasis,
   writeInsightsPfcRatioBasis,
 } from "@/lib/insights-pfc-ratio-storage";
 import {
+  getInsightsBodyCompForDateRange,
+  getInsightsDasForDateRange,
   getInsightsFoodLogForDateRange,
   getInsightsPfcTargetSnapshotsForDateRange,
+  getInsightsTrainingBurnForDateRange,
 } from "./actions";
+import { PeriodEnergySection } from "./_components/PeriodEnergySection";
 import { MEAL_LABELS, MEAL_TAB_STYLES, MEAL_TYPES } from "@/lib/constants/meal";
 import type { MealType } from "@ketolog/types";
 
@@ -92,11 +102,19 @@ function mealFilterButtonClass(mealFilter: MealFilter, target: MealFilter): stri
 
 export default function InsightsClient({
   initialEntries,
+  initialEnergyEntries,
   initialSnapshots,
+  initialDasRows,
+  initialTrainingRows,
+  initialBodyCompRows,
   today,
 }: {
   initialEntries: InsightFoodLogEntry[];
+  initialEnergyEntries: InsightFoodLogEntry[];
   initialSnapshots: InsightPfcTargetSnapshot[];
+  initialDasRows: DasRow[];
+  initialTrainingRows: TrainingBurnRow[];
+  initialBodyCompRows: BodyCompRow[];
   today: string;
 }) {
   const preset7 = getPresetRange(today, 7);
@@ -104,7 +122,11 @@ export default function InsightsClient({
   const [start, setStart] = useState(preset7.start);
   const [end, setEnd] = useState(preset7.end);
   const [entries, setEntries] = useState(initialEntries);
+  const [energyEntries, setEnergyEntries] = useState(initialEnergyEntries);
   const [snapshots, setSnapshots] = useState(initialSnapshots);
+  const [dasRows, setDasRows] = useState(initialDasRows);
+  const [trainingRows, setTrainingRows] = useState(initialTrainingRows);
+  const [bodyCompRows, setBodyCompRows] = useState(initialBodyCompRows);
   const [mealFilter, setMealFilter] = useState<MealFilter>("all");
   const [metricMode, setMetricMode] = useState<MetricMode>("achievement");
   const [loading, setLoading] = useState(false);
@@ -154,6 +176,32 @@ export default function InsightsClient({
   );
   const avgDailyKcal = useMemo(() => pfcTotalKcal(avgGrams), [avgGrams]);
 
+  const energyInsight = useMemo(
+    () => buildInsights(energyEntries, start, end),
+    [energyEntries, start, end]
+  );
+  const periodEnergy = useMemo(() => {
+    const dailyIntake = energyInsight.chart.map((d) => {
+      const day = energyInsight.daily.find((x) => x.date === d.date);
+      return {
+        date: d.date,
+        intake_kcal: pfcTotalKcal({ p: d.protein, f: d.fat, c: d.carbs }),
+        hasFood: (day?.entries.length ?? 0) > 0,
+      };
+    });
+    return buildPeriodEnergyMetrics({
+      start,
+      end,
+      todayJst: today,
+      excludeToday: true,
+      excludeIncompleteToday: true,
+      dailyIntake,
+      dasRows,
+      trainingRows,
+      bodyCompRows,
+    });
+  }, [energyInsight, start, end, today, dasRows, trainingRows, bodyCompRows]);
+
   async function loadRange(
     nextStart: string,
     nextEnd: string,
@@ -163,17 +211,43 @@ export default function InsightsClient({
     setLoading(true);
     setError(null);
     const mealTypes = nextMealFilter === "all" ? undefined : [nextMealFilter];
-    const [foodResult, snapResult] = await Promise.all([
-      getInsightsFoodLogForDateRange(nextStart, nextEnd, mealTypes),
-      getInsightsPfcTargetSnapshotsForDateRange(nextStart, nextEnd),
-    ]);
+    const energyFoodPromise = getInsightsFoodLogForDateRange(nextStart, nextEnd);
+    const foodPromise =
+      mealTypes == null
+        ? energyFoodPromise
+        : getInsightsFoodLogForDateRange(nextStart, nextEnd, mealTypes);
+    const [foodResult, energyFoodResult, snapResult, dasResult, trainingResult, bodyResult] =
+      await Promise.all([
+        foodPromise,
+        energyFoodPromise,
+        getInsightsPfcTargetSnapshotsForDateRange(nextStart, nextEnd),
+        getInsightsDasForDateRange(nextStart, nextEnd),
+        getInsightsTrainingBurnForDateRange(nextStart, nextEnd),
+        getInsightsBodyCompForDateRange(nextStart, nextEnd),
+      ]);
     setLoading(false);
     if (foodResult.error) {
       setError(foodResult.error);
       return;
     }
+    if (energyFoodResult.error) {
+      setError(energyFoodResult.error);
+      return;
+    }
     if (snapResult.error) {
       setError(snapResult.error);
+      return;
+    }
+    if (dasResult.error) {
+      setError(dasResult.error);
+      return;
+    }
+    if (trainingResult.error) {
+      setError(trainingResult.error);
+      return;
+    }
+    if (bodyResult.error) {
+      setError(bodyResult.error);
       return;
     }
     setPreset(nextPreset);
@@ -181,7 +255,11 @@ export default function InsightsClient({
     setEnd(nextEnd);
     setMealFilter(nextMealFilter);
     setEntries(foodResult.entries);
+    setEnergyEntries(energyFoodResult.entries);
     setSnapshots(snapResult.snapshots);
+    setDasRows(dasResult.rows);
+    setTrainingRows(trainingResult.rows);
+    setBodyCompRows(bodyResult.rows);
     setExpanded(new Set());
   }
 
@@ -466,6 +544,11 @@ export default function InsightsClient({
             </>
           )}
         </div>
+
+        <PeriodEnergySection
+          summary={periodEnergy.summary}
+          mealFilterActive={mealFilter !== "all"}
+        />
 
         <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3">
           <h2 className="mb-2 text-sm font-medium text-white">

--- a/src/app/insights/_components/PeriodEnergySection.tsx
+++ b/src/app/insights/_components/PeriodEnergySection.tsx
@@ -1,0 +1,93 @@
+import type { PeriodEnergySummary, RedsBand } from "@ketolog/domain/energy-availability";
+
+const BAND_LABEL: Record<Exclude<RedsBand, null>, string> = {
+  red: "LEA リスク帯（参考）",
+  yellow: "注意",
+  green: "当面の余裕",
+};
+
+const BAND_DOT: Record<Exclude<RedsBand, null>, string> = {
+  red: "bg-red-500",
+  yellow: "bg-yellow-400",
+  green: "bg-emerald-400",
+};
+
+function fmtNum(v: number): string {
+  return v.toFixed(1);
+}
+
+function fmtSigned(v: number): string {
+  const sign = v > 0 ? "+" : "";
+  return `${sign}${fmtNum(v)}`;
+}
+
+export function PeriodEnergySection({
+  summary,
+  mealFilterActive,
+}: {
+  summary: PeriodEnergySummary;
+  mealFilterActive: boolean;
+}) {
+  const band = summary.redsBand;
+
+  return (
+    <div className="rounded-xl border border-gray-800 bg-gray-900/70 p-3">
+      <h2 className="mb-2 text-sm font-medium text-white">期間カロリー収支・EA</h2>
+      <div className="grid grid-cols-2 gap-2">
+        <div className="rounded-lg border border-gray-800 bg-gray-900/60 px-2 py-2">
+          <p className="text-[11px] text-gray-400">期間平均収支</p>
+          {summary.avgBalanceKcal == null ? (
+            <p className="mt-1 text-sm text-gray-500">計算不可</p>
+          ) : (
+            <p className="mt-1 text-sm font-semibold text-white">
+              {fmtSigned(summary.avgBalanceKcal)}{" "}
+              <span className="text-xs font-normal text-gray-400">kcal/日</span>
+            </p>
+          )}
+          <p className="mt-1 text-[10px] text-gray-500">
+            有効 {summary.balanceValidDayCount} 日 · 除外{" "}
+            {summary.balanceExcludedDayCount} 日
+          </p>
+        </div>
+        <div className="rounded-lg border border-gray-800 bg-gray-900/60 px-2 py-2">
+          <p className="text-[11px] text-gray-400">期間平均 EA</p>
+          {summary.periodEa == null ? (
+            <p className="mt-1 text-sm text-gray-500">計算不可</p>
+          ) : (
+            <p className="mt-1 flex items-center gap-1.5 text-sm font-semibold text-white">
+              {band ? (
+                <span
+                  className={`inline-block h-2.5 w-2.5 shrink-0 rounded-full ${BAND_DOT[band]}`}
+                  aria-hidden
+                />
+              ) : null}
+              {fmtNum(summary.periodEa)}{" "}
+              <span className="text-xs font-normal text-gray-400">kcal/kgFFM/日</span>
+            </p>
+          )}
+          {band ? (
+            <p className="mt-1 text-[10px] text-gray-400">{BAND_LABEL[band]}</p>
+          ) : null}
+          <p className="mt-1 text-[10px] text-gray-500">
+            有効 {summary.eaValidDayCount} 日 · 除外 {summary.eaExcludedDayCount} 日
+          </p>
+        </div>
+      </div>
+      <div className="mt-2 space-y-1 text-[10px] leading-relaxed text-gray-500">
+        <p>医療診断ではありません。閾値（20 / 30）は参考の目安です。</p>
+        <p>本日は活動量の確定待ち・日未完了のため集計対象外です。</p>
+        <p>
+          食事未記録日は摂取 0 kcal として EA に含めます（記録漏れでも低く出ることがあります）。
+        </p>
+        {mealFilterActive ? (
+          <p className="text-amber-300/90">収支・EA は全日の食事で計算しています。</p>
+        ) : null}
+        {summary.balanceValidDayCount === 0 && summary.eaValidDayCount === 0 ? (
+          <p className="text-amber-300/90">
+            活動量・体組成データがない場合は HealthKit 連携（MyVitalRelay）が必要です。
+          </p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/app/insights/actions.ts
+++ b/src/app/insights/actions.ts
@@ -1,7 +1,13 @@
 "use server";
 
 import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
+import { addDaysJst } from "@/lib/insights";
 import type { InsightFoodLogEntry, InsightPfcTargetSnapshot } from "@/lib/insights";
+import type {
+  BodyCompRow,
+  DasRow,
+  TrainingBurnRow,
+} from "@ketolog/domain/energy-availability";
 import type { MealType } from "@ketolog/types";
 
 const INSIGHTS_PAGE_SIZE = 1000;
@@ -95,4 +101,98 @@ export async function getInsightsPfcTargetSnapshotsForDateRange(
   });
 
   return { snapshots, error: null };
+}
+
+export async function getInsightsDasForDateRange(
+  start: string,
+  end: string
+): Promise<{ rows: DasRow[]; error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { rows: [], error: "認証が必要です" };
+
+  // DAS.date は格納日 = 活動日 D+1
+  const storageStart = addDaysJst(start, 1);
+  const storageEnd = addDaysJst(end, 1);
+
+  const { data, error } = await supabase
+    .from("daily_activity_summary")
+    .select("date, basal_calories_kcal, active_calories_kcal")
+    .eq("user_id", user.id)
+    .gte("date", storageStart)
+    .lte("date", storageEnd)
+    .order("date", { ascending: true });
+
+  if (error) return { rows: [], error: error.message };
+
+  const rows: DasRow[] = (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    return {
+      date: String(r.date),
+      basal_calories_kcal:
+        r.basal_calories_kcal == null ? null : Number(r.basal_calories_kcal),
+      active_calories_kcal:
+        r.active_calories_kcal == null ? null : Number(r.active_calories_kcal),
+    };
+  });
+
+  return { rows, error: null };
+}
+
+export async function getInsightsTrainingBurnForDateRange(
+  start: string,
+  end: string
+): Promise<{ rows: TrainingBurnRow[]; error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { rows: [], error: "認証が必要です" };
+
+  const { data, error } = await supabase
+    .from("training_log")
+    .select("date, calories_burned")
+    .eq("user_id", user.id)
+    .gte("date", start)
+    .lte("date", end)
+    .order("date", { ascending: true });
+
+  if (error) return { rows: [], error: error.message };
+
+  const rows: TrainingBurnRow[] = (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    return {
+      date: String(r.date),
+      calories_burned:
+        r.calories_burned == null ? null : Number(r.calories_burned),
+    };
+  });
+
+  return { rows, error: null };
+}
+
+export async function getInsightsBodyCompForDateRange(
+  start: string,
+  end: string
+): Promise<{ rows: BodyCompRow[]; error: string | null }> {
+  const { supabase, user } = await getSupabaseAuthForRequest();
+  if (!user) return { rows: [], error: "認証が必要です" };
+
+  const { data, error } = await supabase
+    .from("body_composition_sample")
+    .select("date, measured_at, weight_kg, body_fat_pct")
+    .eq("user_id", user.id)
+    .gte("date", start)
+    .lte("date", end)
+    .order("measured_at", { ascending: true });
+
+  if (error) return { rows: [], error: error.message };
+
+  const rows: BodyCompRow[] = (data ?? []).map((row) => {
+    const r = row as Record<string, unknown>;
+    return {
+      date: String(r.date),
+      measured_at: String(r.measured_at),
+      weight_kg: r.weight_kg == null ? null : Number(r.weight_kg),
+      body_fat_pct: r.body_fat_pct == null ? null : Number(r.body_fat_pct),
+    };
+  });
+
+  return { rows, error: null };
 }

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -2,8 +2,11 @@ import { redirect } from "next/navigation";
 import { getSupabaseAuthForRequest } from "@/lib/supabase/request-auth";
 import { getPresetRange, getTodayJstDate } from "@/lib/insights";
 import {
+  getInsightsBodyCompForDateRange,
+  getInsightsDasForDateRange,
   getInsightsFoodLogForDateRange,
   getInsightsPfcTargetSnapshotsForDateRange,
+  getInsightsTrainingBurnForDateRange,
 } from "./actions";
 import InsightsClient from "./InsightsClient";
 
@@ -13,15 +16,23 @@ export default async function InsightsPage() {
 
   const today = getTodayJstDate();
   const initialRange = getPresetRange(today, 7);
-  const [foodResult, snapResult] = await Promise.all([
-    getInsightsFoodLogForDateRange(initialRange.start, initialRange.end),
-    getInsightsPfcTargetSnapshotsForDateRange(initialRange.start, initialRange.end),
-  ]);
+  const [foodResult, snapResult, dasResult, trainingResult, bodyResult] =
+    await Promise.all([
+      getInsightsFoodLogForDateRange(initialRange.start, initialRange.end),
+      getInsightsPfcTargetSnapshotsForDateRange(initialRange.start, initialRange.end),
+      getInsightsDasForDateRange(initialRange.start, initialRange.end),
+      getInsightsTrainingBurnForDateRange(initialRange.start, initialRange.end),
+      getInsightsBodyCompForDateRange(initialRange.start, initialRange.end),
+    ]);
 
   return (
     <InsightsClient
       initialEntries={foodResult.entries}
+      initialEnergyEntries={foodResult.entries}
       initialSnapshots={snapResult.snapshots}
+      initialDasRows={dasResult.rows}
+      initialTrainingRows={trainingResult.rows}
+      initialBodyCompRows={bodyResult.rows}
       today={today}
     />
   );


### PR DESCRIPTION
## Summary
- Insights（Web / Mobile）に期間カロリー収支・エネルギー可用性（EA）サマリーと REDs 風参考色分けを追加
- domain: DAS の D+1 シフト、収支（training 非加算）、FFM 結合、period_EA、今日除外を純関数化＋テスト
- エネルギー指標は食事フィルタ非依存（全日摂取）。注記・免責を表示
- closes #348
- 前提 schema は #353 でマージ済み（旧 #354 は base 削除で閉じたため再作成）

## Test plan
- [ ] `npm test -- packages/domain/src/energy-availability.test.ts`
- [ ] Web / Mobile Insights で収支・EA サマリーが表示される
- [ ] 食事フィルタ時に全日計算の注記が出る
- [ ] 今日が有効日に含まれない


Made with [Cursor](https://cursor.com)